### PR TITLE
feat: CHACO NODO Design System — Knowledge Base + token integration

### DIFF
--- a/docs/client/sprints/sprint-001-consumo-horas.md
+++ b/docs/client/sprints/sprint-001-consumo-horas.md
@@ -1,0 +1,18 @@
+# :material-table-clock: Sprint 001 - Detalle de consumo de horas
+
+## :material-account-clock: Consumo por persona
+
+| Persona | Motivo | Qué hice | Consumo |
+|---|---|---|---:|
+| Agostina Coppola | Reunión inicial y alineación funcional del sprint | Definición funcional inicial y coordinación del alcance | 50 min |
+| Matías Fariña | Reunión inicial y definición operativa del sprint | Organización operativa y planificación de trabajo del sprint | 50 min |
+| Matías Fariña | Analizar la documentacion del programa a implementar | Relevamiento del módulo de becas e inicio del análisis funcional | 32 min |
+| Matías Fariña | Continuar el análisis funcional del módulo de becas | Cierre temporal de la sesión de análisis del módulo de becas | 87 min |
+| Juani Portilla | Design System CHACO NODO — especificación completa e integración de tokens | Construcción del Design Knowledge Base (foundations, tokens, 13 componentes, 5 patrones, constitución de diseño). Resolución de conflictos NODO vs CHACO, coordinación con diseñadora (10 respuestas + diseños de referencia), migración de chaco-tokens.css al repo y extensión de Tailwind config en templates base. PR #56 abierto. | 480 min |
+
+---
+
+## :material-counter: Total consumido
+
+!!! success "Contador total"
+    **699 minutos** (11 h 39 min)

--- a/docs/design-kb/IMPLEMENT_DESIGN_SYSTEM.md
+++ b/docs/design-kb/IMPLEMENT_DESIGN_SYSTEM.md
@@ -1,0 +1,307 @@
+# Prompt de Implementación — CHACO NODO Design System
+**Copiar y pegar completo en una nueva sesión de Claude**
+
+---
+
+## Contexto
+
+Sos un Senior Frontend Engineer implementando el Design System de NODO para el Gobierno del Chaco. El sistema fue completamente especificado por la diseñadora y documentado en `docs/design-kb/`. Tu trabajo es implementar ese diseño en el código Django existente.
+
+**Stack:**
+- Python 3.12, Django 4.2, MySQL 8
+- CSS nuevos → Tailwind CSS (Play CDN, sin build step)
+- CSS legacy → Bootstrap 5.3.2 + AdminLTE
+- Íconos nuevos → Heroicons (SVG inline)
+- Íconos legacy → Font Awesome 6.4.0
+- JS → Alpine.js 3.14.1, jQuery 3.6.0, SweetAlert2, Toastr, ApexCharts
+- Branding dinámico → `config/branding.py` genera CSS variables inyectadas en templates
+
+**Regla de fuentes:** CHACO siempre gana sobre NODO. La fuente de verdad es `docs/design-kb/`.
+
+---
+
+## Lo que ya está hecho — NO repetir
+
+- `static/custom/css/chaco-tokens.css` → copiado al repo ✅
+- `static/custom/js/chaco-tailwind.config.js` → copiado al repo ✅
+- `docs/design-kb/tokens/chaco-tokens.json` → copiado al repo ✅
+- `templates/includes/base.html` → chaco-tokens.css wired como primer import, tailwind.config extendido con todos los semantic tokens, Inter agregado a Google Fonts ✅
+- `portal/templates/portal/base.html` → chaco-tokens.css wired ✅
+- `docs/design-kb/` → Knowledge Base completo (foundations, tokens, 13 components, 5 patterns, constitution) ✅
+
+---
+
+## Lo que falta — ejecutar en orden
+
+### FASE 1 (incompleta) — Completar integración de tokens
+
+**1a. Reconciliar `config/branding.py` con chaco-tokens.css**
+
+Lee `config/branding.py`. Identifica qué variables CSS genera y mapéalas contra las variables de `chaco-tokens.css`. Donde haya valores duplicados:
+- Si branding.py genera `--color-primario: #5059BC` y chaco-tokens.css ya define `--bg-brand: #5059bc`, actualiza branding.py para que use `--bg-brand` como referencia en lugar de definir un valor propio.
+- Mantén la compatibilidad: los templates existentes usan `{{ branding.css_variables }}`.
+
+**1b. Auditar valores hex crudos en CSS existentes**
+
+Busca en `static/custom/css/paleta-unificada.css`, `nodo-brand.css` y `nodo-buttons.css` valores hex que ahora tienen equivalente en token:
+- `#5059bc` o `#5059BC` → `var(--bg-brand)`
+- `#c70036` → `var(--bg-danger)`
+- `#f9fafb` → `var(--bg-secondary-soft)`
+- `#e5e7eb` → `var(--border-base)`
+- `#111827` → `var(--text-heading)`
+- `#4b5563` → `var(--text-body)`
+- `#6b7280` → `var(--text-body-subtle)`
+
+No reemplazar todos los hex de una vez — reemplazar solo los que corresponden exactamente a un semantic token. Los valores únicos/específicos de componentes legacy pueden quedarse.
+
+---
+
+### FASE 2 — Componentes CSS
+
+Lee primero: `docs/design-kb/components/button.yaml`, `badge.yaml`, `input.yaml`, `sidebar.yaml`, `data-table.yaml`
+
+**2a. `static/custom/css/nodo-buttons.css`**
+
+Implementar o verificar los 3 variantes × 5 tamaños × 4 estados:
+
+```css
+/* Brand button — gradiente Jacaranda → BG Pink */
+.btn-brand {
+  background: linear-gradient(45deg, var(--bg-brand), var(--bg-pink));
+  color: var(--text-white);
+  border: none;
+  border-radius: var(--rounded-full);
+  font-family: var(--font-family-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: filter 150ms ease;
+}
+.btn-brand:hover { filter: brightness(0.92); }
+.btn-brand:focus { outline: 2px solid var(--bg-brand); outline-offset: 2px; }
+.btn-brand:disabled {
+  background: var(--bg-disabled);
+  border: 1px solid var(--border-base);
+  color: var(--text-fg-disabled);
+  cursor: not-allowed;
+}
+
+/* Secondary button */
+.btn-secondary {
+  background: var(--bg-secondary-soft);
+  border: 1px solid var(--border-base);
+  color: var(--text-body);
+  border-radius: var(--rounded-full);
+}
+.btn-secondary:hover { background: var(--bg-tertiary); color: var(--text-heading); }
+.btn-secondary:disabled { background: var(--bg-disabled); color: var(--text-fg-disabled); cursor: not-allowed; }
+
+/* Tertiary button — outlined brand */
+.btn-tertiary {
+  background: var(--bg-white);
+  border: 1px solid var(--border-brand);
+  color: var(--text-fg-brand);
+  border-radius: var(--rounded-full);
+}
+.btn-tertiary:hover { background: #DEE1FF; }
+.btn-tertiary:disabled { background: #F0F2FF; cursor: not-allowed; }
+
+/* Danger button */
+.btn-danger {
+  background: var(--bg-danger);
+  color: var(--text-white);
+  border: none;
+  border-radius: var(--rounded-full);
+}
+
+/* Sizes */
+.btn-xs   { font-size: var(--font-size-xs);  padding: 6px 12px;  height: 32px; }
+.btn-sm   { font-size: var(--font-size-sm);  padding: 8px 12px;  height: 36px; }
+.btn-base { font-size: var(--font-size-sm);  padding: 10px 16px; height: 40px; }
+.btn-l    { font-size: var(--font-size-base); padding: 12px 20px; height: 48px; }
+.btn-xl   { font-size: var(--font-size-base); padding: 14px 24px; height: 52px; }
+
+/* Loading state */
+.btn-loading { position: relative; color: transparent; pointer-events: none; }
+.btn-loading::after {
+  content: '';
+  position: absolute;
+  width: 16px; height: 16px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+```
+
+**2b. Badge component** — ver `docs/design-kb/components/badge.yaml`
+
+6 variantes (gray, white, brand, danger, warning, success) × 2 tamaños (sm: 20px, lg: 24px). Border-radius: 6px. Implementar en `static/custom/css/nodo-brand.css` o crear `static/custom/css/nodo-badges.css`.
+
+**2c. Input / Form fields** — ver `docs/design-kb/components/input.yaml`
+
+4 estados: default, focus (border-brand 1.5px), error (border-danger + bg-danger-soft), disabled (bg-disabled).
+
+**2d. Avatar** — ver `docs/design-kb/components/avatar.yaml`
+
+31×31px, rounded-full, bg-brand-medium, text-white font-semibold. Clase `.avatar-initials`.
+
+---
+
+### FASE 3 — Django template fragments
+
+Crear en `templates/includes/ds/`:
+
+| Archivo | Params |
+|---------|--------|
+| `stat-card.html` | `number`, `label`, `icon_svg`, `alert_dot` (bool) |
+| `badge.html` | `variant`, `size`, `text`, `dismissible` (bool) |
+| `empty-state.html` | `title`, `message`, `cta_url`, `cta_label` |
+| `breadcrumb.html` | `steps` (list de `{label, url, active}`) |
+| `alert-panel.html` | `alerts` (list) |
+
+Cada template:
+- Solo clases Tailwind o CSS variables (ningún hex crudo)
+- `{% load static %}` si necesita imágenes
+- Aria attributes para accesibilidad
+
+Ejemplo stat-card.html:
+```html
+<div class="bg-bg-primary border border-bg-quaternary rounded-xl p-5 cursor-default"
+     style="box-shadow: var(--sombra-sm)">
+  <div class="flex items-center justify-between mb-2">
+    <div class="w-10 h-10 rounded-xl flex items-center justify-center"
+         style="background: linear-gradient(45deg, var(--bg-brand), var(--bg-pink))">
+      {{ icon_svg }}
+    </div>
+    {% if alert_dot %}
+    <span class="w-2.5 h-2.5 rounded-full bg-bg-danger" aria-label="Alerta activa"></span>
+    {% endif %}
+  </div>
+  <p class="text-3xl font-bold" style="color: var(--text-heading)">{{ number }}</p>
+  <p class="text-xs font-medium uppercase tracking-wide mt-1"
+     style="color: var(--text-body-subtle)">{{ label }}</p>
+</div>
+```
+
+---
+
+### FASE 4 — Dark mode toggle (backoffice únicamente)
+
+Agregar al topbar del backoffice un toggle que:
+```javascript
+// Alpine.js component
+function darkModeToggle() {
+  return {
+    dark: localStorage.getItem('theme') === 'dark',
+    toggle() {
+      this.dark = !this.dark
+      document.documentElement.setAttribute('data-theme', this.dark ? 'dark' : 'light')
+      localStorage.setItem('theme', this.dark ? 'dark' : 'light')
+    },
+    init() {
+      const saved = localStorage.getItem('theme') || 'light'
+      document.documentElement.setAttribute('data-theme', saved)
+      this.dark = saved === 'dark'
+    }
+  }
+}
+```
+
+El portal ciudadano NO tiene dark mode (Amendment III de la Design Constitution).
+
+---
+
+### FASE 5 — Auditoría de accesibilidad
+
+Para cada componente implementado verificar:
+1. `outline: 2px solid` en focus — NUNCA `outline: none`
+2. Botones icon-only: `aria-label` requerido
+3. Badges de estado: texto + color (nunca solo color)
+4. Campos requeridos: `*` en `text-fg-danger` + atributo HTML `required`
+5. `window.confirm()` → reemplazar por SweetAlert2 donde quede
+
+Buscar: `grep -r "outline: none" static/custom/css/`
+Buscar: `grep -r "window.confirm" . --include="*.html" --include="*.js"`
+
+---
+
+### FASE 6 — Página de documentación del sistema
+
+Crear vista Django en `/configuracion/design-system/` (staff-only):
+- App: `configuracion`
+- View: `DesignSystemView` (LoginRequired + staff check)
+- Template: `configuracion/design-system.html`
+- URL: `path('design-system/', views.DesignSystemView.as_view())`
+
+La página muestra en vivo:
+- Swatches de todos los semantic tokens de color
+- Escala tipográfica
+- Matriz: variantes × tamaños × estados de botones
+- Todos los badge variants
+- Ejemplos de inputs (default, focus, error, disabled)
+- Stat card demo
+- Empty state demo
+
+---
+
+## Decisiones clave — no re-consultar
+
+| Qué | Valor |
+|-----|-------|
+| Brand primary | `#5059BC` Jacaranda → `var(--bg-brand)` |
+| Gradiente Brand | `linear-gradient(45deg, var(--bg-brand), var(--bg-pink))` |
+| Sidebar width | `288px` (Tailwind `w-72`) |
+| Form max-width | `768px` fijo (`max-w-3xl`) — todos los formularios |
+| Avatar size | `31×31px`, circular, iniciales 2 chars |
+| Toast | Centrado, `rgba(75,85,99,0.7)`, 10 segundos |
+| Modal backdrop | `rgba(209,213,219,0.7)` (gray-300 al 70%) |
+| Modal confirm btn | Brand gradient (NO rojo, incluso en acciones destructivas) |
+| Button border-radius | `rounded-full` (9999px) — todas las variantes y tamaños |
+| Table headers | `text-xs font-semibold uppercase text-body-subtle` |
+| Dark mode | Backoffice únicamente — portal usa light mode |
+| Stat cards | Visual only — `cursor: default`, no son links |
+| Asterisco requerido | `text-fg-danger` (#c70036) |
+| Íconos (nuevos templates) | Heroicons outline (default) / solid (active) |
+| Íconos (legacy templates) | Font Awesome 6.4.0 |
+| CSS (nuevos) | Tailwind — NUNCA mezclar con Bootstrap en el mismo componente |
+| CSS (legacy) | Bootstrap 5.3.2 + AdminLTE |
+| Confirmaciones destructivas | SweetAlert2 obligatorio — `window.confirm()` prohibido |
+
+---
+
+## Archivos a leer antes de empezar
+
+```
+docs/design-kb/design-constitution.md       ← ley suprema
+docs/design-kb/foundations/colors.yaml      ← todos los color tokens
+docs/design-kb/foundations/typography.yaml  ← reglas de fuente
+docs/design-kb/tokens/design-tokens.yaml    ← inventario completo
+docs/design-kb/anti-patterns.md             ← qué NO hacer
+docs/design-kb/components/button.yaml
+docs/design-kb/components/badge.yaml
+docs/design-kb/components/input.yaml
+docs/design-kb/components/sidebar.yaml
+docs/design-kb/components/data-table.yaml
+docs/design-kb/components/toast.yaml
+docs/design-kb/components/modal.yaml
+docs/design-kb/components/avatar.yaml
+docs/design-kb/components/select.yaml
+static/custom/css/chaco-tokens.css          ← CSS variables (fuente de verdad)
+static/custom/css/nodo-buttons.css          ← implementación actual de botones
+static/custom/css/paleta-unificada.css      ← sombras, transiciones
+config/branding.py                          ← generador dinámico de CSS vars
+templates/includes/base.html               ← template base backoffice
+```
+
+---
+
+## Verificación al final de cada fase
+
+- [ ] `python manage.py check` sin errores
+- [ ] No hay valores hex crudos en CSS de componentes (solo CSS vars)
+- [ ] Los 3 variantes de botón tienen los 4 estados (default, hover, focus, disabled)
+- [ ] Todas las tablas tienen empty state definido
+- [ ] SweetAlert2 usado en todas las acciones destructivas
+- [ ] No quedan `window.confirm()` en el código
+- [ ] Focus ring visible en todos los elementos interactivos
+- [ ] Dark mode toggle persiste en localStorage (solo backoffice)

--- a/docs/design-kb/NEXT_PROMPT_DESIGN_SYSTEM.md
+++ b/docs/design-kb/NEXT_PROMPT_DESIGN_SYSTEM.md
@@ -174,12 +174,23 @@ templates/includes/base.html                   ← Main template entry point
 
 ---
 
-### Notes on Conflicts to Resolve
+### Source Hierarchy
 
-1. **Two token systems coexist:** `NODO DS.md` uses magenta (`#FF0080`) as brand primary. `chaco-tokens.json` uses Jacaranda (`#5059BC`) as brand primary. **Resolution: Use `chaco-tokens.json` as authoritative. NODO DS.md is an earlier version.**
+**CHACO siempre gana sobre NODO.** `NODO DS.md` es la documentación del proyecto padre. En todo conflicto prevalece `CHACO_NODO_Design_Manual.md` + `chaco-tokens.json`. NODO DS.md se usa únicamente como fallback para especificaciones que CHACO no documenta (e.g., alturas exactas de botón, valores hex de badge).
 
-2. **Table header typography conflict:** CHACO_NODO_Design_Manual says `text-xs font-semibold uppercase` for column headers. NODO DS.md says `Inter Medium 13px, text-body`. **Resolution: Prefer the manual's spec (uppercase, semibold xs) for new implementations.**
+**Decisiones ya resueltas (no requieren consulta):**
+- Brand primary: `#5059BC` (Jacaranda), no magenta
+- Gradiente Brand button: `linear-gradient(45deg, #5059BC, #598DFF)`
+- Botón tertiary: `#5059BC` en border y texto
+- Sidebar active: pill `bg-brand (#5059bc)` + texto blanco
+- Asterisco requerido: `text-fg-danger` (rojo)
+- Headers de tabla: `text-xs, font-semibold, uppercase, text-body-subtle`
+- Border-radius botones: `rounded-full` (pill / 9999px)
 
-3. **Icon libraries:** New templates → Heroicons only. Legacy → Font Awesome only. Never mix.
+**Pendientes técnicos (sin conflicto, pero sin valor exacto en fuentes CHACO):**
+- Ancho exacto del sidebar: main.css dice 300px, manual dice ~205px — ver pregunta A1
+- `#598DFF` como stop final del gradiente no está en chaco-tokens.json — verificar si tiene token
 
-4. **CSS coexistence:** New templates → Tailwind CSS. Legacy → Bootstrap. Never mix in same component.
+**Coexistencia de stacks:**
+- Iconos nuevos → Heroicons. Legacy → Font Awesome. Nunca mezclar en el mismo componente.
+- CSS nuevos → Tailwind CSS. Legacy → Bootstrap. Nunca mezclar en el mismo componente.

--- a/docs/design-kb/NEXT_PROMPT_DESIGN_SYSTEM.md
+++ b/docs/design-kb/NEXT_PROMPT_DESIGN_SYSTEM.md
@@ -49,7 +49,7 @@ For each component in `docs/design-kb/components/`, implement or update the corr
 - Verify all five sizes (xs, sm, base, l, xl) match exact measurements
 - Verify all states (default, hover, focus, disabled) match token values
 - Add loading state: spinner replaces label, width unchanged
-- Confirm gradient direction: `linear-gradient(45deg, #5059BC, #F26DF9)` (or NODO variant)
+- Confirm gradient direction: `linear-gradient(45deg, #5059BC, #F98DFF)` — Jacaranda → BG Pink (`var(--bg-brand)` → `var(--bg-pink)`)
 
 #### 2b. Badge Component
 - Implement all six variants (gray, white, brand, danger, warning, success) per `components/badge.yaml`
@@ -61,13 +61,13 @@ For each component in `docs/design-kb/components/`, implement or update the corr
 - Focus border: `border-brand 1.5px`
 - Error state: `border-danger 1px` + `bg-danger-soft` background
 - Disabled: `bg-disabled` + `text-fg-disabled`
-- Label always above field, required `*` in `text-fg-brand`
+- Label always above field, required `*` in `text-fg-danger` (#c70036)
 
 #### 2d. Sidebar Navigation
 - Active item: pill shape (rounded-full or rounded-lg), `bg-brand`, white text
 - Hover: `bg-tertiary`
 - Chevron rotation transition: 150ms ease
-- Logo badge: `linear-gradient(45deg, #7928CA, #FF0080)`, border-radius 12px
+- Logo badge: `linear-gradient(45deg, #5059BC, #F98DFF)`, border-radius 12px
 
 #### 2e. Data Table
 - No alternating row colors
@@ -180,16 +180,24 @@ templates/includes/base.html                   ← Main template entry point
 
 **Decisiones ya resueltas (no requieren consulta):**
 - Brand primary: `#5059BC` (Jacaranda), no magenta
-- Gradiente Brand button: `linear-gradient(45deg, #5059BC, #598DFF)`
+- Gradiente Brand button: `linear-gradient(45deg, #5059BC, #F98DFF)` — Jacaranda → BG Pink (`var(--bg-pink)`)
 - Botón tertiary: `#5059BC` en border y texto
 - Sidebar active: pill `bg-brand (#5059bc)` + texto blanco
 - Asterisco requerido: `text-fg-danger` (rojo)
 - Headers de tabla: `text-xs, font-semibold, uppercase, text-body-subtle`
 - Border-radius botones: `rounded-full` (pill / 9999px)
 
-**Pendientes técnicos (sin conflicto, pero sin valor exacto en fuentes CHACO):**
-- Ancho exacto del sidebar: main.css dice 300px, manual dice ~205px — ver pregunta A1
-- `#598DFF` como stop final del gradiente no está en chaco-tokens.json — verificar si tiene token
+**Decisiones adicionales — confirmadas por diseñadora (todas resueltas):**
+- Ancho sidebar: **288px** (Tailwind `w-72` — token primitivo 72 × 4px)
+- Gradiente endpoint: **`#F98DFF`** = `var(--bg-pink)` — token existe en chaco-tokens.json como `bg-pink`
+- Form max-width: **768px fijo** (`max-w-3xl`, 48rem) — uniforme en TODOS los formularios sin excepción
+- Mobile sidebar: **drawer** (panel deslizante desde izquierda) — sin prioridad, implementar solo si se requiere
+- Modal backdrop: `rgba(209, 213, 219, 0.7)` — token `bg-gray` (#d1d5db / gray-300) al 70% de opacidad
+- Toast: **centrado en pantalla**, background `rgba(75, 85, 99, 0.7)` (gray-600 al 70%), duración **10 segundos**
+- Select/Dropdown: diseño de panel personalizado pendiente (diseñadora prometió enviar — ver `components/select.yaml`)
+- Avatar: **31×31px**, circular, iniciales en `text-white font-semibold`
+- Portal dark mode: **backoffice únicamente** — portal ciudadano usa light mode exclusivamente
+- Stat cards: **solo visuales** — no son links ni botones; `cursor: default`
 
 **Coexistencia de stacks:**
 - Iconos nuevos → Heroicons. Legacy → Font Awesome. Nunca mezclar en el mismo componente.

--- a/docs/design-kb/NEXT_PROMPT_DESIGN_SYSTEM.md
+++ b/docs/design-kb/NEXT_PROMPT_DESIGN_SYSTEM.md
@@ -1,0 +1,185 @@
+# NEXT_PROMPT_DESIGN_SYSTEM
+**Complete prompt to transform this Design Knowledge Base into a production-grade Design System**
+
+---
+
+## Context
+
+You are working on the **NODO Design System** for the Gobierno del Chaco, a Django-based backoffice and citizen portal (`Chaco` monorepo). The Design Knowledge Base is located at `docs/design-kb/` in this repository.
+
+The tech stack is:
+- **Backend:** Python 3.12, Django 4.2
+- **CSS (new templates):** Tailwind CSS (Play CDN, no build step)
+- **CSS (legacy templates):** Bootstrap 5.3.2 + AdminLTE
+- **Custom CSS:** `static/custom/css/` (paleta-unificada.css, nodo-brand.css, nodo-buttons.css)
+- **Token files:** `chaco-tokens.css`, `chaco-tailwind.config.js`, `chaco-tokens.json` (in source from design team)
+- **JavaScript:** Alpine.js 3.14.1, jQuery 3.6.0, SweetAlert2, Toastr, Chart.js, ApexCharts
+- **Icons (new):** Heroicons — `@heroicons/react` or SVG direct
+- **Icons (legacy):** Font Awesome 6.4.0
+- **Branding config:** `config/branding.py` (generates CSS variables dynamically)
+
+---
+
+## Your Task
+
+Transform the `docs/design-kb/` Design Knowledge Base into a **production-grade, implementable Design System** for the NODO platform. This includes:
+
+---
+
+### Phase 1: Token Integration
+
+1. **Copy `chaco-tokens.css` to `static/custom/css/chaco-tokens.css`** and make it the first CSS import in:
+   - `templates/includes/base.html` (backoffice)
+   - `portal/templates/portal/base.html` (portal)
+   
+2. **Reconcile `config/branding.py` with the new tokens.** The branding.py generates CSS variables dynamically. Map the branding.py variables to their equivalent chaco-tokens.css variables. Where they conflict, favor the token file values. Update branding.py to reference token variables where possible instead of raw hex values.
+
+3. **Validate token coverage.** Grep through `static/custom/css/paleta-unificada.css`, `nodo-brand.css`, and `nodo-buttons.css` for any raw hex values that now have token equivalents. Replace each with the corresponding CSS variable from chaco-tokens.css.
+
+4. **Extend the Tailwind config.** If a `tailwind.config.js` does not exist at the root, create one that extends `chaco-tailwind.config.js`. Verify the CDN script tag in `base.html` includes the config extension.
+
+---
+
+### Phase 2: Component Library
+
+For each component in `docs/design-kb/components/`, implement or update the corresponding HTML/CSS:
+
+#### 2a. Button System (`static/custom/css/nodo-buttons.css`)
+- Verify all three variants (brand, secondary, tertiary) match specs in `components/button.yaml`
+- Verify all five sizes (xs, sm, base, l, xl) match exact measurements
+- Verify all states (default, hover, focus, disabled) match token values
+- Add loading state: spinner replaces label, width unchanged
+- Confirm gradient direction: `linear-gradient(45deg, #5059BC, #F26DF9)` (or NODO variant)
+
+#### 2b. Badge Component
+- Implement all six variants (gray, white, brand, danger, warning, success) per `components/badge.yaml`
+- Two sizes (sm: 20px height, lg: 24px height)
+- Confirm border-radius: 6px (rounded-md)
+
+#### 2c. Input / Form Fields
+- Implement all four states (default, focus, error, disabled) per `components/input.yaml`
+- Focus border: `border-brand 1.5px`
+- Error state: `border-danger 1px` + `bg-danger-soft` background
+- Disabled: `bg-disabled` + `text-fg-disabled`
+- Label always above field, required `*` in `text-fg-brand`
+
+#### 2d. Sidebar Navigation
+- Active item: pill shape (rounded-full or rounded-lg), `bg-brand`, white text
+- Hover: `bg-tertiary`
+- Chevron rotation transition: 150ms ease
+- Logo badge: `linear-gradient(45deg, #7928CA, #FF0080)`, border-radius 12px
+
+#### 2e. Data Table
+- No alternating row colors
+- Row hover: `bg-tertiary`
+- Column headers: `text-xs, font-semibold, uppercase, text-body-subtle` (wait — cross-reference: CHACO_NODO_Design_Manual says `text-xs font-semibold uppercase`, NODO DS says `Inter Medium 13px, text-body` — reconcile and pick one)
+- Pagination: Tertiary buttons (outlined brand)
+- Empty state: required for every table
+
+---
+
+### Phase 3: Pattern Templates
+
+Create reusable Django template fragments (includes) for:
+
+1. **`templates/includes/ds/stat-card.html`** — takes `number`, `label`, `icon`, `alert_dot` params
+2. **`templates/includes/ds/badge.html`** — takes `variant`, `size`, `text`, `dismissible` params
+3. **`templates/includes/ds/alert-panel.html`** — takes `alerts` list param
+4. **`templates/includes/ds/empty-state.html`** — takes `title`, `message`, `cta_url`, `cta_label` params
+5. **`templates/includes/ds/breadcrumb.html`** — takes `steps` list param (each: `label`, `url`, `active`)
+
+Each template must:
+- Use only token-based classes (Tailwind or CSS variables)
+- Support dark mode via `data-theme` attribute
+- Include accessible attributes (aria-labels, roles)
+
+---
+
+### Phase 4: Dark Mode Implementation
+
+1. Verify `[data-theme="dark"]` and `.dark` selectors in `chaco-tokens.css` cover all semantic tokens
+2. Add a dark mode toggle to the topbar (Alpine.js or vanilla JS):
+   ```javascript
+   document.documentElement.setAttribute('data-theme', 'dark') // activate
+   document.documentElement.setAttribute('data-theme', 'light') // deactivate
+   ```
+3. Persist the preference in `localStorage`
+4. Test all documented screens in dark mode against the token values in `foundations/colors.yaml`
+
+---
+
+### Phase 5: Accessibility Audit
+
+For each component in `docs/design-kb/components/`:
+1. Verify focus states are visible (never `outline: none`)
+2. Verify icon-only buttons have `aria-label`
+3. Verify status badges have text labels (not only color)
+4. Verify required fields have both the `*` indicator and `required` HTML attribute
+5. Verify color contrast ratios for key pairs:
+   - `text-heading` on `bg-primary` (should be: #111827 on #ffffff = AAA)
+   - `text-white` on `bg-brand` (#ffffff on #5059bc — check AA)
+   - `text-fg-disabled` on `bg-disabled` (#9ca3af on #f3f4f6 — verify AA)
+
+---
+
+### Phase 6: Documentation Page
+
+Create a live documentation page at `/configuracion/design-system/` (Django view, staff-only):
+- Rendered HTML showing all components with their states
+- Color swatches for all semantic tokens
+- Typography scale samples
+- Button variants × sizes × states matrix
+- Badge variants
+- This page should be self-contained — no external dependencies beyond what's in the project
+
+---
+
+### Verification Checklist
+
+After completing each phase:
+
+- [ ] `manage.py check` passes with no errors
+- [ ] Tokens are not duplicated between branding.py and chaco-tokens.css
+- [ ] No raw hex values in component CSS (only CSS variables or token-mapped values)
+- [ ] All six badge variants render correctly in light and dark mode
+- [ ] All three button variants have all four states (default, hover, focus, disabled)
+- [ ] All tables have empty states defined
+- [ ] SweetAlert2 is wired for all delete actions
+- [ ] No `window.confirm()` remains in the codebase
+- [ ] Focus rings are visible on all interactive elements
+- [ ] Tailwind config is extended with chaco-tokens
+- [ ] Dark mode toggle persists preference in localStorage
+
+---
+
+### Files to Read Before Starting
+
+```
+docs/design-kb/design-constitution.md          ← Supreme law
+docs/design-kb/foundations/colors.yaml         ← All color tokens
+docs/design-kb/foundations/typography.yaml     ← Font rules
+docs/design-kb/foundations/spacing.yaml        ← Spacing + radius tokens
+docs/design-kb/tokens/design-tokens.yaml       ← Full token inventory
+docs/design-kb/components/button.yaml          ← Button spec
+docs/design-kb/components/badge.yaml           ← Badge spec
+docs/design-kb/components/input.yaml           ← Input spec
+docs/design-kb/components/sidebar.yaml         ← Sidebar spec
+docs/design-kb/components/data-table.yaml      ← Table spec
+docs/design-kb/anti-patterns.md                ← What NOT to do
+static/custom/css/nodo-buttons.css             ← Current button implementation
+static/custom/css/paleta-unificada.css         ← Current token implementation
+config/branding.py                             ← Dynamic CSS variable generator
+templates/includes/base.html                   ← Main template entry point
+```
+
+---
+
+### Notes on Conflicts to Resolve
+
+1. **Two token systems coexist:** `NODO DS.md` uses magenta (`#FF0080`) as brand primary. `chaco-tokens.json` uses Jacaranda (`#5059BC`) as brand primary. **Resolution: Use `chaco-tokens.json` as authoritative. NODO DS.md is an earlier version.**
+
+2. **Table header typography conflict:** CHACO_NODO_Design_Manual says `text-xs font-semibold uppercase` for column headers. NODO DS.md says `Inter Medium 13px, text-body`. **Resolution: Prefer the manual's spec (uppercase, semibold xs) for new implementations.**
+
+3. **Icon libraries:** New templates → Heroicons only. Legacy → Font Awesome only. Never mix.
+
+4. **CSS coexistence:** New templates → Tailwind CSS. Legacy → Bootstrap. Never mix in same component.

--- a/docs/design-kb/anti-patterns.md
+++ b/docs/design-kb/anti-patterns.md
@@ -1,0 +1,266 @@
+# Anti-Patterns
+**NODO Design System — What NOT to do**
+
+---
+
+## A. Color & Token Violations
+
+### AP-C01: Hardcoded hex values in components
+```css
+/* ❌ WRONG */
+.card { background: #f9fafb; border: 1px solid #e5e7eb; }
+.button-primary { background: #5059bc; }
+
+/* ✅ CORRECT */
+.card { background: var(--bg-secondary-soft); border: var(--border-width) solid var(--border-base); }
+.button-primary { background: var(--bg-brand); }
+```
+
+### AP-C02: Using opacity as disabled state substitute
+```css
+/* ❌ WRONG */
+button:disabled { opacity: 0.5; }
+
+/* ✅ CORRECT */
+button:disabled { background: var(--bg-disabled); color: var(--text-fg-disabled); border-color: var(--border-base); }
+```
+
+### AP-C03: Using text-heading or text-body on colored backgrounds
+```css
+/* ❌ WRONG — text-heading on bg-brand surface */
+<div class="bg-brand text-heading">Brand button label</div>
+
+/* ✅ CORRECT */
+<div class="bg-brand text-white">Brand button label</div>
+/* Or use text-fg-brand-strong inside brand-colored alerts/badges */
+```
+
+### AP-C04: Creating ad-hoc colors outside the system
+```css
+/* ❌ WRONG */
+.custom-badge { background: #ff6600; color: white; }
+
+/* ✅ CORRECT — use warning tokens */
+<span class="badge-warning">Status</span>
+```
+
+### AP-C05: Using color as the only state communicator
+```html
+<!-- ❌ WRONG — only red text, no icon or label change -->
+<p style="color: red">Email incorrecto</p>
+
+<!-- ✅ CORRECT — color + icon + specific message -->
+<p class="text-fg-danger text-xs flex items-center gap-1">
+  <ExclamationCircleIcon class="w-4 h-4" /> El email no es válido
+</p>
+```
+
+---
+
+## B. Typography Violations
+
+### AP-T01: Using Gellat outside access screens
+```html
+<!-- ❌ WRONG — Gellat in a dashboard card heading -->
+<h2 class="font-brand text-xl">Ciudadanos en Tratamiento</h2>
+
+<!-- ✅ CORRECT — Inter for all internal UI -->
+<h2 class="font-sans font-semibold text-xl text-heading">Ciudadanos en Tratamiento</h2>
+```
+
+### AP-T02: Arbitrary font sizes outside the scale
+```css
+/* ❌ WRONG */
+.heading { font-size: 22px; }
+
+/* ✅ CORRECT — use scale (text-xl = 20px, text-2xl = 24px) */
+.heading { font-size: var(--font-size-2xl); }
+```
+
+### AP-T03: font-normal on button labels
+```html
+<!-- ❌ WRONG -->
+<button class="btn-brand font-normal">Guardar</button>
+
+<!-- ✅ CORRECT -->
+<button class="btn-brand font-medium">Guardar</button>
+```
+
+### AP-T04: Placeholder used as field label
+```html
+<!-- ❌ WRONG -->
+<input type="text" placeholder="Email" />
+
+<!-- ✅ CORRECT -->
+<label>Email institucional</label>
+<input type="text" placeholder="usuario@chaco.gov.ar" />
+```
+
+---
+
+## C. Layout Violations
+
+### AP-L01: Split-screen layout on internal screens
+```html
+<!-- ❌ WRONG — split screen for a list view -->
+<div class="flex">
+  <div class="w-60%">Illustration</div>
+  <div class="w-40%">Citizen table</div>
+</div>
+
+<!-- ✅ CORRECT — only for authentication -->
+<!-- Split screen is ONLY for login and password recovery -->
+```
+
+### AP-L02: Full-width form within content area
+```html
+<!-- ❌ WRONG -->
+<form class="w-full">...</form>
+
+<!-- ✅ CORRECT -->
+<form class="max-w-[700px] mx-auto">...</form>
+```
+
+### AP-L03: Primary CTA left-aligned
+```html
+<!-- ❌ WRONG -->
+<div class="flex">
+  <button class="btn-brand">⊕ Nuevo legajo</button>
+</div>
+
+<!-- ✅ CORRECT -->
+<div class="flex justify-between items-center">
+  <h1>Ciudadanos</h1>
+  <button class="btn-brand">⊕ Nuevo legajo</button>
+</div>
+```
+
+---
+
+## D. Component Violations
+
+### AP-CO01: Two Brand buttons in the same section
+```html
+<!-- ❌ WRONG -->
+<div>
+  <button class="btn-brand">Guardar borrador</button>
+  <button class="btn-brand">Publicar</button>
+</div>
+
+<!-- ✅ CORRECT — one Brand, one Tertiary or Secondary -->
+<div>
+  <button class="btn-tertiary">Guardar borrador</button>
+  <button class="btn-brand">Publicar →</button>
+</div>
+```
+
+### AP-CO02: Destructive action without SweetAlert2 confirmation
+```javascript
+// ❌ WRONG
+deleteButton.onclick = () => fetch('/api/citizen/delete/123');
+
+// ❌ ALSO WRONG
+deleteButton.onclick = () => { if(confirm('Are you sure?')) fetch(...) };
+
+// ✅ CORRECT
+deleteButton.onclick = () => {
+  Swal.fire({
+    title: '¿Estás seguro?',
+    text: 'Esta acción no se puede deshacer.',
+    showCancelButton: true,
+    confirmButtonText: 'Eliminar',
+  }).then(result => {
+    if (result.isConfirmed) fetch('/api/citizen/delete/123');
+  });
+};
+```
+
+### AP-CO03: Table without empty state
+```html
+<!-- ❌ WRONG — blank table body -->
+<tbody></tbody>
+
+<!-- ✅ CORRECT -->
+<tbody>
+  {% if not citizens %}
+  <tr><td colspan="8">
+    <div class="empty-state">
+      <UserGroupIcon class="w-12 h-12 text-body-subtle" />
+      <p class="text-heading font-semibold">No hay ciudadanos registrados</p>
+    </div>
+  </td></tr>
+  {% endif %}
+</tbody>
+```
+
+### AP-CO04: Removing focus rings for "aesthetic" reasons
+```css
+/* ❌ WRONG — accessibility violation */
+* { outline: none; }
+button:focus { outline: none; }
+
+/* ✅ CORRECT — always keep visible focus */
+button:focus { outline: 2px solid var(--border-brand); }
+```
+
+### AP-CO05: Arbitrary z-index values
+```css
+/* ❌ WRONG */
+.my-modal { z-index: 9999; }
+.my-dropdown { z-index: 500; }
+
+/* ✅ CORRECT — use the defined z-index scale */
+/* base=0, dropdown=10, modal=100, toast=200 */
+.my-modal { z-index: 100; }
+.my-dropdown { z-index: 10; }
+```
+
+---
+
+## E. Icon Violations
+
+### AP-I01: Mixing icon libraries in the same component
+```html
+<!-- ❌ WRONG — Heroicons + Font Awesome mixed -->
+<div>
+  <UserIcon /> <!-- Heroicons -->
+  <i class="fa-solid fa-trash"></i> <!-- Font Awesome -->
+</div>
+
+<!-- ✅ CORRECT — Heroicons only in new templates -->
+<div>
+  <UserIcon />
+  <TrashIcon />
+</div>
+```
+
+### AP-I02: Hardcoded color on icon
+```html
+<!-- ❌ WRONG -->
+<BellIcon style="color: #5059bc" />
+
+<!-- ✅ CORRECT -->
+<BellIcon class="text-fg-brand" />
+```
+
+---
+
+## F. Error Handling Violations
+
+### AP-E01: Exposing technical details to users
+```python
+# ❌ WRONG — Django view returning exception detail
+return JsonResponse({'error': str(e)}, status=500)
+
+# ✅ CORRECT
+return JsonResponse({'error': 'Error al procesar la solicitud. Intenta nuevamente.'}, status=500)
+```
+
+### AP-E02: Auto-dismissing error toasts
+```javascript
+// ❌ WRONG — error silently disappears
+toastr.error('Error al guardar.', '', { timeOut: 3000 });
+
+// ✅ CORRECT — errors persist until dismissed
+toastr.error('Error al guardar.', '', { timeOut: 0, closeButton: true });
+```

--- a/docs/design-kb/brand-principles.md
+++ b/docs/design-kb/brand-principles.md
@@ -93,11 +93,11 @@ The NODO logo is composed of:
 
 ## Brand Color Gradient
 
-The signature gradient — **Jacaranda → Rosa at 45°** — is the single most recognizable brand element.
+The signature gradient — **Jacaranda → Azul Claro at 45°** — es el elemento de marca más distintivo del sistema.
 
 | Format | Value |
 |--------|-------|
-| CSS | `linear-gradient(45deg, #5059BC, #F26DF9)` |
-| Alternative (NODO DS) | `linear-gradient(45deg, #7928CA, #FF0080)` |
+| CSS | `linear-gradient(45deg, #5059BC, #598DFF)` |
+| CSS variable approach | `linear-gradient(45deg, var(--color-brand-700), #598DFF)` |
 
 Used on: primary Brand buttons, sidebar logo badge, metric card icon shapes, total/summary banner backgrounds.

--- a/docs/design-kb/brand-principles.md
+++ b/docs/design-kb/brand-principles.md
@@ -93,11 +93,11 @@ The NODO logo is composed of:
 
 ## Brand Color Gradient
 
-The signature gradient — **Jacaranda → Azul Claro at 45°** — es el elemento de marca más distintivo del sistema.
+The signature gradient — **Jacaranda → Rosa BG Pink at 45°** — es el elemento de marca más distintivo del sistema.
 
 | Format | Value |
 |--------|-------|
-| CSS | `linear-gradient(45deg, #5059BC, #598DFF)` |
-| CSS variable approach | `linear-gradient(45deg, var(--color-brand-700), #598DFF)` |
+| CSS | `linear-gradient(45deg, #5059BC, #F98DFF)` |
+| CSS variable approach | `linear-gradient(45deg, var(--bg-brand), var(--bg-pink))` |
 
 Used on: primary Brand buttons, sidebar logo badge, metric card icon shapes, total/summary banner backgrounds.

--- a/docs/design-kb/brand-principles.md
+++ b/docs/design-kb/brand-principles.md
@@ -1,0 +1,103 @@
+# NODO Brand Principles
+**Gobierno del Chaco — Sistema Integral**
+
+---
+
+## Visual Personality
+
+NODO presents as a **modern, trustworthy, and energetic government platform**. The visual identity balances institutional seriousness with the accessibility and approachability of modern SaaS products.
+
+The brand communicates capability and care simultaneously: capable enough for complex social management work, approachable enough for daily use by social workers and public servants.
+
+**Core visual character:**
+- Bold, gradient-driven brand colors (Jacaranda purple → Rosa pink at 45°) signal modernity and forward motion
+- Clean neutral surfaces (white, gray-50, gray-100) provide breathing room and professional calm
+- Flat illustration style with bright magenta accents creates warmth without whimsy
+- Wavy line textures on access screens evoke fluidity and openness
+
+---
+
+## Emotional Goals
+
+The system aims to evoke:
+
+1. **Confidence** — The platform handles sensitive citizen data; users must trust it implicitly
+2. **Clarity** — Complex social case data must be scannable and digestible at a glance
+3. **Efficiency** — Every second a social worker spends navigating the UI is a second not spent helping citizens
+4. **Pride** — Public servants should feel they are using a professional-grade tool
+
+---
+
+## Trust Signals
+
+| Signal | Implementation |
+|--------|---------------|
+| Institutional identity | Government logo visible in sidebar and all access screens |
+| Data accuracy | RENAPER integration with clearly labeled read-only vs. editable fields |
+| System status | Always-visible system health indicators on the dashboard |
+| Role clarity | User name, role, and group always shown in sidebar user card |
+| Destructive action gates | SweetAlert2 confirmation for all delete/destructive actions |
+| Accessible states | Every interactive element has visible focus, hover, and disabled states |
+| Error clarity | Error messages are descriptive ("El email no es válido"), never generic |
+
+---
+
+## Hierarchy Philosophy
+
+Visual hierarchy in NODO is intentional and strict:
+
+1. **One primary action per screen** — A single Brand button is the CTA. Never two Brand buttons in the same section.
+2. **Content before chrome** — The content area dominates; sidebar and topbar are recessive
+3. **Data over decoration** — Charts, tables, and metrics are the heroes of the interface
+4. **State before style** — Every component's visual appearance communicates its interactive state
+5. **Heading → Body → Subtle** — Three text levels establish hierarchy; never use heading color on body copy or vice versa
+
+---
+
+## Content Philosophy
+
+- **Labels describe, they do not decorate** — Every label, heading, and helper text exists to reduce cognitive load, not add visual weight
+- **Required fields are marked** — The asterisk in `text-fg-danger` communicates clearly what the user must provide
+- **Errors explain, not accuse** — Error messages say what went wrong and how to fix it
+- **Empty states have purpose** — Empty states show an illustration with a contextual action, never a blank space
+- **Plurals and zeros are handled** — "0 ciudadanos", "3 Alertas" — the system always renders quantity correctly
+- **IDs and stack traces are hidden** — Never expose technical identifiers or error details to end users
+
+---
+
+## Interaction Philosophy
+
+- **Keyboard accessibility is non-negotiable** — Focus states are always visible (`outline: 2px solid` on focus)
+- **Destructive actions require confirmation** — SweetAlert2 modal before any delete or irreversible operation
+- **State changes are animated** — 150ms transitions on all interactive state changes prevent jarring shifts
+- **Loading states preserve layout** — Spinner replaces label in buttons; card skeletons replace content during load
+- **One active nav item at a time** — The sidebar pill indicator is singular and unambiguous
+- **Dark mode is a first-class citizen** — All tokens have light and dark variants; themes switch via `data-theme="dark"` or `.dark` class
+
+---
+
+## Logo Usage
+
+The NODO logo is composed of:
+1. **Isologo** — Stylized shield with olive green (`#8A9A46`/`#C8D29C`) and Jacaranda blue (`#5059BC`) stripes, crowned by three rosa pink (`#F26DF9`) dots
+2. **Wordmark** — "Gobierno del CHACO" with "CHACO" in extra bold. Color: Azul Principal `#00203A`
+
+**Usage rules:**
+- Isologo + Wordmark: sidebar header, all access screens
+- Isologo alone: favicon and app icons only
+- Always on light backgrounds (`bg-white`, `bg-primary`)
+- Dark background variant: only with design team approval
+- Never change logo colors, crop, distort, or rotate
+
+---
+
+## Brand Color Gradient
+
+The signature gradient — **Jacaranda → Rosa at 45°** — is the single most recognizable brand element.
+
+| Format | Value |
+|--------|-------|
+| CSS | `linear-gradient(45deg, #5059BC, #F26DF9)` |
+| Alternative (NODO DS) | `linear-gradient(45deg, #7928CA, #FF0080)` |
+
+Used on: primary Brand buttons, sidebar logo badge, metric card icon shapes, total/summary banner backgrounds.

--- a/docs/design-kb/components/alert-panel.yaml
+++ b/docs/design-kb/components/alert-panel.yaml
@@ -1,0 +1,85 @@
+# =============================================================
+# Component: Alert Panel (Critical Alerts)
+# Source: CHACO_NODO_Design_Manual.md §12.8
+# =============================================================
+
+purpose: >
+  Displays a collection of critical alerts that require the user's attention.
+  Appears on the dashboard home screen when critical conditions exist.
+  The panel is absent when there are no alerts — not rendered as empty.
+
+variants:
+  critical:
+    trigger: "When citizens with high risk, no-contact, or overdue follow-up exist"
+    container_bg: "bg-brand-softer / bg-danger-soft (rosa very soft)"
+    container_border: "border-brand-subtle or border-danger-subtle"
+    border_radius: "rounded-xl (8–12px)"
+
+states:
+  with_alerts:
+    shows: "Full panel with alert cards"
+  no_alerts:
+    shows: "Component is NOT rendered — not shown as empty"
+
+anatomy:
+  structure: |
+    ┌─────────────────────────────────────────────────┐
+    │ Alertas Críticas                   3 Alertas × │
+    │ ┌──────────────┐ ┌──────────────┐ ┌──────────┐  │
+    │ │ Juan Pérez   │ │ María García │ │ Carlos   │  │
+    │ │ Riesgo Alto  │ │ Sin Contacto │ │ Seg. Ven.│  │
+    │ │ Hace 2 horas │ │ Hace 4 horas │ │ Ayer     │  │
+    │ └──────────────┘ └──────────────┘ └──────────┘  │
+    └─────────────────────────────────────────────────┘
+
+  header:
+    title: "Alertas Críticas"
+    badge: "Count badge (e.g., '3 Alertas') — badge-danger or text-fg-danger with × dismiss"
+
+  alert_cards:
+    background: "bg-white"
+    border: "border-base"
+    border_radius: "rounded-lg (8px)"
+    content:
+      citizen_name: "text-sm, font-semibold, text-heading"
+      alert_type: "Badge — danger/warning variant matching the alert type"
+      time_ago: "text-xs, text-body-subtle, relative time format"
+    action_arrow:
+      icon: "ChevronRightIcon or ArrowRightIcon"
+      color: "text-fg-brand"
+      function: "Navigates to citizen detail"
+
+responsive_rules:
+  - "Alert cards scroll horizontally if more than 3 alerts"
+  - "Mobile behavior: UNKNOWN"
+
+accessibility_rules:
+  - "Panel title announces urgency — 'Alertas Críticas'"
+  - "Each alert card should be an accessible link to the citizen"
+  - "Dismiss (×) button has aria-label"
+  - "Alert count badge communicates quantity"
+
+allowed_usage:
+  - "Dashboard home screen only"
+  - "Rendered only when critical alerts exist"
+
+forbidden_usage:
+  - "Showing the panel in empty state"
+  - "Using this pattern for non-critical informational messages (use info banner instead)"
+  - "Hard-coding citizen names or alert counts"
+
+examples:
+  panel: |
+    <div class="alert-panel bg-brand-softer border border-brand-subtle rounded-xl p-4">
+      <div class="flex justify-between">
+        <h3 class="font-semibold text-heading">Alertas Críticas</h3>
+        <span class="badge-danger badge-sm">3 Alertas ×</span>
+      </div>
+      <div class="alert-cards flex gap-3 mt-3">
+        <!-- alert cards -->
+      </div>
+    </div>
+
+anti_examples:
+  - "An empty 'Alertas Críticas' panel with 'No hay alertas' text — omit entirely when empty"
+  - "Using blue/info color for critical alerts that need danger treatment"

--- a/docs/design-kb/components/alert-panel.yaml
+++ b/docs/design-kb/components/alert-panel.yaml
@@ -83,3 +83,121 @@ examples:
 anti_examples:
   - "An empty 'Alertas Críticas' panel with 'No hay alertas' text — omit entirely when empty"
   - "Using blue/info color for critical alerts that need danger treatment"
+
+# -------------------------------------------------------------
+# INLINE ALERT (Error / Warning inline panel)
+# Source: Designer design reference (2026-06-08)
+# Usage: Inline within a page or section — NOT the dashboard alert panel above
+# -------------------------------------------------------------
+inline_alert:
+  purpose: >
+    A contextual alert card that appears inline within a page or section
+    when a user action fails or needs attention. Has explicit action buttons.
+    Distinct from the dashboard critical-alert panel.
+
+  variants:
+    error:
+      background: "bg-danger-soft (#fef0f2)"
+      border: "border-danger-subtle (#ffccd3) 1px"
+      icon_circle_bg: "bg-danger-medium (#ffe4e6)"
+      icon_color: "text-fg-danger (#c70036)"
+      title_color: "text-heading (#111827)"
+      body_color: "text-body (#4b5563)"
+
+    warning:
+      background: "bg-warning-soft (#fff8f1)"
+      border: "border-warning-subtle (#fcd9bd) 1px"
+      icon_circle_bg: "bg-warning-medium (#feecdc)"
+      icon_color: "text-fg-warning-subtle"
+      title_color: "text-heading"
+      body_color: "text-body"
+
+    info:
+      background: "bg-brand-softer (#fef3ff)"
+      border: "border-brand-subtle (#fee3ff) 1px"
+      icon_circle_bg: "bg-brand-soft (#fee9ff)"
+      icon_color: "text-fg-brand (#5059bc)"
+      title_color: "text-heading"
+      body_color: "text-body"
+
+  anatomy: |
+    ┌────────────────────────────────────────────────────────┐  ← bg-danger-soft, border-danger-subtle, rounded-xl
+    │ [ⓘ] Whoops! Something went wrong                       │  ← icon circle (20px) + title (font-semibold 15px)
+    │      The file format is not supported. Please upload   │  ← body text (14px, text-body)
+    │      a valid file type (PDF, JPG, PNG).                │
+    │                                                        │
+    │  [Close]  [↑ Try again]                                │  ← action buttons (left-aligned)
+    └────────────────────────────────────────────────────────┘
+
+  icon:
+    shape: "circle"
+    size: "~20px"
+    background: "variant-specific (see variants above)"
+    icon: "InformationCircleIcon or variant-specific icon"
+
+  title:
+    font: "Inter SemiBold 15px"
+    color: "text-heading"
+
+  body:
+    font: "Inter Regular 14px"
+    color: "text-body"
+
+  action_buttons:
+    close:
+      style: "Secondary (outlined)"
+      label: "Close / Cerrar"
+    primary_action:
+      style: "Danger filled (bg-danger, text-white) for error; Brand gradient for info"
+      label: "Try again / Reintentar / Ver más"
+      icon: "Relevant icon to the left of label"
+
+  border_radius: "rounded-xl (12px)"
+  padding: "16px 20px"
+
+# -------------------------------------------------------------
+# NOTIFICATION CARD (Persistent info notification)
+# Source: Designer design reference (2026-06-08)
+# Usage: Persistent notification — does NOT auto-dismiss
+# -------------------------------------------------------------
+notification_card:
+  purpose: >
+    A persistent notification card that appears in a panel or at the top of a section.
+    Unlike toast, it does NOT auto-dismiss. Used for software updates, important
+    announcements, or background task completions that require user action.
+
+  appearance:
+    background: "bg-secondary-soft (#f9fafb)"
+    border: "none (shadow or subtle background differentiates it)"
+    border_radius: "rounded-xl (12px)"
+    padding: "16px 20px"
+
+  icon_shape:
+    background: "bg-brand-soft (#fee9ff) or bg-tertiary"
+    icon_color: "text-fg-brand (#5059bc)"
+    border_radius: "rounded-lg (10–12px)"
+    size: "~40px"
+    note: "Icon shape uses brand-soft background — NOT the gradient"
+
+  close_button:
+    position: "top-right"
+    icon: "XMarkIcon"
+    color: "text-body-subtle"
+
+  anatomy: |
+    ┌──────────────────────────────────────────┐  ← bg-secondary-soft, rounded-xl
+    │ [Icon]  Update available           [×]   │  ← icon-shape (40px) + title (font-semibold) + close
+    │         The latest software version is   │  ← body text (14px, text-body-subtle)
+    │         now accessible for download.     │
+    │                                          │
+    │  [Not now]  [↓ Update]                   │  ← action buttons right-aligned
+    └──────────────────────────────────────────┘
+
+  action_buttons:
+    dismiss:
+      style: "Secondary (outlined)"
+      label: "Not now / Ahora no"
+    primary_action:
+      style: "Brand gradient pill"
+      icon: "Relevant action icon"
+      label: "Update / Actualizar / Ver más"

--- a/docs/design-kb/components/avatar.yaml
+++ b/docs/design-kb/components/avatar.yaml
@@ -1,0 +1,104 @@
+# =============================================================
+# Component: Avatar
+# Source: Designer confirmation (2026-06-08)
+# Note: Partially inferred from data-table.yaml + sidebar.yaml + direct spec
+# =============================================================
+
+purpose: >
+  Circular element representing a user or entity identity.
+  Shows initials when no photo is available.
+  Used consistently in sidebar user card, data table rows, and entity headers.
+
+variants:
+  initials:
+    description: "Circle with 1–2 uppercase initials from name"
+    when: "Default — no photo available or photo not loaded"
+
+  photo:
+    description: "Circular crop of user profile photo"
+    when: "User has uploaded a photo (system staff/users)"
+    fallback: "Always render initials variant if photo fails to load"
+
+size:
+  standard:
+    width: "31px"
+    height: "31px"
+    font: "Inter SemiBold, ~12–13px"
+    note: "Single size used throughout the system — do not create other sizes without design approval"
+
+appearance:
+  shape: "circle (border-radius: 9999px)"
+  background: "bg-brand-medium (jacaranda soft) for citizen initials"
+  text_color: "text-white (#ffffff)"
+  font_weight: "font-semibold"
+  overflow: "hidden (for photo variant)"
+
+generating_initials:
+  rule: "First letter of first name + first letter of last name"
+  example: "Carlos Martínez → CM"
+  fallback_1_letter: "If only one name: first letter only"
+  uppercase: true
+  max_characters: 2
+
+contexts:
+  sidebar_user_card:
+    position: "Left of user name and role"
+    background: "bg-brand-medium or brand gradient shape"
+    shows: "Logged-in user's initials"
+
+  data_table_row:
+    position: "First column (CIUDADANO cell)"
+    background: "bg-brand-medium (jacaranda soft)"
+    shows: "Citizen's initials"
+    example: "'CM' for Carlos Martínez"
+
+  entity_header:
+    position: "Left of entity name in detail view header"
+    background: "bg-brand-medium"
+    shows: "Entity's initials"
+
+anatomy: |
+  ┌────────┐
+  │  CM    │  ← 31×31px circle, bg-brand-medium, text-white font-semibold ~12px
+  └────────┘
+
+accessibility_rules:
+  - "Avatar must have aria-label with the person's full name"
+  - "Example: aria-label='Carlos Martínez'"
+  - "Never use alt text with just initials — screen readers need the full name"
+
+allowed_usage:
+  - "Sidebar user card (logged-in user)"
+  - "Data table CIUDADANO column"
+  - "Entity detail view header"
+  - "Comment/conversation threads (if applicable)"
+
+forbidden_usage:
+  - "Sizes other than 31×31px unless explicitly approved by designer"
+  - "Square avatars — always circular"
+  - "More than 2 initials"
+  - "Hardcoded background colors — always use `bg-brand-medium` token"
+  - "Avatar without accessible label"
+
+examples:
+  initials: |
+    <div class="avatar"
+         style="width: 31px; height: 31px; border-radius: 9999px;"
+         class="bg-brand-medium flex items-center justify-center"
+         aria-label="Carlos Martínez">
+      <span class="text-white font-semibold text-xs">CM</span>
+    </div>
+
+  tailwind: |
+    <div class="w-[31px] h-[31px] rounded-full bg-brand-medium
+                flex items-center justify-center
+                text-white font-semibold text-xs"
+         aria-label="{{ ciudadano.nombre_completo }}">
+      {{ ciudadano.iniciales }}
+    </div>
+
+anti_examples:
+  - "Avatar 40×40px when the spec is 31×31px"
+  - "Avatar with square corners"
+  - "Three initials (JMC instead of JM)"
+  - "Missing aria-label"

--- a/docs/design-kb/components/badge.yaml
+++ b/docs/design-kb/components/badge.yaml
@@ -1,0 +1,123 @@
+# =============================================================
+# Component: Badge
+# Source: NODO DS.md §6, Canva brand manual (badges section)
+# =============================================================
+
+purpose: >
+  Small label element for communicating status, category, or count.
+  Purely informational — not interactive unless it includes a dismiss (×) control.
+  Six color variants cover all semantic states.
+
+variants:
+  gray:
+    fill: "#F9FAFB"
+    stroke: "#101828 1px"
+    text: "#101828"
+    use: "Neutral / default state labels"
+    css_example: ".badge-gray { background:#F9FAFB; border:1px solid #101828; color:#101828; }"
+
+  white:
+    fill: "#FFFFFF"
+    stroke: "#E5E7EB 1px"
+    text: "#101828"
+    use: "White surface badges, minimal styling"
+    css_example: ".badge-white { background:#FFFFFF; border:1px solid #E5E7EB; color:#101828; }"
+
+  brand:
+    fill: "#FFB9DC"
+    stroke: "#101828 1px"
+    text: "#A11F60"
+    use: "Brand/informational — announcements, info tags"
+    css_example: ".badge-brand { background:#FFB9DC; border:1px solid #101828; color:#A11F60; }"
+
+  danger:
+    fill: "#FEF0F2"
+    stroke: "#FFCCD3 1px"
+    text: "#8B0836"
+    use: "Error state, critical risk level, overdue status"
+    css_example: ".badge-danger { background:#FEF0F2; border:1px solid #FFCCD3; color:#8B0836; }"
+
+  warning:
+    fill: "#FFF8F1"
+    stroke: "#FCD9BD 1px"
+    text: "#771D1D"
+    use: "Medium risk, pending, non-critical alerts"
+    css_example: ".badge-warning { background:#FFF8F1; border:1px solid #FCD9BD; color:#771D1D; }"
+
+  success:
+    fill: "#ECFDF5"
+    stroke: "#A4F4CF 1px"
+    text: "#006045"
+    use: "Low risk, completed, confirmed, positive status"
+    css_example: ".badge-success { background:#ECFDF5; border:1px solid #A4F4CF; color:#006045; }"
+
+  # Risk level badge mapping (from citizen table):
+  risk_levels:
+    BAJO: "success"
+    MEDIO: "warning"
+    ALTO: "danger"
+    SIN_CONTACTO: "warning"
+    SEGUIMIENTO_VENCIDO: "danger"
+
+sizes:
+  sm:
+    font: "Inter Medium 12px"
+    padding_v: "2px"
+    padding_h: "4px"
+    gap: "2px"
+    height: "20px"
+    border_radius: "6px"
+    icon_size: "optional — both leading and trailing"
+
+  lg:
+    font: "Inter Medium 14px"
+    padding_v: "4px"
+    padding_h: "6px"
+    gap: "4px"
+    height: "24px"
+    border_radius: "6px"
+    icon_size: "optional — both leading and trailing"
+
+states:
+  - display: "Default informational state"
+  - dismissible: "With × close button — indicates the badge can be removed by the user"
+
+anatomy:
+  structure: "[leading-icon/avatar/dot]  [Label text]  [Secondary text (optional)]  [× dismiss (optional)]"
+  note: >
+    The × dismiss control implies the badge can be removed by user interaction.
+    Do not include × if badge is display-only.
+
+responsive_rules:
+  - "Badge width is variable — sized to content"
+  - "Numeric badges (counts) are always circular"
+
+accessibility_rules:
+  - "Badge color alone must not be the only state indicator — label text must also communicate the state"
+  - "Dismissible badges must have an accessible × button with aria-label"
+  - "Color contrast: each variant must meet WCAG AA (pending full audit)"
+
+allowed_usage:
+  - "Risk level indicators in tables (BAJO/MEDIO/ALTO)"
+  - "Status indicators (Completa, En progreso, Sin éxito)"
+  - "Alert quantity labels (3 Alertas)"
+  - "Navigation notification counts (sidebar badge)"
+  - "Category tags in data views"
+
+forbidden_usage:
+  - "Creating badge colors outside the six defined variants"
+  - "Using badges as interactive navigation elements (use chips/buttons instead)"
+  - "Secondary text with same weight as primary label text"
+  - "Numeric badges in non-circular shapes"
+  - "Badges with hardcoded hex colors not from the system"
+
+examples:
+  risk_low: '<span class="badge-success badge-sm">BAJO</span>'
+  risk_high: '<span class="badge-danger badge-sm">ALTO</span>'
+  notification: '<span class="badge-brand badge-sm">3 Alertas ×</span>'
+  table_status: '<span class="badge-success badge-lg">Completa</span>'
+
+anti_examples:
+  - "A custom orange badge for a new state that should be warning"
+  - "A badge with only color (no text) to indicate status"
+  - "Using a badge for a clickable filter (that is a chip, not a badge)"

--- a/docs/design-kb/components/breadcrumb.yaml
+++ b/docs/design-kb/components/breadcrumb.yaml
@@ -1,0 +1,76 @@
+# =============================================================
+# Component: Breadcrumb / Step Indicator
+# Source: CHACO_NODO_Design_Manual.md §12.9
+# =============================================================
+
+purpose: >
+  Shows the user's current location within a navigation hierarchy
+  or the current step in a multi-step flow.
+  Observed in the Confirmar Datos del Ciudadano screen.
+
+variants:
+  navigation_breadcrumb:
+    description: "Path-based breadcrumb showing hierarchy"
+    structure: "[icon] > Step 1 > Step 2 (current)"
+
+states:
+  previous_step:
+    style: "Link — clickable, text-body-subtle or text-fg-brand"
+  current_step:
+    style: "text-fg-brand or text-heading, font-medium, not a link"
+  separator:
+    character: ">"
+    color: "text-body-subtle"
+
+anatomy:
+  example: "[👥 icon]  >  Nuevo Ciudadano  >  Confirmar"
+
+  icon:
+    color: "text-fg-brand"
+    size: "w-5 h-5 or w-4 h-4"
+
+  previous_link:
+    font: "text-sm, font-normal"
+    color: "text-body-subtle (or text-fg-brand if clickable)"
+    cursor: "pointer (clickable)"
+
+  current_page:
+    font: "text-sm, font-medium"
+    color: "text-fg-brand or text-heading"
+    cursor: "default (not a link)"
+
+  separator:
+    character: ">"
+    font: "text-sm"
+    color: "text-body-subtle"
+    spacing: "small padding each side"
+
+responsive_rules:
+  - "Breadcrumb should truncate on very small screens (UNKNOWN — not documented)"
+
+accessibility_rules:
+  - "Wrap in <nav aria-label='Breadcrumb'>"
+  - "Current page must have aria-current='page'"
+  - "Previous steps should be real <a> links"
+
+allowed_usage:
+  - "Multi-step forms (Nuevo Ciudadano → Confirmar Datos)"
+  - "Deep navigation paths within an entity"
+
+forbidden_usage:
+  - "Using breadcrumb on top-level screens (Home, Ciudadanos list)"
+  - "Breadcrumb with non-clickable previous steps"
+
+examples:
+  breadcrumb: |
+    <nav aria-label="Breadcrumb" class="flex items-center gap-1 text-sm">
+      <UserGroupIcon class="w-4 h-4 text-fg-brand" />
+      <span class="text-body-subtle">></span>
+      <a class="text-body-subtle hover:text-fg-brand">Nuevo Ciudadano</a>
+      <span class="text-body-subtle">></span>
+      <span class="text-fg-brand font-medium" aria-current="page">Confirmar</span>
+    </nav>
+
+anti_examples:
+  - "Breadcrumb on the home/dashboard screen"
+  - "All steps rendered as plain text (no link on navigable steps)"

--- a/docs/design-kb/components/button.yaml
+++ b/docs/design-kb/components/button.yaml
@@ -1,0 +1,199 @@
+# =============================================================
+# Component: Button
+# Source: CHACO_NODO_Design_Manual.md §7, NODO DS.md §5
+# =============================================================
+
+purpose: >
+  The primary interactive element for triggering actions.
+  Three variants establish a strict visual hierarchy.
+  Only one Brand button may appear per screen section.
+
+variants:
+  brand:
+    description: "Primary action button with gradient fill. One per section maximum."
+    background: "linear-gradient(45deg, #5059BC, #F26DF9)"
+    alternative_gradient: "linear-gradient(45deg, #7928CA, #FF0080)"
+    text_color: "#ffffff"
+    border: "none"
+    states:
+      default:
+        background: "linear-gradient(45deg, #5059BC, #F26DF9)"
+        text: "#ffffff"
+        border: "none"
+      hover:
+        background: "linear-gradient(45deg, #5059BC, #F26DF9) + ::after overlay #000 20% opacity"
+        text: "#ffffff"
+      focus:
+        background: "linear-gradient(45deg, #5059BC, #F26DF9)"
+        border: "#5059BC 2px"
+        text: "#ffffff"
+        box_shadow: "0 1px 0 2px #E5E7EB"
+      disabled:
+        background: "#F3F4F6"
+        border: "#E5E7E8 1px"
+        text: "#99A1AF"
+        cursor: "not-allowed"
+
+  secondary:
+    description: "Alternative action. Less visual weight than brand, neutral outlined style."
+    states:
+      default:
+        background: "#F9FAFB"
+        border: "#E5E7EB 1px"
+        text: "#4A5565"
+      hover:
+        background: "#F3F4F6"
+        border: "#E5E7EB 1px"
+        text: "#101828"
+      focus:
+        background: "#F3F4F6"
+        border: "#E5E7EB 1px"
+        text: "#101828"
+        box_shadow: "0 1px 0 2px #F3F4F6"
+      disabled:
+        background: "#F3F4F6"
+        border: "#E5E7E8 1px"
+        text: "#99A1AF"
+        cursor: "not-allowed"
+
+  tertiary:
+    description: "Outlined brand. Secondary actions with brand identity (e.g., Back, Export)."
+    states:
+      default:
+        background: "#FFFFFF"
+        border: "#5059BC 1px"
+        text: "#5059BC"
+      hover:
+        background: "#DEE1FF"
+        border: "#5059BC 1px"
+        text: "#5059BC"
+      focus:
+        background: "#DEE1FF"
+        border: "#2331C9 1px"
+        text: "#2331C9"
+        box_shadow: "0 1px 0 2px #F3F4F6"
+      disabled:
+        background: "#F0F2FF"
+        border: "#5059BC 1px"
+        text: "#5059BC"
+        cursor: "not-allowed"
+
+    # Alternative values from NODO DS.md (magenta-based):
+    nodo_ds_alternative:
+      default:
+        background: "#FFFFFF"
+        border: "#FF0080 1px"
+        text: "#FF0080"
+      hover:
+        background: "rgba(255,0,128,0.1)"
+        border: "#D4006A 1px"
+        text: "#D4006A"
+      focus:
+        background: "rgba(212,0,106,0.1)"
+        border: "#D4006A 1px"
+        text: "#D4006A"
+        box_shadow: "0 1px 0 2px #F3F4F6"
+      disabled:
+        background: "rgba(199,160,180,0.2)"
+        border: "#C7A0B4 1px"
+        text: "#D4006A"
+
+sizes:
+  xs:
+    font: "Inter Medium 12px"
+    padding_v: "6px"
+    padding_h: "12px"
+    gap_icon: "6px"
+    height: "32px"
+    border_radius: "12px"
+    min_width: "~128px"
+
+  sm:
+    font: "Inter Medium 14px"
+    padding_v: "8px"
+    padding_h: "12px"
+    gap_icon: "6px"
+    height: "36px"
+    border_radius: "12px"
+    min_width: "~140px"
+
+  base:
+    font: "Inter Medium 14px"
+    padding_v: "10px"
+    padding_h: "16px"
+    gap_icon: "6px"
+    height: "40px"
+    border_radius: "12px"
+    min_width: "~152px"
+    note: "DEFAULT size"
+
+  l:
+    font: "Inter Medium 16px"
+    padding_v: "12px"
+    padding_h: "20px"
+    gap_icon: "6px"
+    height: "48px"
+    border_radius: "12px"
+    min_width: "~166px"
+
+  xl:
+    font: "Inter Medium 16px"
+    padding_v: "14px"
+    padding_h: "24px"
+    gap_icon: "6px"
+    height: "52px"
+    border_radius: "12px"
+    min_width: "~186px"
+
+states:
+  - default
+  - hover
+  - focus
+  - disabled
+  - loading:
+      description: "Spinner replaces label text. Button width does not change."
+
+responsive_rules:
+  - "Button width adjusts to content unless explicitly constrained"
+  - "Full-width buttons in mobile form CTAs (UNKNOWN — not fully documented)"
+
+accessibility_rules:
+  - "Focus state is always visible (2px outline/ring)"
+  - "Disabled buttons never become invisible — they use disabled styling"
+  - "Icon-only buttons require aria-label"
+  - "Brand button uses white text on gradient for WCAG contrast"
+  - "Disabled state text (#99A1AF on #F3F4F6) — contrast UNKNOWN, pending WCAG audit"
+
+allowed_usage:
+  brand:
+    - "Primary CTA for each screen or section"
+    - "Form submission (create, save, confirm)"
+    - "Key navigation trigger (Consulta Renaper, Crear Ciudadano)"
+  secondary:
+    - "Alternative actions without strong brand association"
+    - "Filter and action dropdown triggers in tables"
+  tertiary:
+    - "Back navigation (← Volver)"
+    - "Export / download actions"
+    - "Secondary form actions"
+    - "Pagination controls"
+
+forbidden_usage:
+  - "Two Brand buttons in the same screen section"
+  - "Brand button for destructive actions (use Danger-styled button)"
+  - "Creating new button color variants outside these three"
+  - "Using font-normal for button label text"
+  - "Changing gradient angles or colors from defined values"
+  - "Using opacity: 0.5 as substitute for disabled state"
+
+examples:
+  brand: '<button class="btn-brand btn-base">Crear Ciudadano →</button>'
+  secondary: '<button class="btn-secondary btn-sm">Filtrar ∨</button>'
+  tertiary: '<button class="btn-tertiary btn-base">← Volver</button>'
+  icon_only: '<button class="btn-secondary btn-base" aria-label="Exportar"><DownloadIcon /></button>'
+
+anti_examples:
+  - "Two gradient buttons side by side in the same form"
+  - "A red/danger button styled with a custom hex instead of danger tokens"
+  - "A Brand button used for 'Cancelar' or 'Eliminar'"
+  - "Button with font-size outside the scale"

--- a/docs/design-kb/components/button.yaml
+++ b/docs/design-kb/components/button.yaml
@@ -12,19 +12,19 @@ purpose: >
 variants:
   brand:
     description: "Primary action button with gradient fill. One per section maximum."
-    background: "linear-gradient(45deg, #5059BC, #598DFF)"
+    background: "linear-gradient(45deg, #5059BC, #F98DFF)"
     text_color: "#ffffff"
     border: "none"
     states:
       default:
-        background: "linear-gradient(45deg, #5059BC, #598DFF)"
+        background: "linear-gradient(45deg, #5059BC, #F98DFF)"
         text: "#ffffff"
         border: "none"
       hover:
-        background: "linear-gradient(45deg, #5059BC, #598DFF) + ::after overlay #000 20% opacity"
+        background: "linear-gradient(45deg, #5059BC, #F98DFF) + ::after overlay #000 20% opacity"
         text: "#ffffff"
       focus:
-        background: "linear-gradient(45deg, #5059BC, #598DFF)"
+        background: "linear-gradient(45deg, #5059BC, #F98DFF)"
         border: "#5059BC 2px"
         text: "#ffffff"
         box_shadow: "0 1px 0 2px #E5E7EB"

--- a/docs/design-kb/components/button.yaml
+++ b/docs/design-kb/components/button.yaml
@@ -1,6 +1,7 @@
 # =============================================================
 # Component: Button
-# Source: CHACO_NODO_Design_Manual.md §7, NODO DS.md §5
+# Source: CHACO_NODO_Design_Manual.md §7
+# Note: NODO DS.md values were the parent project spec and are superseded by CHACO.
 # =============================================================
 
 purpose: >
@@ -11,20 +12,19 @@ purpose: >
 variants:
   brand:
     description: "Primary action button with gradient fill. One per section maximum."
-    background: "linear-gradient(45deg, #5059BC, #F26DF9)"
-    alternative_gradient: "linear-gradient(45deg, #7928CA, #FF0080)"
+    background: "linear-gradient(45deg, #5059BC, #598DFF)"
     text_color: "#ffffff"
     border: "none"
     states:
       default:
-        background: "linear-gradient(45deg, #5059BC, #F26DF9)"
+        background: "linear-gradient(45deg, #5059BC, #598DFF)"
         text: "#ffffff"
         border: "none"
       hover:
-        background: "linear-gradient(45deg, #5059BC, #F26DF9) + ::after overlay #000 20% opacity"
+        background: "linear-gradient(45deg, #5059BC, #598DFF) + ::after overlay #000 20% opacity"
         text: "#ffffff"
       focus:
-        background: "linear-gradient(45deg, #5059BC, #F26DF9)"
+        background: "linear-gradient(45deg, #5059BC, #598DFF)"
         border: "#5059BC 2px"
         text: "#ffffff"
         box_shadow: "0 1px 0 2px #E5E7EB"
@@ -78,26 +78,6 @@ variants:
         text: "#5059BC"
         cursor: "not-allowed"
 
-    # Alternative values from NODO DS.md (magenta-based):
-    nodo_ds_alternative:
-      default:
-        background: "#FFFFFF"
-        border: "#FF0080 1px"
-        text: "#FF0080"
-      hover:
-        background: "rgba(255,0,128,0.1)"
-        border: "#D4006A 1px"
-        text: "#D4006A"
-      focus:
-        background: "rgba(212,0,106,0.1)"
-        border: "#D4006A 1px"
-        text: "#D4006A"
-        box_shadow: "0 1px 0 2px #F3F4F6"
-      disabled:
-        background: "rgba(199,160,180,0.2)"
-        border: "#C7A0B4 1px"
-        text: "#D4006A"
-
 sizes:
   xs:
     font: "Inter Medium 12px"
@@ -105,7 +85,7 @@ sizes:
     padding_h: "12px"
     gap_icon: "6px"
     height: "32px"
-    border_radius: "12px"
+    border_radius: "rounded-full (9999px — pill shape)"
     min_width: "~128px"
 
   sm:
@@ -114,7 +94,7 @@ sizes:
     padding_h: "12px"
     gap_icon: "6px"
     height: "36px"
-    border_radius: "12px"
+    border_radius: "rounded-full (9999px — pill shape)"
     min_width: "~140px"
 
   base:
@@ -123,7 +103,7 @@ sizes:
     padding_h: "16px"
     gap_icon: "6px"
     height: "40px"
-    border_radius: "12px"
+    border_radius: "rounded-full (9999px — pill shape)"
     min_width: "~152px"
     note: "DEFAULT size"
 
@@ -133,7 +113,7 @@ sizes:
     padding_h: "20px"
     gap_icon: "6px"
     height: "48px"
-    border_radius: "12px"
+    border_radius: "rounded-full (9999px — pill shape)"
     min_width: "~166px"
 
   xl:
@@ -142,7 +122,7 @@ sizes:
     padding_h: "24px"
     gap_icon: "6px"
     height: "52px"
-    border_radius: "12px"
+    border_radius: "rounded-full (9999px — pill shape)"
     min_width: "~186px"
 
 states:

--- a/docs/design-kb/components/card-entity.yaml
+++ b/docs/design-kb/components/card-entity.yaml
@@ -1,0 +1,132 @@
+# =============================================================
+# Component: Entity Card (Profile Header)
+# Source: NODO DS.md §10, §12
+# =============================================================
+
+purpose: >
+  The header component for entity detail views (Ciudadano, Comedor, Institución, etc.).
+  Provides identity information at a glance with an avatar, name, subtitle, and action icons.
+
+variants:
+  entity_header:
+    description: "Profile header with gradient avatar, name, subtitle, and action icons"
+
+  metric_card:
+    description: "KPI card showing a single metric with label, number, delta, and icon shape"
+    source: "NODO DS.md §11"
+
+  benefits_card:
+    description: "Financial summary showing direct/indirect transfers and monthly total"
+    source: "NODO DS.md §12"
+
+states:
+  default:
+    background: "bg-primary"
+    border: "border-base 1px"
+    border_radius: "rounded-xl (12px)"
+
+anatomy:
+  entity_header: |
+    ┌─────────────────────────────────────────────────────────────┐
+    │ [Avatar with gradient brand]   [Nombre]         [icons →]  │
+    │                                [Subtítulo]                  │
+    └─────────────────────────────────────────────────────────────┘
+
+  avatar:
+    shape: "square with rounded corners (border-radius 12px)"
+    background: "linear-gradient(45deg, #7928CA, #FF0080)"
+    icon: "Font Awesome — white, centered"
+    size: "~56px"
+
+  entity_name:
+    font: "Inter Semibold 18px"
+    color: "text-heading"
+
+  entity_subtitle:
+    font: "Inter Regular 13px"
+    color: "text-body-subtle"
+
+  action_icons:
+    position: "right-aligned"
+    gap: "16px between icons"
+    color: "text-body (#4b5563)"
+    hover_color: "text-fg-brand"
+    icon_size: "w-5 h-5 or w-6 h-6"
+
+  metric_card: |
+    ┌──────────────────────────────────┐
+    │ Label                            │  ← Inter Regular 13px, text-body-subtle
+    │ 250 +12                  [Icon]  │  ← Number: Inter Bold 28px, text-heading
+    └──────────────────────────────────┘
+
+  benefits_card: |
+    ┌──────────────────────────────────────────────┐
+    │ Transferencia directa                        │
+    │ [mini-card] [mini-card] [mini-card]          │
+    │ Transferencia indirecta                      │
+    │ [mini-card] [mini-card] [mini-card]          │
+    │ ┌──────────────────────────────────────────┐ │
+    │ │ Monto total Octubre 2025    $390.213     │ │  ← gradient brand
+    │ └──────────────────────────────────────────┘ │
+    └──────────────────────────────────────────────┘
+
+  benefits_mini_card:
+    border: "border-base 1px"
+    border_radius: "rounded-lg (8px)"
+    padding: "12px"
+    icon_color: "text-fg-brand"
+    icon_size: "fa-lg"
+    amount_font: "Inter Bold 16px"
+    amount_color: "text-heading"
+    label_font: "Inter Regular 12px"
+    label_color: "text-body-subtle"
+    disabled_variant:
+      background: "bg-disabled"
+      icon_and_text: "text-fg-disabled"
+
+  total_banner:
+    background: "linear-gradient(45deg, #FF0080, #7928CA)"
+    border_radius: "rounded-lg (8px)"
+    padding: "12px 16px"
+    label_font: "Inter Regular 13px, text-white"
+    amount_font: "Inter Bold 24px, text-white"
+
+responsive_rules:
+  - "Entity header always spans full width of content area"
+  - "Metric cards in grid layout — UNKNOWN exact columns"
+  - "Benefits mini-cards in 3-column row"
+
+accessibility_rules:
+  - "Avatar icon requires aria-label describing the entity type"
+  - "Metric delta must use +/- prefix, not just color"
+  - "Benefits amounts should be formatted consistently (currency format)"
+
+allowed_usage:
+  - "Top of entity detail views (Ciudadano, Comedor, Centro, Institución)"
+  - "Metric cards in entity detail dashboards"
+  - "Financial summary in citizen benefit views"
+
+forbidden_usage:
+  - "Entity header on list views (use table row instead)"
+  - "Changing gradient direction from 45°"
+  - "Total banner with non-brand colors"
+
+examples:
+  entity_header: |
+    <div class="entity-header bg-primary border border-base rounded-xl p-4 flex items-center gap-4">
+      <div class="avatar rounded-xl" style="background: linear-gradient(45deg, #7928CA, #FF0080)">
+        <UserIcon class="text-white w-8 h-8" />
+      </div>
+      <div>
+        <h2 class="font-semibold text-lg text-heading">José Gomes</h2>
+        <p class="text-sm text-body-subtle">24-31256.248-4</p>
+      </div>
+      <div class="ml-auto flex gap-4">
+        <PencilIcon class="w-5 h-5 text-body hover:text-fg-brand" />
+      </div>
+    </div>
+
+anti_examples:
+  - "Entity header without avatar/identity visual"
+  - "Total banner with a flat color instead of gradient"
+  - "Metric delta showing only color (no +/- prefix)"

--- a/docs/design-kb/components/data-table.yaml
+++ b/docs/design-kb/components/data-table.yaml
@@ -56,9 +56,9 @@ anatomy:
       position: "right-aligned in filter row"
 
   column_header:
-    font: "Inter Medium 13px"
-    color: "text-body (#4b5563)"
-    transform: "none (NOT uppercase — differs from stat card labels)"
+    font: "Inter SemiBold 12px (text-xs font-semibold)"
+    color: "text-body-subtle (#6b7280)"
+    transform: "uppercase"
     border_bottom: "border-base (#e5e7eb) 1px"
     background: "same as table (no different bg)"
     sortable:

--- a/docs/design-kb/components/data-table.yaml
+++ b/docs/design-kb/components/data-table.yaml
@@ -1,0 +1,159 @@
+# =============================================================
+# Component: Data Table
+# Source: CHACO_NODO_Design_Manual.md §12.4, §12.7, NODO DS.md §9
+# =============================================================
+
+purpose: >
+  The primary way to display lists of entity records.
+  Always includes search, filters, pagination, and a defined empty state.
+  Supports row-level actions and badge-based status columns.
+
+variants:
+  standard:
+    description: "Search toolbar + filter row + column headers + rows + pagination footer"
+
+states:
+  row_default:
+    background: "bg-primary (#ffffff)"
+    border_bottom: "border-base (#e5e7eb) 1px"
+    height: "~48px"
+
+  row_hover:
+    background: "bg-tertiary (#f3f4f6)"
+    transition: "150ms ease"
+
+  row_selected:
+    description: "UNKNOWN — not documented"
+
+anatomy:
+  toolbar:
+    search_input:
+      style: "Secondary (bg #F9FAFB, border #E5E7EB)"
+      icon: "MagnifyingGlassIcon leading"
+      placeholder: "Descriptive placeholder with min character hint"
+      width: "full-width or flexible"
+    primary_action_button:
+      style: "Tertiary (outlined brand)"
+      position: "right of search, or top-right of section"
+      example: "+ Nuevo legajo"
+    secondary_buttons:
+      style: "Secondary with chevron"
+      examples: ["▼ Filtrar", "Acciones ∨"]
+
+  filter_row:
+    pattern: "Chip/button filters in a horizontal row"
+    examples: ["Todos los riesgos ∨", "Todos los estados ∨", "🔔 Con alertas", "📅 Sin plan vigente"]
+    filter_chip_style:
+      background: "bg-primary (#ffffff)"
+      border: "border-base"
+      border_radius: "rounded-md (6px)"
+      font: "text-sm, font-medium"
+      active_state:
+        border: "border-brand"
+        text: "text-fg-brand"
+    export_button:
+      style: "Tertiary with download icon"
+      position: "right-aligned in filter row"
+
+  column_header:
+    font: "Inter Medium 13px"
+    color: "text-body (#4b5563)"
+    transform: "none (NOT uppercase — differs from stat card labels)"
+    border_bottom: "border-base (#e5e7eb) 1px"
+    background: "same as table (no different bg)"
+    sortable:
+      shows: "sort icon (fa-sort or equivalent) to the right of label"
+
+  row_cells:
+    font: "Inter Regular 14px"
+    color: "text-body or text-heading"
+    padding_v: "12–16px"
+    border_bottom: "border-base 1px"
+    no_alternating_bg: true
+
+  avatar_cell:
+    type: "Circle with citizen initials (e.g., 'CM')"
+    background: "bg-brand-medium (jacaranda soft)"
+    text: "text-white, font-semibold"
+
+  status_badge:
+    component: "badge"
+    mapping:
+      Completa: "badge-success"
+      En_progreso: "badge-warning"
+      Sin_exito: "badge-danger"
+      BAJO: "badge-success"
+      MEDIO: "badge-warning"
+      ALTO: "badge-danger"
+      Sin_Contacto: "badge-warning"
+      Seguimiento_Vencido: "badge-danger"
+
+  actions_column:
+    position: "always last column, fixed width"
+    view_action:
+      icon: "EyeIcon (w-6 h-6)"
+      color: "text-fg-brand"
+      background: "none (default)"
+      hover_background: "bg-secondary-soft"
+      label: "no text — icon only with aria-label"
+    actions_dropdown:
+      style: "Tertiary button + chevron"
+      label: "Acciones ∨"
+    delete_action:
+      style: "Danger filled — bg #c70036, text white, trash icon"
+      requires_confirmation: true
+      confirmation_library: "SweetAlert2"
+
+  pagination_footer:
+    info_text:
+      format: "Mostrando X-Y of Z"
+      font: "Inter Regular 13px"
+      color: "text-body-subtle"
+    prev_next_buttons:
+      style: "Tertiary (outlined brand), size SM"
+    page_indicator:
+      format: "1 de 4"
+      font: "Inter Medium 13px"
+
+  empty_state:
+    required: true
+    note: "Every table must define an empty state — not a blank table"
+    pattern: "Illustration + contextual message + optional CTA"
+
+responsive_rules:
+  - "Table scrolls horizontally on mobile (UNKNOWN — not fully documented)"
+  - "Actions column always visible"
+  - "Column widths not fixed except actions column"
+
+accessibility_rules:
+  - "Sort icons indicate sortable columns — must have accessible labels"
+  - "Action icon buttons require aria-label (icon-only)"
+  - "Delete action always gated by SweetAlert2 confirmation"
+  - "Table must have defined empty state — not a blank experience"
+  - "No row-level shadows"
+
+allowed_usage:
+  - "Any list of entities (citizens, organizations, programs)"
+  - "Historical records within an entity detail view"
+  - "Paginated data with search and filter controls"
+
+forbidden_usage:
+  - "Alternating row background colors (zebra striping)"
+  - "Row shadows or elevation"
+  - "Delete action without SweetAlert2 confirmation modal"
+  - "Table without a defined empty state"
+  - "Sortable column without a visual indicator"
+
+examples:
+  columns: "CIUDADANO · DNI · DISPOSITIVO · RESPONSABLE · RIESGO · ESTADO · ALERTAS · ACCIONES"
+  toolbar: |
+    <div class="table-toolbar flex gap-2 items-center">
+      <input class="bg-secondary-soft border-base" placeholder="Buscar por nombre..." />
+      <button class="btn-tertiary btn-sm">+ Nuevo legajo</button>
+    </div>
+
+anti_examples:
+  - "Table with no empty state defined — renders as blank space"
+  - "Delete button that immediately deletes without confirmation"
+  - "Sort column header without sort icon"
+  - "Alternating gray/white rows"

--- a/docs/design-kb/components/input.yaml
+++ b/docs/design-kb/components/input.yaml
@@ -66,14 +66,14 @@ states:
 
 anatomy:
   structure: |
-    Label *               ← Inter Medium 13px, text-heading. * in text-fg-brand if required
+    Label *               ← Inter Medium 13px, text-heading. * in text-fg-danger if required
     [leading-icon]  [input text / placeholder]   ← 40px height (base size)
     [helper text or error message]               ← Inter Regular 12px, text-body-subtle / text-fg-danger
 
   label:
     font: "Inter Medium 13px"
     color: "text-heading"
-    required_indicator: "* in text-fg-brand (#ff0080)"
+    required_indicator: "* in text-fg-danger (#c70036)"
     position: "Always above the field — never inside (placeholder only for hint text)"
 
   icon_prefix:

--- a/docs/design-kb/components/input.yaml
+++ b/docs/design-kb/components/input.yaml
@@ -1,0 +1,135 @@
+# =============================================================
+# Component: Input / Form Field
+# Source: CHACO_NODO_Design_Manual.md §12.1, NODO DS.md §13
+# =============================================================
+
+purpose: >
+  Text entry field for forms. Always paired with a visible label above.
+  Never uses placeholder as label replacement.
+  States communicate validity and interactivity clearly.
+
+variants:
+  text:
+    description: "Standard text input"
+    height: "40px"
+
+  password:
+    description: "Password input with lock icon prefix and optional visibility toggle"
+    height: "40px"
+
+  email:
+    description: "Email input with envelope icon prefix"
+    height: "40px"
+
+  select:
+    description: "Dropdown select — same visual appearance as text input"
+    chevron: "∨ aligned to the right"
+    placeholder: "Seleccionar..."
+    selected_text_color: "text-heading"
+
+states:
+  default:
+    border: "border-base (#e5e7eb) 1px"
+    border_radius: "rounded-lg (8px)"
+    background: "bg-primary (#ffffff)"
+    text: "text-heading (#111827 / #101828)"
+    placeholder_color: "text-body-subtle"
+
+  focus:
+    border: "border-brand (#5059bc) 1.5px"
+    border_radius: "rounded-lg (8px)"
+    background: "bg-primary (#ffffff)"
+    text: "text-heading"
+    note: "Focus outline must always be visible — never remove"
+
+  error:
+    border: "border-danger (#c70036) 1px"
+    border_radius: "rounded-lg (8px)"
+    background: "bg-danger-soft (#fef0f2)"
+    text: "text-heading"
+    helper_text_color: "text-fg-danger"
+    helper_icon: "fa-circle-exclamation or ExclamationCircleIcon"
+
+  disabled:
+    border: "border-base (#e5e7eb) 1px"
+    border_radius: "rounded-lg (8px)"
+    background: "bg-disabled (#f3f4f6)"
+    text: "text-fg-disabled (#9ca3af)"
+    cursor: "not-allowed"
+
+  read_only_prefilled:
+    description: "RENAPER pre-filled data — visually distinct from editable fields"
+    border: "border-base"
+    background: "bg-white"
+    helper_text: "Informational note explaining why field is locked"
+    note: "Must be visually distinguishable from editable fields"
+
+anatomy:
+  structure: |
+    Label *               ← Inter Medium 13px, text-heading. * in text-fg-brand if required
+    [leading-icon]  [input text / placeholder]   ← 40px height (base size)
+    [helper text or error message]               ← Inter Regular 12px, text-body-subtle / text-fg-danger
+
+  label:
+    font: "Inter Medium 13px"
+    color: "text-heading"
+    required_indicator: "* in text-fg-brand (#ff0080)"
+    position: "Always above the field — never inside (placeholder only for hint text)"
+
+  icon_prefix:
+    size: "w-4 h-4 (16px) or w-5 h-5 (20px)"
+    color: "text-body (#4b5563)"
+    position: "Leading (left side of input)"
+
+  helper_text:
+    font: "Inter Regular 12px"
+    color_default: "text-body-subtle"
+    color_error: "text-fg-danger"
+    position: "Below the field"
+
+responsive_rules:
+  - "Inputs stretch to container width by default"
+  - "Multiple inputs on same row (inline): DNI + Sex example — equal width columns"
+
+accessibility_rules:
+  - "Label always above field — never use placeholder as the only label"
+  - "Required fields marked with * in danger color before user interaction"
+  - "Error message appears below field with icon, not only through color"
+  - "Focus state must be visible (1.5px brand-colored border)"
+  - "Disabled state must be visually distinct from editable state"
+
+allowed_usage:
+  - "Text, email, password inputs in all forms"
+  - "Select/dropdown fields (same visual treatment)"
+  - "Search bar (with magnifying glass icon prefix)"
+  - "Read-only RENAPER data with explicit helper text"
+
+forbidden_usage:
+  - "Using placeholder as field label"
+  - "Removing the focus ring from input fields"
+  - "Mixing disabled and editable fields without visual distinction"
+  - "Input without associated label element"
+  - "Using opacity: 0.5 for disabled state"
+  - "Applying border-radius: rounded-full (pill) to text inputs"
+
+examples:
+  default: |
+    <label>Email institucional <span class="text-fg-brand">*</span></label>
+    <div class="input-wrapper">
+      <EnvelopeIcon class="w-5 h-5 text-body" />
+      <input type="email" placeholder="usuario@chaco.gov.ar" />
+    </div>
+
+  error: |
+    <label>Email institucional</label>
+    <input class="border-danger bg-danger-soft" type="email" value="invalid" />
+    <p class="text-fg-danger text-xs">El email no es válido</p>
+
+  disabled: |
+    <label>DNI</label>
+    <input class="bg-disabled text-fg-disabled" disabled value="32.456.789" />
+
+anti_examples:
+  - "Input with no label, only placeholder text as the label"
+  - "Error state shown only by changing text color with no border change"
+  - "Disabled input with opacity: 0.5 instead of bg-disabled + text-fg-disabled"

--- a/docs/design-kb/components/modal.yaml
+++ b/docs/design-kb/components/modal.yaml
@@ -35,31 +35,61 @@ backdrop:
 
 modal_card:
   background: "bg-white (#ffffff)"
-  border_radius: "rounded-xl (12px)"
+  border_radius: "rounded-2xl (16px)"
   box_shadow: "var(--sombra-xl)"
   padding: "24px"
   max_width:
-    sm: "~400px (confirmation dialogs)"
+    sm: "~380px (confirmation dialogs — compact)"
     md: "~560px (form modals)"
     lg: "~720px (information modals with content)"
   position: "Center of viewport (horizontally and vertically)"
 
-anatomy: |
-  [Backdrop rgba(209,213,219,0.7)]
-  ┌─────────────────────────────────┐
-  │ Modal title              [× ]   │  ← text-heading font-semibold + close button
-  ├─────────────────────────────────┤
-  │                                 │
-  │  Body content / form / message  │
-  │                                 │
-  ├─────────────────────────────────┤
-  │        [Cancel]  [Confirm]      │  ← action row right-aligned
-  └─────────────────────────────────┘
+anatomy:
+  confirmation_compact: |
+    [Backdrop rgba(209,213,219,0.7)]
+    ┌──────────────────────────────────┐
+    │                             [×]  │  ← XMarkIcon, text-body-subtle, top-right
+    │            ┌─────┐               │
+    │            │  !  │               │  ← neutral circle ~48px, bg-tertiary, text-body-subtle
+    │            └─────┘               │
+    │  ¿Estás seguro de que querés     │
+    │     eliminar este elemento?      │  ← Inter Regular 15px, text-heading, centered
+    │                                  │
+    │  [No, cancel]       [Confirm]    │  ← see action_buttons spec below
+    └──────────────────────────────────┘
 
-  - Title: Inter SemiBold 18px, text-heading
-  - Body: Inter Regular 14px, text-body
-  - Close (×): top-right, icon-only with aria-label="Cerrar"
-  - Action row: right-aligned, Tertiary (cancel) + Brand or Danger (primary action)
+  form_modal: |
+    ┌──────────────────────────────────┐
+    │ Título del modal            [×]  │  ← Inter SemiBold 18px, text-heading
+    ├──────────────────────────────────┤
+    │  form fields here                │  ← Inter Regular 14px, text-body
+    ├──────────────────────────────────┤
+    │              [Cancelar] [Guardar]│  ← right-aligned
+    └──────────────────────────────────┘
+
+confirmation_icon:
+  shape: "circle"
+  size: "~48px diameter"
+  background: "bg-tertiary (#f3f4f6)"
+  icon_color: "text-body-subtle (#6b7280)"
+  icon: "ExclamationCircleIcon"
+  note: "NEUTRAL GRAY — not danger red. The message communicates urgency, not the icon color."
+
+action_buttons:
+  important_note: >
+    The CONFIRM button always uses the Brand gradient — even for destructive confirmations.
+    The danger is communicated through the warning icon and the message text, NOT through
+    a red button. This is the system-confirmed pattern from design reference.
+  confirm:
+    style: "Brand gradient (linear-gradient(45deg, #5059BC, #F98DFF))"
+    text_color: "text-white"
+    shape: "rounded-full (pill)"
+    label_examples: ["Confirm", "Confirmar", "Eliminar", "Guardar"]
+  cancel:
+    style: "Secondary (bg-white, border-base)"
+    text_color: "text-body"
+    shape: "rounded-full (pill)"
+    label_examples: ["No, cancel", "Cancelar", "Volver"]
 
 positioning_css: |
   position: fixed;
@@ -78,9 +108,10 @@ destructive_confirmation_pattern:
   library: "SweetAlert2 (mandatory per Design Constitution Article VIII)"
   title: "¿Estás seguro?"
   message: "Descriptive consequence ('Este ciudadano será eliminado permanentemente.')"
-  confirm_button: "Danger style (bg-danger #c70036, text-white)"
+  confirm_button: "Brand gradient style — NOT danger red (see action_buttons spec)"
   cancel_button: "Secondary style"
-  icon: "ExclamationTriangleIcon or SweetAlert2 'warning' icon"
+  icon: "Neutral gray circle with ExclamationCircleIcon — NOT SweetAlert2 default red"
+  sweetalert_customization: "Override SweetAlert2 defaults to match design: customClass for buttons + icon"
   note: "window.confirm() is FORBIDDEN — SweetAlert2 only"
 
 accessibility_rules:

--- a/docs/design-kb/components/modal.yaml
+++ b/docs/design-kb/components/modal.yaml
@@ -1,0 +1,138 @@
+# =============================================================
+# Component: Modal / Dialog
+# Source: Designer confirmation (2026-06-08)
+# Note: Partially inferred from system patterns + direct designer spec
+# =============================================================
+
+purpose: >
+  Overlays that interrupt the current flow to request user input or confirmation.
+  Used for destructive action confirmation, form-in-modal workflows, and
+  complex selections that do not warrant a new page.
+
+scope:
+  applies_to: "Backoffice (authenticated views) only"
+  portal: "Not used in citizen portal"
+
+variants:
+  confirmation:
+    description: "SweetAlert2-style — action confirmation for destructive operations"
+    trigger: "Always required before delete, archive, or irreversible actions"
+    note: "SweetAlert2 is the mandated library for this variant (Article VIII of Design Constitution)"
+
+  form_modal:
+    description: "Small form inside an overlay — for quick data entry without navigation"
+    note: "Prefer a dedicated page for forms with more than 4 fields"
+
+  information:
+    description: "Read-only content display — details panel, preview, help text"
+
+backdrop:
+  color: "#d1d5db"
+  token: "bg-gray (gray-300)"
+  opacity: "70%"
+  css: "rgba(209, 213, 219, 0.7)"
+  behavior: "clicking outside the modal closes it (unless confirmation modal)"
+
+modal_card:
+  background: "bg-white (#ffffff)"
+  border_radius: "rounded-xl (12px)"
+  box_shadow: "var(--sombra-xl)"
+  padding: "24px"
+  max_width:
+    sm: "~400px (confirmation dialogs)"
+    md: "~560px (form modals)"
+    lg: "~720px (information modals with content)"
+  position: "Center of viewport (horizontally and vertically)"
+
+anatomy: |
+  [Backdrop rgba(209,213,219,0.7)]
+  ┌─────────────────────────────────┐
+  │ Modal title              [× ]   │  ← text-heading font-semibold + close button
+  ├─────────────────────────────────┤
+  │                                 │
+  │  Body content / form / message  │
+  │                                 │
+  ├─────────────────────────────────┤
+  │        [Cancel]  [Confirm]      │  ← action row right-aligned
+  └─────────────────────────────────┘
+
+  - Title: Inter SemiBold 18px, text-heading
+  - Body: Inter Regular 14px, text-body
+  - Close (×): top-right, icon-only with aria-label="Cerrar"
+  - Action row: right-aligned, Tertiary (cancel) + Brand or Danger (primary action)
+
+positioning_css: |
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 100;
+
+z_index: "100 (modal layer)"
+
+animation:
+  in: "fade-in + scale from 95% to 100% (150ms ease-out)"
+  out: "fade-out + scale to 95% (150ms ease-in)"
+
+destructive_confirmation_pattern:
+  library: "SweetAlert2 (mandatory per Design Constitution Article VIII)"
+  title: "¿Estás seguro?"
+  message: "Descriptive consequence ('Este ciudadano será eliminado permanentemente.')"
+  confirm_button: "Danger style (bg-danger #c70036, text-white)"
+  cancel_button: "Secondary style"
+  icon: "ExclamationTriangleIcon or SweetAlert2 'warning' icon"
+  note: "window.confirm() is FORBIDDEN — SweetAlert2 only"
+
+accessibility_rules:
+  - "role='dialog' with aria-modal='true'"
+  - "aria-labelledby pointing to the modal title"
+  - "Focus is trapped inside the modal while open"
+  - "Escape key closes the modal (except confirmation dialogs — must click explicitly)"
+  - "Focus returns to the triggering element when modal closes"
+  - "Close button has aria-label='Cerrar'"
+
+allowed_usage:
+  - "Destructive action confirmation (delete, archive, revoke)"
+  - "Quick form for adding a simple item without leaving the page"
+  - "Media or document preview"
+  - "Alert/information that must be acknowledged before continuing"
+
+forbidden_usage:
+  - "Forms with more than 4–5 fields — use a dedicated page"
+  - "Nested modals (modal inside modal)"
+  - "window.confirm() — always use SweetAlert2 for destructive confirmations"
+  - "Modal without a visible title"
+  - "Modal without a close mechanism (× button or Escape key)"
+  - "Modal in the citizen portal"
+
+examples:
+  confirmation_trigger: |
+    <!-- Trigger -->
+    <button class="btn-danger btn-sm"
+            onclick="confirmDelete({{ ciudadano.id }})">
+      Eliminar
+    </button>
+
+    <!-- SweetAlert2 handler -->
+    <script>
+    function confirmDelete(id) {
+      Swal.fire({
+        title: '¿Estás seguro?',
+        text: 'Este ciudadano será eliminado permanentemente.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Eliminar',
+        cancelButtonText: 'Cancelar',
+      }).then((result) => {
+        if (result.isConfirmed) {
+          // execute delete
+        }
+      });
+    }
+    </script>
+
+anti_examples:
+  - "window.confirm('¿Eliminar?') — never use native browser confirm"
+  - "Delete button that executes immediately without confirmation"
+  - "Modal with backdrop opacity 100% — must be 70%"
+  - "Modal positioned top of page instead of centered"

--- a/docs/design-kb/components/select.yaml
+++ b/docs/design-kb/components/select.yaml
@@ -54,31 +54,57 @@ trigger:
 
 # -------------------------------------------------------------
 # DROPDOWN PANEL
-# Status: DESIGN PENDING from designer
+# Status: SPECIFIED — confirmed by designer design reference (2026-06-08)
 # -------------------------------------------------------------
 panel:
-  status: "PENDING — designer to provide Figma spec"
-  known_behavior:
-    position: "Below the trigger, left-aligned, full-width of trigger"
-    z_index: "10 (dropdown layer)"
-    animation: "fade-in (150ms ease-out)"
-  provisional_spec:
+  status: "Specified"
+  position: "Below the trigger, left-aligned"
+  width: "Min-width matches trigger; can be wider for longer labels"
+  z_index: "10 (dropdown layer)"
+  animation: "fade-in + slight scale from 97% to 100% (150ms ease-out)"
+
+  appearance:
     background: "bg-white (#ffffff)"
-    border: "border-base (#e5e7eb) 1px"
-    border_radius: "rounded-lg (8px)"
-    box_shadow: "var(--sombra-md)"
-    max_height: "~240px (scrollable if more options)"
+    border: "none (shadow provides container definition)"
+    border_radius: "rounded-2xl (16px)"
+    box_shadow: "var(--sombra-lg)"
+    padding: "8px all sides"
+    max_height: "~320px (scrollable if more options)"
+
   option_item:
-    height: "~40px"
-    padding_h: "12px"
-    font: "Inter Regular 14px"
-    text_color: "text-body"
-    hover:
-      background: "bg-tertiary (#f3f4f6)"
-    selected:
-      background: "bg-brand-soft"
-      text_color: "text-fg-brand (#5059bc)"
-      icon: "CheckIcon right-aligned, text-fg-brand"
+    height: "~50px"
+    padding_h: "16px"
+    padding_v: "12px"
+    layout: "flex items-center gap-3 (icon + label)"
+    icon:
+      size: "w-5 h-5 (20px)"
+      color: "text-body-subtle (#6b7280) — default"
+      color_destructive: "text-fg-danger (#c70036)"
+    font: "Inter Medium 15px"
+    text_color: "text-heading (#111827)"
+    border_radius_item: "rounded-lg (8px) — applied on hover/active within the panel"
+
+    states:
+      default:
+        background: "transparent"
+      hover:
+        background: "bg-tertiary (#f3f4f6)"
+        border_radius: "rounded-lg (8px)"
+      selected:
+        background: "bg-brand-soft (#fee9ff)"
+        text_color: "text-fg-brand (#5059bc)"
+        icon_color: "text-fg-brand"
+        indicator: "no CheckIcon visible in design — background is the selected indicator"
+
+    destructive_item:
+      text_color: "text-fg-danger (#c70036)"
+      icon_color: "text-fg-danger (#c70036)"
+      note: "Used for logout, delete account, or irreversible actions in the menu"
+      example: "→ Sign out"
+
+  divider:
+    usage: "NOT used between regular items — no dividers"
+    exception: "A 1px border-base divider may be used ONLY to separate the destructive item group"
 
 # -------------------------------------------------------------
 # LABEL (same rules as input component)
@@ -94,30 +120,45 @@ label:
 # -------------------------------------------------------------
 contexts:
   form_select:
-    description: "Full-width within form column, 40px height"
+    description: "Full-width within form column, 40px height — input-style trigger"
+    trigger_style: "Input-style (bg-secondary-soft, border-base) — see trigger spec above"
     example: "Sexo (M / F / X), Estado civil, Programa"
+
+  action_menu:
+    description: "Navigation / action dropdown triggered by a Brand gradient button"
+    trigger_style: "Brand gradient pill button (same as btn-brand) + ChevronDownIcon"
+    trigger_border: "2px solid border-brand (#5059bc) — stroke visible around gradient"
+    trigger_font: "Inter Medium 14px, text-white"
+    example: "User account menu, 'Acciones ∨' dropdown in tables"
+    note: "Uses the same panel design as form_select"
 
   filter_chip:
     description: "Compact variant used in table filter rows"
-    background: "bg-primary (#ffffff)"
-    border: "border-base"
-    border_radius: "rounded-md (6px)"
-    font: "text-sm font-medium"
+    trigger_style: "bg-primary, border-base, rounded-md (6px), text-sm font-medium"
     active_state:
       border: "border-brand"
       text: "text-fg-brand"
     example: "Todos los riesgos ∨, Todos los estados ∨"
 
 anatomy: |
+  FORM SELECT:
   [Label *]
   ┌────────────────────────────────┐
-  │ Seleccioná una opción     [∨]  │  ← trigger
+  │ Seleccioná una opción     [∨]  │  ← input-style trigger
   └────────────────────────────────┘
-  ┌────────────────────────────────┐  ← panel (when open)
-  │ Opción 1                       │
-  │ Opción 2                   [✓] │  ← selected
-  │ Opción 3                       │
-  └────────────────────────────────┘
+
+  ACTION MENU (open):
+  ┌──────────────────────┐
+  │ Dropdown         [∨] │  ← Brand gradient pill trigger (border-brand stroke)
+  └──────────────────────┘
+  ╔══════════════════════════════╗  ← panel (rounded-2xl, sombra-lg)
+  ║  [🧑] Account               ║
+  ║  [⚙] Settings               ║
+  ║  [🔒] Privacy               ║
+  ║  [🔔] Notifications   ←hover ║  (bg-tertiary rounded-lg on hover/active)
+  ║  [?] Help center             ║
+  ║  [→] Sign out          (red) ║  ← destructive: text-fg-danger + icon-fg-danger
+  ╚══════════════════════════════╝
 
 accessibility_rules:
   - "Use role='combobox' on trigger, role='listbox' on panel, role='option' on each item"

--- a/docs/design-kb/components/select.yaml
+++ b/docs/design-kb/components/select.yaml
@@ -1,0 +1,142 @@
+# =============================================================
+# Component: Select / Dropdown
+# Source: CHACO_NODO_Design_Manual.md §12.1 (inferred), Designer (2026-06-08)
+# Status: PARTIALLY DOCUMENTED — custom panel design pending from designer
+# =============================================================
+
+purpose: >
+  Form control for selecting one value from a predefined list.
+  Appears in forms (sex, status, program type) and table filter rows.
+  Uses custom styling to match the NODO design language, not the browser default.
+
+status_note: >
+  The TRIGGER element (the visible field + chevron) is fully specified below.
+  The DROPDOWN PANEL design (the list that opens) was requested from the designer
+  on 2026-06-08. Update this file when that design is received.
+
+# -------------------------------------------------------------
+# TRIGGER (the visible input-like element)
+# -------------------------------------------------------------
+trigger:
+  appearance:
+    background: "bg-secondary-soft (#f9fafb)"
+    border: "border-base (#e5e7eb) 1px"
+    border_radius: "rounded-lg (8px)"
+    height: "40px (same as input base size)"
+    padding_h: "12px"
+    padding_v: "10px"
+    font: "Inter Regular 14px"
+    text_color: "text-body (#4b5563)"
+    placeholder_color: "text-fg-disabled (#9ca3af)"
+
+  chevron:
+    icon: "ChevronDownIcon (Heroicons)"
+    position: "right side, 12px from edge"
+    color: "text-fg-disabled"
+    rotation_when_open: "180° (transition 150ms ease)"
+
+  states:
+    default:
+      border: "border-base (#e5e7eb) 1px"
+      background: "bg-secondary-soft (#f9fafb)"
+    focus:
+      border: "border-brand (#5059bc) 1.5px"
+      background: "bg-secondary-soft"
+      outline: "none (ring via box-shadow)"
+    error:
+      border: "border-danger (#c70036) 1px"
+      background: "bg-danger-soft (#fef0f2)"
+    disabled:
+      background: "bg-disabled (#f3f4f6)"
+      text_color: "text-fg-disabled (#9ca3af)"
+      cursor: "not-allowed"
+      chevron_color: "text-fg-disabled"
+
+# -------------------------------------------------------------
+# DROPDOWN PANEL
+# Status: DESIGN PENDING from designer
+# -------------------------------------------------------------
+panel:
+  status: "PENDING — designer to provide Figma spec"
+  known_behavior:
+    position: "Below the trigger, left-aligned, full-width of trigger"
+    z_index: "10 (dropdown layer)"
+    animation: "fade-in (150ms ease-out)"
+  provisional_spec:
+    background: "bg-white (#ffffff)"
+    border: "border-base (#e5e7eb) 1px"
+    border_radius: "rounded-lg (8px)"
+    box_shadow: "var(--sombra-md)"
+    max_height: "~240px (scrollable if more options)"
+  option_item:
+    height: "~40px"
+    padding_h: "12px"
+    font: "Inter Regular 14px"
+    text_color: "text-body"
+    hover:
+      background: "bg-tertiary (#f3f4f6)"
+    selected:
+      background: "bg-brand-soft"
+      text_color: "text-fg-brand (#5059bc)"
+      icon: "CheckIcon right-aligned, text-fg-brand"
+
+# -------------------------------------------------------------
+# LABEL (same rules as input component)
+# -------------------------------------------------------------
+label:
+  position: "Always above the trigger"
+  font: "Inter Medium 14px"
+  color: "text-heading"
+  required_indicator: "* in text-fg-danger (#c70036)"
+
+# -------------------------------------------------------------
+# CONTEXT VARIANTS
+# -------------------------------------------------------------
+contexts:
+  form_select:
+    description: "Full-width within form column, 40px height"
+    example: "Sexo (M / F / X), Estado civil, Programa"
+
+  filter_chip:
+    description: "Compact variant used in table filter rows"
+    background: "bg-primary (#ffffff)"
+    border: "border-base"
+    border_radius: "rounded-md (6px)"
+    font: "text-sm font-medium"
+    active_state:
+      border: "border-brand"
+      text: "text-fg-brand"
+    example: "Todos los riesgos ∨, Todos los estados ∨"
+
+anatomy: |
+  [Label *]
+  ┌────────────────────────────────┐
+  │ Seleccioná una opción     [∨]  │  ← trigger
+  └────────────────────────────────┘
+  ┌────────────────────────────────┐  ← panel (when open)
+  │ Opción 1                       │
+  │ Opción 2                   [✓] │  ← selected
+  │ Opción 3                       │
+  └────────────────────────────────┘
+
+accessibility_rules:
+  - "Use role='combobox' on trigger, role='listbox' on panel, role='option' on each item"
+  - "aria-expanded reflects open/closed state on trigger"
+  - "aria-selected on the currently selected option"
+  - "Keyboard: Arrow keys navigate options, Enter selects, Escape closes"
+  - "Label must be associated via for/id or aria-labelledby"
+
+allowed_usage:
+  - "Form fields with a predefined list of options (sex, program, risk level)"
+  - "Table filter chips with limited value sets"
+  - "Any list with fewer than ~30 options (more than 30 → consider searchable select)"
+
+forbidden_usage:
+  - "Native browser <select> element with default styling — always use custom component"
+  - "Select for binary choices — use radio buttons or a toggle for Yes/No"
+  - "Opening the panel without proper keyboard support"
+
+anti_examples:
+  - "Unstyled browser select element with OS-default dropdown"
+  - "Select that uses the Brand gradient background on trigger"
+  - "Dropdown panel without hover state on options"

--- a/docs/design-kb/components/sidebar.yaml
+++ b/docs/design-kb/components/sidebar.yaml
@@ -10,7 +10,7 @@ purpose: >
 
 variants:
   expanded:
-    width: "~200–300px"
+    width: "288px (Tailwind w-72 — 72 × 4px)"
     shows: "Logo + nav items with labels + footer"
 
   collapsed:
@@ -75,7 +75,7 @@ anatomy:
     └──────────────────────────────────┘
 
   logo_badge:
-    background: "linear-gradient(45deg, #7928CA, #FF0080) or linear-gradient(45deg, #5059BC, #F26DF9)"
+    background: "linear-gradient(45deg, #5059BC, #F98DFF)"
     border_radius: "12px"
     padding: "16px"
     icon_color: "text-white"

--- a/docs/design-kb/components/sidebar.yaml
+++ b/docs/design-kb/components/sidebar.yaml
@@ -1,0 +1,130 @@
+# =============================================================
+# Component: Sidebar Navigation
+# Source: CHACO_NODO_Design_Manual.md §11, NODO DS.md §8
+# =============================================================
+
+purpose: >
+  The primary navigation mechanism for the authenticated backoffice.
+  Fixed on the left side of the screen. Provides hierarchical navigation
+  with expandable groups and a clear active state indicator.
+
+variants:
+  expanded:
+    width: "~200–300px"
+    shows: "Logo + nav items with labels + footer"
+
+  collapsed:
+    width: "UNKNOWN"
+    shows: "UNKNOWN — behavior not fully documented"
+    trigger: "Minimizar button in sidebar footer"
+
+states:
+  nav_item_default:
+    background: "none"
+    text_color: "text-body (#4b5563)"
+    icon_color: "text-body (#4b5563)"
+
+  nav_item_hover:
+    background: "bg-tertiary (#f3f4f6)"
+    text_color: "text-body"
+    transition: "150ms ease"
+
+  nav_item_active:
+    shape: "pill (rounded-full or rounded-lg: 8px)"
+    background: "bg-brand (#5059bc)"
+    text_color: "text-white (#ffffff)"
+    icon_color: "text-white"
+    note: "Only ONE active item at any time including subitems"
+
+  subitem_default:
+    indent: "16px additional from parent"
+    no_icon: true
+    text_color: "text-body"
+
+  subitem_active:
+    background: "bg-tertiary (#f3f4f6)"
+    text_color: "text-fg-brand (#5059bc)"
+    shape: "pill/rounded"
+
+  group_expanded:
+    chevron: "rotated 180° (∧ up)"
+    subitems: "visible, indented"
+
+  group_collapsed:
+    chevron: "default (∨ down)"
+    subitems: "hidden"
+
+anatomy:
+  structure: |
+    ┌──────────────────────────────────┐
+    │ [Logo Badge]                     │  ← gradient brand 45°, border-radius 12px, padding 16px
+    │                                  │
+    │ [Avatar] User Name               │  ← User card: name + role below
+    │          Rol / Sin grupo         │
+    ├──────────────────────────────────┤
+    │ 🏠 Inicio                        │  ← nav item simple
+    │ 📊 Dashboard          ∨          │  ← collapsible group
+    │ ● Legajos             ∧          │  ← active group (expanded)
+    │    ○ Todos los...                │  ← subitem
+    │    ● [Ciudadano]                 │  ← active subitem
+    │ 📋 Programas          ∨          │
+    │ 💬 Conversaciones                │
+    │ ⚙️  Configuración      ∨          │
+    ├──────────────────────────────────┤
+    │ ‹ Minimizar                      │  ← footer
+    └──────────────────────────────────┘
+
+  logo_badge:
+    background: "linear-gradient(45deg, #7928CA, #FF0080) or linear-gradient(45deg, #5059BC, #F26DF9)"
+    border_radius: "12px"
+    padding: "16px"
+    icon_color: "text-white"
+
+  user_card:
+    position: "top of nav, below logo"
+    shows: "circular avatar + user name (font-medium) + role below (text-body-subtle)"
+
+  notification_badge:
+    example: "Mensajes [4]"
+    background: "#FF0080 or bg-brand"
+    text: "text-white"
+    shape: "circular"
+    font: "Inter Medium 12px"
+
+  footer:
+    content: "‹ Minimizar (collapse trigger)"
+    position: "bottom of sidebar"
+
+responsive_rules:
+  - "Fixed width on desktop — does not change with content"
+  - "Text truncates with ellipsis when too long — never overflows"
+  - "Mobile behavior: UNKNOWN (not documented)"
+
+accessibility_rules:
+  - "Active item must be visually clear without relying only on color (pill shape + brand color)"
+  - "Expandable groups use aria-expanded attribute"
+  - "Logo navigates to home — must have aria-label"
+  - "Sidebar navigation uses role='navigation' and aria-label"
+
+allowed_usage:
+  - "Primary navigation in all authenticated backoffice screens"
+  - "Single-level items for simple navigation destinations"
+  - "Grouped items with chevron for sections with sub-navigation"
+  - "Notification badges on items that have pending counts"
+
+forbidden_usage:
+  - "Hiding the sidebar entirely on authenticated desktop screens"
+  - "Multiple simultaneously active nav items"
+  - "Using the sidebar in portal/citizen-facing templates"
+  - "Text long enough to overflow without ellipsis"
+
+examples:
+  nav_item_active: '<li class="nav-item bg-brand rounded-lg"><HomeIcon class="text-white" /> Inicio</li>'
+  nav_item_default: '<li class="nav-item hover:bg-tertiary"><ChartBarIcon class="text-body" /> Dashboard</li>'
+  collapsible_group: '<li class="nav-group"><FolderIcon /> Legajos <ChevronDownIcon class="transition-transform" /></li>'
+
+anti_examples:
+  - "Showing all subitems always visible without a collapsible group"
+  - "Using underline or bold as the only active indicator"
+  - "Two nav items with the active pill simultaneously"
+  - "Sidebar that disappears on desktop viewport"

--- a/docs/design-kb/components/sidebar.yaml
+++ b/docs/design-kb/components/sidebar.yaml
@@ -30,7 +30,7 @@ states:
     transition: "150ms ease"
 
   nav_item_active:
-    shape: "pill (rounded-full or rounded-lg: 8px)"
+    shape: "pill (rounded-full — 9999px)"
     background: "bg-brand (#5059bc)"
     text_color: "text-white (#ffffff)"
     icon_color: "text-white"

--- a/docs/design-kb/components/stat-card.yaml
+++ b/docs/design-kb/components/stat-card.yaml
@@ -1,0 +1,121 @@
+# =============================================================
+# Component: Stat Card (Metric Card)
+# Source: CHACO_NODO_Design_Manual.md §12.3, §11, NODO DS.md §11
+# =============================================================
+
+purpose: >
+  Displays a single key performance indicator (KPI) or metric.
+  Used in dashboard and list-view headers to provide quantitative
+  context before the user interacts with the detail data below.
+
+variants:
+  standard:
+    description: "Icon top-left + large number + uppercase label"
+    layout: "vertical stack"
+
+  with_alert_dot:
+    description: "Adds a red alert dot positioned top-right of the icon"
+    when_to_use: "When the metric category has active critical alerts"
+
+  metric_with_delta:
+    description: "Number + delta change (e.g., +12) + icon shape top-right"
+    source: "NODO DS.md §11 — Tarjeta de métrica"
+    layout: "label top-left + number + delta + icon shape right"
+
+states:
+  default:
+    background: "bg-primary (#ffffff)"
+    border: "border-base (#e5e7eb) 1px"
+    border_radius: "rounded-xl (12px)"
+    box_shadow: "var(--sombra-sm)"
+
+  hover:
+    box_shadow: "var(--sombra-md)"
+    transition: "300ms ease-in-out"
+
+  disabled_variant:
+    background: "bg-disabled (#f3f4f6)"
+    icon_color: "text-fg-disabled (#9ca3af)"
+    text: "text-fg-disabled"
+    delta: "text-fg-disabled"
+
+anatomy:
+  standard: |
+    ┌────────────────────────┐
+    │ [Icon]          [●]    │  ← Icon in text-fg-brand, optional alert dot in bg-danger
+    │ 0                      │  ← Large number: text-3xl/4xl, font-bold, text-heading
+    │ ETIQUETA               │  ← Label: text-xs, font-medium, uppercase, text-body-subtle
+    └────────────────────────┘
+
+  metric_with_delta: |
+    ┌──────────────────────────────────┐
+    │ Label                            │  ← Inter Regular 13px, text-body-subtle
+    │ 250 +12                  [Icon]  │  ← Number: Inter Bold 28px, text-heading
+    │                                  │    Delta: Inter Medium 12px, color by sign
+    └──────────────────────────────────┘
+
+  icon_shape:
+    type: "Square with rounded corners"
+    background: "linear-gradient(45deg, #7928CA, #FF0080) — brand gradient"
+    border_radius: "~10–12px"
+    size: "~40px"
+    icon_color: "text-white"
+    icon_library: "Font Awesome fa-lg or Heroicons w-6 h-6"
+
+  alert_dot:
+    shape: "circle"
+    background: "bg-danger (#c70036)"
+    size: "~8–10px"
+    position: "top-right of the icon area"
+
+  metric_number:
+    font: "Inter Bold (font-bold)"
+    size: "text-3xl (30px) or text-4xl (36px)"
+    color: "text-heading (#111827)"
+
+  stat_label:
+    font: "Inter Medium (font-medium)"
+    size: "text-xs (12px)"
+    transform: "uppercase"
+    color: "text-body-subtle"
+
+  delta:
+    font: "Inter Medium 12px"
+    positive: "text-fg-success (#007a55)"
+    negative: "text-fg-danger (#c70036)"
+
+responsive_rules:
+  - "Dashboard home: 4 stat cards in a horizontal grid"
+  - "Ciudadanos list: 6 stat cards in a horizontal grid"
+  - "Mobile behavior: UNKNOWN"
+
+accessibility_rules:
+  - "Metric number must have text alternative for screen readers"
+  - "Alert dot must not be the only way to communicate alerts — icon or label also communicates it"
+  - "Color of delta (positive/negative) must not be sole communicator — use + or - prefix"
+
+allowed_usage:
+  - "Dashboard KPI display (top of home screen)"
+  - "List view summary metrics (above data table)"
+  - "Entity detail view quick metrics (Asistentes, Prestaciones, etc.)"
+
+forbidden_usage:
+  - "Multiple stat cards used for navigation (they are display-only)"
+  - "Stat cards without a number — they must always show a quantitative value"
+  - "Icon without a label to explain the metric"
+
+examples:
+  standard: |
+    <div class="stat-card bg-primary border border-base rounded-xl p-5">
+      <div class="flex items-center justify-between">
+        <UserGroupIcon class="w-6 h-6 text-fg-brand" />
+        <span class="dot bg-danger rounded-full" /> <!-- optional alert -->
+      </div>
+      <p class="text-3xl font-bold text-heading">247</p>
+      <p class="text-xs font-medium uppercase text-body-subtle">CIUDADANOS ACTIVOS</p>
+    </div>
+
+anti_examples:
+  - "Stat card with no label explaining what the number represents"
+  - "Using stat card layout for navigation links"
+  - "Delta number without +/- prefix, relying only on green/red color"

--- a/docs/design-kb/components/stat-card.yaml
+++ b/docs/design-kb/components/stat-card.yaml
@@ -32,6 +32,8 @@ states:
   hover:
     box_shadow: "var(--sombra-md)"
     transition: "300ms ease-in-out"
+    cursor: "default (not pointer — cards are NOT clickable)"
+    note: "Hover shadow is a visual richness effect only, not a clickability affordance"
 
   disabled_variant:
     background: "bg-disabled (#f3f4f6)"
@@ -56,7 +58,7 @@ anatomy:
 
   icon_shape:
     type: "Square with rounded corners"
-    background: "linear-gradient(45deg, #7928CA, #FF0080) — brand gradient"
+    background: "linear-gradient(45deg, #5059BC, #F98DFF) — brand gradient (Jacaranda → BG Pink)"
     border_radius: "~10–12px"
     size: "~40px"
     icon_color: "text-white"
@@ -100,7 +102,7 @@ allowed_usage:
   - "Entity detail view quick metrics (Asistentes, Prestaciones, etc.)"
 
 forbidden_usage:
-  - "Multiple stat cards used for navigation (they are display-only)"
+  - "Making stat cards clickable or treating them as navigation links — they are visual-only display elements"
   - "Stat cards without a number — they must always show a quantitative value"
   - "Icon without a label to explain the metric"
 

--- a/docs/design-kb/components/toast.yaml
+++ b/docs/design-kb/components/toast.yaml
@@ -1,0 +1,108 @@
+# =============================================================
+# Component: Toast / Notification
+# Source: Designer confirmation (2026-06-08)
+# Note: Not documented in CHACO_NODO_Design_Manual.md — spec confirmed directly
+# =============================================================
+
+purpose: >
+  Transient status messages that appear after a user action.
+  Toasts confirm success, warn of issues, or report errors.
+  They are temporary and do not require user interaction to dismiss.
+
+scope:
+  applies_to: "Backoffice (authenticated views) only"
+  portal: "Not used in citizen portal"
+
+variants:
+  success:
+    icon: "CheckCircleIcon"
+    label: "Acción completada"
+    example: "Ciudadano creado correctamente."
+  error:
+    icon: "ExclamationCircleIcon"
+    label: "Error"
+    example: "No se pudo guardar. Intentá de nuevo."
+  warning:
+    icon: "ExclamationTriangleIcon"
+    label: "Atención"
+    example: "El formulario tiene campos incompletos."
+  info:
+    icon: "InformationCircleIcon"
+    label: "Información"
+    example: "Los cambios se guardarán automáticamente."
+
+appearance:
+  position: "Center of viewport (horizontally and vertically)"
+  background: "rgba(75, 85, 99, 0.7)"
+  background_token: "gray-600 at 70% opacity (--color-gray-600 = #4b5563)"
+  text_color: "text-white (#ffffff)"
+  border_radius: "rounded-xl (12px)"
+  padding: "16px 20px"
+  min_width: "~280px"
+  max_width: "~480px"
+  box_shadow: "var(--sombra-lg)"
+
+timing:
+  duration: "10 seconds"
+  animation_in: "fade-in + slight scale up (150ms ease-out)"
+  animation_out: "fade-out (150ms ease-in)"
+  user_dismiss: "clicking the toast or a close (×) button dismisses early"
+
+anatomy: |
+  ┌────────────────────────────────────────┐
+  │ [Icon]  Message text here          [×] │
+  └────────────────────────────────────────┘
+
+  - Icon: w-5 h-5, text-white, matches variant semantic color
+  - Message: Inter Regular 14px, text-white
+  - Close button: optional, top-right, × icon, text-white
+
+z_index: "200 (toast layer — above modal at 100)"
+
+implementation:
+  library: "Toastr (legacy templates) or custom Alpine.js (new templates)"
+  positioning_css: |
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 200;
+
+accessibility_rules:
+  - "role='alert' or role='status' depending on urgency"
+  - "aria-live='polite' for info/success, aria-live='assertive' for error"
+  - "Toast must be announced by screen readers"
+  - "Auto-dismiss must not remove focus from the user's current element"
+  - "Color is never the only differentiator — icon + text communicates the variant"
+
+allowed_usage:
+  - "Confirmation of successful actions (create, save, delete)"
+  - "Non-blocking error feedback that does not require form correction"
+  - "Background process completion (export ready, import finished)"
+
+forbidden_usage:
+  - "Replacing inline form validation (validation errors go below the field)"
+  - "Critical errors that require user action — use a modal or inline alert instead"
+  - "Stacking multiple toasts simultaneously — show one at a time"
+  - "Toast without an icon — icon is required for accessibility"
+  - "Duration shorter than 3 seconds — user must have time to read"
+  - "Using window.alert() or browser-native notifications"
+
+examples:
+  success: |
+    <div class="toast toast-success" role="alert">
+      <CheckCircleIcon class="w-5 h-5 text-white" />
+      <span>Ciudadano creado correctamente.</span>
+      <button aria-label="Cerrar">×</button>
+    </div>
+  error: |
+    <div class="toast toast-error" role="alert" aria-live="assertive">
+      <ExclamationCircleIcon class="w-5 h-5 text-white" />
+      <span>No se pudo guardar. Intentá de nuevo.</span>
+    </div>
+
+anti_examples:
+  - "Toast positioned top-right corner (system uses center-screen)"
+  - "Toast with light background — background must be gray-600 at 70%"
+  - "Toast that auto-dismisses in 2 seconds — minimum is 10 seconds"
+  - "Using Toastr's default positioning without overriding to center"

--- a/docs/design-kb/design-constitution.md
+++ b/docs/design-kb/design-constitution.md
@@ -136,3 +136,17 @@ This is a transitional state. The long-term goal is Tailwind CSS throughout.
 - **Never mix icon libraries within the same component**
 
 Both libraries have the same color inheritance rule: icons always use text color tokens, never hardcoded values.
+
+---
+
+## Amendment III: Dark Mode Scope
+
+**Dark mode applies to the backoffice (authenticated views) only.**
+
+The citizen portal (`portal/` templates) does not implement dark mode. Portal components use light mode exclusively.
+
+- `data-theme="dark"` / `.dark` selectors: backoffice templates only
+- `localStorage` preference persistence: backoffice only
+- Dark token variants: must exist for all tokens (for design system completeness), but are only activated in backoffice contexts
+
+Article III's dark-mode requirement applies exclusively to backoffice components. When building portal components, dark-mode compliance is not required.

--- a/docs/design-kb/design-constitution.md
+++ b/docs/design-kb/design-constitution.md
@@ -1,0 +1,138 @@
+# Design Constitution
+**NODO — Gobierno del Chaco**
+**Highest-Level Principles Governing Every UI Decision**
+
+---
+
+> These are the inviolable laws of the NODO design system.
+> When in doubt about any UI decision, return to these principles.
+> They take precedence over personal preference, legacy patterns, and convenience.
+
+---
+
+## Article I: Tokens Are Law
+
+**Every color, every size, every spacing value must come from a design token.**
+
+The system has a complete token vocabulary: `--bg-*`, `--border-*`, `--text-*`, `--font-*`, `--rounded-*`. No hex value, no pixel measurement, no color name may be used in a component without a corresponding token.
+
+If a token does not exist for your use case, you must consult the design team before creating a one-off value. Ad-hoc values fragment the system and break dark mode, theming, and future upgrades.
+
+*Exception: The explicit hex values documented in component specifications (button states, badge colors) are permitted because they ARE the token definitions for those components.*
+
+---
+
+## Article II: The Semantic Layer Protects the System
+
+**Never reference primitive color scales directly in components. Always use semantic tokens.**
+
+`bg-brand` is correct. `bg-[#5059bc]` or `color-brand-700` in component code is wrong.
+
+Semantic tokens abstract the color meaning from the color value. When the brand color changes, updating one token updates the entire system. This is why the system was built.
+
+---
+
+## Article III: Dark Mode Is a First-Class Citizen
+
+**Every component must work in both light and dark mode from day one.**
+
+All semantic tokens have light and dark variants. Dark mode is toggled by `data-theme="dark"` or `.dark` on the root element. No component may hardcode a value that only works in light mode.
+
+Building light-mode-only components is technical debt that compounds with every new screen added to the system.
+
+---
+
+## Article IV: Accessibility Is Not Optional
+
+**The system must be usable by all users, regardless of ability.**
+
+- Focus states are always visible — `outline: 2px solid` on focus, never removed
+- Color is never the sole communicator of state — labels and icons accompany color
+- Interactive elements have accessible labels (aria-label for icon-only buttons)
+- Error messages use both color and text to communicate the issue
+- WCAG AA contrast ratio must be maintained for all text/background pairs
+
+Disabling focus rings for aesthetic reasons is a system violation, not a style choice.
+
+---
+
+## Article V: One Primary Action Per Context
+
+**Each screen section may have exactly one Brand (gradient) button.**
+
+The visual hierarchy of the system depends on one dominant action being identifiable at a glance. When two Brand buttons exist in the same section, neither is primary — both become noise.
+
+Primary: Brand button. Secondary: Tertiary (outlined brand) or Secondary (neutral outlined).
+
+---
+
+## Article VI: Hierarchy Before Decoration
+
+**Every visual element must earn its place by clarifying hierarchy or communicating meaning.**
+
+The brand gradient exists to mark the single most important action. The `text-heading` color exists to mark primary content. The `text-body-subtle` color exists to mark secondary information.
+
+Decoration that does not serve hierarchy, meaning, or state communication should not exist.
+
+---
+
+## Article VII: Errors Must Be Specific and Actionable
+
+**No user should ever see a generic "Error" message.**
+
+Every error message must:
+1. State specifically what went wrong ("El email no es válido")
+2. Appear where the error occurred (inline, below the field)
+3. Include a visual indicator beyond color alone (icon + text)
+4. Never expose internal system details (IDs, stack traces, HTTP codes)
+
+Error messages are written in Spanish, in plain language that a government worker can understand without technical knowledge.
+
+---
+
+## Article VIII: Destructive Actions Must Be Gated
+
+**No irreversible operation may execute without a SweetAlert2 confirmation dialog.**
+
+This is not about distrust of users — it is about the stakes. The system manages citizen data, social programs, and public records. An accidental deletion could have real consequences for real people.
+
+`window.confirm()` is forbidden. The SweetAlert2 modal is the only permitted confirmation mechanism.
+
+---
+
+## Article IX: Structure Before Mobile
+
+**The desktop experience is the primary surface. Mobile is an adaptation.**
+
+NODO is a backoffice for government workers at desks. The sidebar, data tables, stat card grids, and charts are designed for desktop. Mobile adaptations exist and must work, but mobile-first design decisions should not degrade the desktop experience.
+
+---
+
+## Article X: The System Is the Single Source of Truth
+
+**Documentation, tokens, and code are only valid when they agree.**
+
+When a token file (`chaco-tokens.json`), a CSS file (`chaco-tokens.css`), a documentation file (`CHACO_NODO_Design_Manual.md`), and the component code disagree — the most recently updated token file wins.
+
+When documentation conflicts with code, fix the code to match the documented tokens. Exceptions must be documented with a rationale.
+
+---
+
+## Amendment I: CSS Dual-Stack Rule
+
+While the system migrates from Bootstrap/AdminLTE to Tailwind CSS:
+- **New templates use Tailwind CSS exclusively**
+- **Legacy templates use Bootstrap 5.3.2 + AdminLTE exclusively**
+- **Never mix Tailwind and Bootstrap classes in the same component**
+
+This is a transitional state. The long-term goal is Tailwind CSS throughout.
+
+---
+
+## Amendment II: Icon Library Exclusivity
+
+- **New templates: Heroicons (outline default, solid for active states)**
+- **Legacy templates: Font Awesome 6.4.0**
+- **Never mix icon libraries within the same component**
+
+Both libraries have the same color inheritance rule: icons always use text color tokens, never hardcoded values.

--- a/docs/design-kb/foundations/colors.yaml
+++ b/docs/design-kb/foundations/colors.yaml
@@ -1,0 +1,513 @@
+# =============================================================
+# NODO Design System — Color Foundations
+# Source: chaco-tokens.json, chaco-tokens.css, CHACO_NODO_Design_Manual.md
+# =============================================================
+
+meta:
+  product: "CHACO NODO"
+  version: "1.0"
+  source: "Figma Variables"
+  modes: [light, dark]
+  critical_rule: "NEVER hardcode hex values in components. Always reference semantic tokens."
+
+# -------------------------------------------------------------
+# BRAND COLORS (Reference only — never use directly in CSS)
+# -------------------------------------------------------------
+brand_reference:
+  azul_principal:
+    hex: "#00203A"
+    use: "Headings, high-contrast backgrounds, wordmark text"
+  jacaranda:
+    hex: "#5059BC"
+    use: "Brand color, primary buttons, links"
+  rosa:
+    hex: "#F26DF9"
+    use: "Accent, informational badges, secondary brand elements"
+  verde_oscuro:
+    hex: "#8A9A46"
+    use: "Success states, confirmation"
+  verde_claro:
+    hex: "#C8D29C"
+    use: "Positive state backgrounds, illustrations"
+
+# -------------------------------------------------------------
+# PRIMITIVE COLOR SCALES (Internal reference — prefer semantic tokens)
+# -------------------------------------------------------------
+primitives:
+  brand:
+    "050": "#f5f3ff"
+    "100": "#ede9fe"
+    "200": "#ddd6fe"
+    "300": "#c4b5fd"
+    "400": "#a78bfa"
+    "500": "#5059bc"
+    "600": "#5059bc"
+    "700": "#5059bc"
+    "800": "#4338ca"
+    "900": "#3730a3"
+    "950": "#1e1b4b"
+
+  pink:
+    "050": "#fef3ff"
+    "100": "#fee9ff"
+    "200": "#fee3ff"
+    "300": "#fdcfff"
+    "400": "#fcc3ff"
+    "500": "#fbafff"
+    "600": "#f98dff"
+    "700": "#f26df9"
+    "800": "#dd5fe4"
+    "900": "#bf57c4"
+    "950": "#9b499f"
+
+  gray:
+    "050": "#f9fafb"
+    "100": "#f3f4f6"
+    "200": "#e5e7eb"
+    "300": "#d1d5db"
+    "400": "#9ca3af"
+    "500": "#6b7280"
+    "600": "#4b5563"
+    "700": "#374151"
+    "800": "#1f2937"
+    "850": "#18212f"
+    "900": "#111827"
+    "950": "#030712"
+
+  emerald:
+    "050": "#ecfdf5"
+    "100": "#d0fae5"
+    "200": "#a4f4cf"
+    "300": "#5ee9b5"
+    "400": "#00d492"
+    "500": "#00bc7d"
+    "600": "#009966"
+    "700": "#007a55"
+    "800": "#006045"
+    "900": "#004f3b"
+    "950": "#002c22"
+
+  rose:
+    "050": "#fef0f2"
+    "100": "#ffe4e6"
+    "200": "#ffccd3"
+    "300": "#ffa1ad"
+    "400": "#ff637e"
+    "500": "#ff2056"
+    "600": "#ec003f"
+    "700": "#c70036"
+    "800": "#a50036"
+    "900": "#8b0836"
+    "950": "#4d0218"
+
+  orange:
+    "050": "#fff8f1"
+    "100": "#feecdc"
+    "200": "#fcd9bd"
+    "300": "#fdba8c"
+    "400": "#ff8a4c"
+    "500": "#ff5a1f"
+    "600": "#d03801"
+    "700": "#b43403"
+    "800": "#8a2c0d"
+    "900": "#771d1d"
+
+  categorical:
+    purple: "#a855f7"
+    sky: "#00579d"
+    teal: "#c8d29c"
+    cyan: "#00b8db"
+    fuchsia: "#c800de"
+    indigo: "#4f46e5"
+    yellow: "#fdc700"
+    lime: "#7ccf00"
+
+# -------------------------------------------------------------
+# SEMANTIC TOKENS — BACKGROUND
+# Naming: bg-[role]-[modifier?]
+# Modifiers: (none)=base, -soft=lighter, -medium=mid, -strong=stronger
+# -------------------------------------------------------------
+semantic_background:
+  neutral:
+    bg-white:
+      light: "#ffffff"
+      dark: "#ffffff"    # intentionally stays white
+      use: "Primary layout background, cards, widgets"
+    bg-primary-soft:
+      light: "#ffffff"
+      dark: "#111827"
+      use: "—"
+    bg-primary:
+      light: "#ffffff"
+      dark: "#030712"
+      use: "—"
+    bg-primary-medium:
+      light: "#ffffff"
+      dark: "#1f2937"
+      use: "—"
+    bg-primary-strong:
+      light: "#ffffff"
+      dark: "#374151"
+      use: "—"
+    bg-secondary-soft:
+      light: "#f9fafb"
+      dark: "#111827"
+      use: "Secondary buttons, dropdowns, inputs, icon shapes"
+    bg-secondary:
+      light: "#f9fafb"
+      dark: "#030712"
+      use: "—"
+    bg-secondary-medium:
+      light: "#f9fafb"
+      dark: "#1f2937"
+      use: "—"
+    bg-secondary-strong:
+      light: "#f9fafb"
+      dark: "#374151"
+      use: "—"
+    bg-tertiary-soft:
+      light: "#f3f4f6"
+      dark: "#1f2937"
+      use: "Toggles, checkboxes, input fields (elevated contrast)"
+    bg-tertiary:
+      light: "#f3f4f6"
+      dark: "#1f2937"
+      use: "—"
+    bg-tertiary-medium:
+      light: "#f3f4f6"
+      dark: "#374151"
+      use: "—"
+    bg-quaternary:
+      light: "#e5e7eb"
+      dark: "#374151"
+      use: "Progress bars, slider controls"
+    bg-quaternary-medium:
+      light: "#e5e7eb"
+      dark: "#4b5563"
+      use: "—"
+    bg-gray:
+      light: "#d1d5db"
+      dark: "#4b5563"
+      use: "Patterns, graphic elements"
+
+  brand:
+    bg-brand-softer:
+      light: "#fef3ff"
+      dark: "#1e1b4b"
+      use: "Alerts, badges, informational brand banners"
+    bg-brand-soft:
+      light: "#fee9ff"
+      dark: "#3730a3"
+      use: "—"
+    bg-brand-medium:
+      light: "#fee3ff"
+      dark: "#3730a3"
+      use: "—"
+    bg-brand:
+      light: "#5059bc"
+      dark: "#5059bc"
+      use: "Buttons, icons, brand identity elements"
+    bg-brand-strong:
+      light: "#4338ca"
+      dark: "#5059bc"
+      use: "Data visualization with brand context"
+
+  states:
+    bg-success-soft:
+      light: "#ecfdf5"
+      dark: "#002c22"
+      use: "Alerts, badges, positive feedback banners"
+    bg-success-medium:
+      light: "#d0fae5"
+      dark: "#006045"
+      use: "—"
+    bg-success:
+      light: "#007a55"
+      dark: "#009966"
+      use: "Success buttons, confirmation icons"
+    bg-success-strong:
+      light: "#006045"
+      dark: "#007a55"
+      use: "Data visualization — success"
+    bg-danger-soft:
+      light: "#fef0f2"
+      dark: "#4d0218"
+      use: "Alerts, badges, critical error banners"
+    bg-danger-medium:
+      light: "#ffe4e6"
+      dark: "#8b0836"
+      use: "—"
+    bg-danger:
+      light: "#c70036"
+      dark: "#c70036"
+      use: "Error buttons, negative feedback icons"
+    bg-danger-strong:
+      light: "#a50036"
+      dark: "#c70036"
+      use: "Data visualization — danger"
+    bg-warning-soft:
+      light: "#fff8f1"
+      dark: "#441306"
+      use: "Caution alerts, badges"
+    bg-warning-medium:
+      light: "#feecdc"
+      dark: "#771d1d"
+      use: "—"
+    bg-warning:
+      light: "#ff5a1f"
+      dark: "#d03801"
+      use: "Non-critical alert buttons, icons"
+    bg-warning-strong:
+      light: "#b43403"
+      dark: "#b43403"
+      use: "Data visualization — warning"
+
+  special:
+    bg-dark:
+      light: "#1f2937"
+      dark: "#1f2937"
+      use: "Dark buttons, icon shapes consistent in both modes"
+    bg-dark-strong:
+      light: "#111827"
+      dark: "#1f2937"
+      use: "—"
+    bg-disabled:
+      light: "#f3f4f6"
+      dark: "#1f2937"
+      use: "Non-interactive elements, read-only"
+
+  categorical:
+    bg-purple:
+      value: "#a855f7"
+      use: "Data visualization"
+    bg-sky:
+      value: "#00579d"
+      use: "Data visualization"
+    bg-teal:
+      value: "#c8d29c"
+      use: "Data visualization"
+    bg-pink:
+      value: "#f98dff"
+      use: "Data visualization"
+    bg-cyan:
+      value: "#00b8db"
+      use: "Data visualization"
+    bg-fuchsia:
+      value: "#c800de"
+      use: "Data visualization"
+    bg-indigo:
+      value: "#4f46e5"
+      use: "Data visualization"
+    bg-orange:
+      value: "#ff8a4c"
+      use: "Data visualization"
+
+# -------------------------------------------------------------
+# SEMANTIC TOKENS — BORDER
+# Naming: border-[role]-[modifier?]
+# -------------------------------------------------------------
+semantic_border:
+  base:
+    border-dark:
+      light: "#4b5563"
+      dark: "#4b5563"
+      use: "High-contrast borders for cards, inputs, buttons"
+    border-buffer:
+      light: "#ffffff"
+      dark: "#030712"
+      use: "Invisible border — same color as background (timeline icons)"
+    border-buffer-medium:
+      light: "#ffffff"
+      dark: "#111827"
+      use: "—"
+    border-buffer-strong:
+      light: "#ffffff"
+      dark: "#1f2937"
+      use: "—"
+    border-muted:
+      light: "#f9fafb"
+      dark: "#111827"
+      use: "Low-contrast — subtle dividers, avatar groups"
+    border-light-subtle:
+      light: "#f3f4f6"
+      dark: "#111827"
+      use: "—"
+    border-light:
+      light: "#f3f4f6"
+      dark: "#1f2937"
+      use: "Mid-contrast dividers, heading separators, list items"
+    border-light-medium:
+      light: "#f3f4f6"
+      dark: "#374151"
+      use: "—"
+    border-base-soft:
+      light: "#e5e7eb"
+      dark: "#111827"
+      use: "Clear visual separation — cards, buttons, avatars, inputs, timelines"
+    border-base:
+      light: "#e5e7eb"
+      dark: "#1f2937"
+      use: "MOST USED — cards, buttons, inputs, all default borders"
+    border-base-medium:
+      light: "#e5e7eb"
+      dark: "#374151"
+      use: "—"
+    border-base-strong:
+      light: "#e5e7eb"
+      dark: "#4b5563"
+      use: "—"
+    border-dark-subtle:
+      light: "#1f2937"
+      dark: "#374151"
+      use: "Dark consistent border in both modes"
+
+  states:
+    border-success-subtle:
+      light: "#a4f4cf"
+      dark: "#004f3b"
+      use: "Positive alerts, badges (subtle)"
+    border-success:
+      light: "#007a55"
+      dark: "#009966"
+      use: "Positive alerts, badges (strong)"
+    border-danger-subtle:
+      light: "#ffccd3"
+      dark: "#8b0836"
+      use: "Error alerts, badges (subtle)"
+    border-danger:
+      light: "#c70036"
+      dark: "#ec003f"
+      use: "Error alerts, badges (strong)"
+    border-warning-subtle:
+      light: "#fcd9bd"
+      dark: "#771d1d"
+      use: "Caution alerts, badges (subtle)"
+    border-warning:
+      light: "#d03801"
+      dark: "#ff5a1f"
+      use: "Caution alerts, badges (strong)"
+
+  brand:
+    border-brand-subtle:
+      light: "#fee3ff"
+      dark: "#3730a3"
+      use: "Brand alerts, badges (subtle)"
+    border-brand-light:
+      light: "#f98dff"
+      dark: "#5059bc"
+      use: "Brand border (medium)"
+    border-brand:
+      light: "#5059bc"
+      dark: "#5059bc"
+      use: "Brand border (primary)"
+
+  categorical:
+    border-purple:
+      value: "#a855f7"
+      use: "Data visualization charts/dashboards"
+    border-orange:
+      value: "#ff8a4c"
+      use: "Data visualization charts/dashboards"
+
+# -------------------------------------------------------------
+# SEMANTIC TOKENS — TEXT
+# Naming: text-fg-[role]-[modifier?]
+# Exception: text-white, text-black, text-heading, text-body, text-body-subtle (no -fg prefix)
+# RULE: Never use text-heading or text-body over colored backgrounds — use text-fg-* instead
+# -------------------------------------------------------------
+semantic_text:
+  neutral:
+    text-white:
+      light: "#ffffff"
+      dark: "#ffffff"
+      use: "White text — consistent both modes"
+    text-black:
+      light: "#111827"
+      dark: "#111827"
+      use: "Black text — consistent both modes"
+    text-heading:
+      light: "#111827"
+      dark: "#ffffff"
+      use: "Primary text: H1–H3, important CTA links"
+    text-body:
+      light: "#4b5563"
+      dark: "#9ca3af"
+      use: "Secondary text: paragraphs, helper text, secondary/tertiary buttons"
+    text-body-subtle:
+      light: "#6b7280"
+      dark: "#9ca3af"
+      use: "Low-hierarchy text: optional labels, helper text"
+
+  brand:
+    text-fg-brand-subtle:
+      light: "#fee3ff"
+      dark: "#fee3ff"
+      use: "Brand text visible on both light and dark backgrounds"
+    text-fg-brand:
+      light: "#5059bc"
+      dark: "#5059bc"
+      use: "Primary brand text: links, icons, brand-colored headings"
+    text-fg-brand-strong:
+      light: "#3730a3"
+      dark: "#a78bfa"
+      use: "Brand text inside alerts or badges with brand background"
+
+  states:
+    text-fg-success:
+      light: "#007a55"
+      dark: "#009966"
+      use: "Positive feedback, successful states, confirmations"
+    text-fg-success-strong:
+      light: "#004f3b"
+      dark: "#5ee9b5"
+      use: "Text inside success alert/badge"
+    text-fg-danger:
+      light: "#c70036"
+      dark: "#ff2056"
+      use: "Errors, critical states — requires immediate attention"
+    text-fg-danger-strong:
+      light: "#8b0836"
+      dark: "#ffa1ad"
+      use: "Text inside danger alert/badge"
+    text-fg-warning-subtle:
+      light: "#d03801"
+      dark: "#ff5a1f"
+      use: "Caution, neutral non-critical alerts"
+    text-fg-warning:
+      light: "#771d1d"
+      dark: "#fdba8c"
+      use: "Text inside warning alert/badge"
+    text-fg-yellow:
+      light: "#fdc700"
+      dark: "#fdc700"
+      use: "Rating stars, attention icons"
+    text-fg-info:
+      light: "#3730a3"
+      dark: "#f98dff"
+      use: "Neutral informational content: announcement banners"
+    text-fg-disabled:
+      light: "#9ca3af"
+      dark: "#4b5563"
+      use: "Non-interactive elements, read-only, disabled buttons/inputs"
+
+  categorical:
+    text-fg-purple:
+      light: "#9333ea"
+      dark: "#a855f7"
+      use: "Data visualization"
+    text-fg-cyan:
+      light: "#0092b8"
+      dark: "#00b8db"
+      use: "Data visualization"
+    text-fg-indigo:
+      light: "#4f46e5"
+      dark: "#6366f1"
+      use: "Data visualization"
+    text-fg-pink:
+      light: "#f98dff"
+      dark: "#f98dff"
+      use: "Data visualization"
+    text-fg-lime:
+      light: "#5ea500"
+      dark: "#7ccf00"
+      use: "Data visualization"

--- a/docs/design-kb/foundations/elevation.yaml
+++ b/docs/design-kb/foundations/elevation.yaml
@@ -1,0 +1,78 @@
+# =============================================================
+# NODO Design System — Elevation (Shadows)
+# Source: paleta-unificada.css, Canva brand manual, NODO DS.md
+# =============================================================
+
+meta:
+  design_philosophy: >
+    Minimal, crisp shadows. Near-zero blur with small offsets and spread
+    to suggest depth without complexity. The system favors flat design with
+    subtle shadow cues. No skeumorphic or heavy drop shadows.
+  note: "Shadow tokens are defined in paleta-unificada.css. Not yet in chaco-tokens.json."
+
+# -------------------------------------------------------------
+# SHADOW SCALE
+# -------------------------------------------------------------
+shadows:
+  sm:
+    css_var: "--sombra-sm"
+    value: "0 1px 2px 0 rgba(0, 0, 0, 0.05)"
+    use: "Default card shadow, minimal surface elevation"
+
+  md:
+    css_var: "--sombra-md"
+    value: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)"
+    use: "Cards on hover, dropdowns, tooltips"
+
+  lg:
+    css_var: "--sombra-lg"
+    value: "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)"
+    use: "Modals, overlays, floating panels"
+
+  xl:
+    css_var: "--sombra-xl"
+    value: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)"
+    use: "UNKNOWN — very large floating elements"
+
+# -------------------------------------------------------------
+# COMPONENT-SPECIFIC SHADOW SPECS (from design manual)
+# -------------------------------------------------------------
+component_shadows:
+  card_default:
+    value: "var(--sombra-sm)"
+    transition: "var(--transicion-normal)"
+    hover: "var(--sombra-md)"
+
+  button_focus_ring:
+    value: "0 1px 0 2px #E5E7EB"
+    note: "Used on brand and tertiary button focus state"
+
+  button_secondary_focus:
+    value: "0 1px 0 2px #F3F4F6"
+    note: "Secondary button focus state"
+
+# -------------------------------------------------------------
+# Z-INDEX SCALE
+# (Documented in NODO DS.md general rules)
+# -------------------------------------------------------------
+z_index:
+  base: 0
+  dropdown: 10
+  modal: 100
+  toast: 200
+  note: "Never use arbitrary z-index values outside this scale"
+
+# -------------------------------------------------------------
+# CANVA BRAND MANUAL SHADOW SPECS
+# (From nodo-mm presentation — component-level observations)
+# -------------------------------------------------------------
+brand_manual_shadows:
+  shadow_1:
+    x_offset: "0px"
+    y_offset: "1px"
+    blur_radius: "0px"
+    spread: "2px"
+    note: "Used for focus states and card accents"
+  note: >
+    The brand manual shows minimal blur (0px) and small spread (2px),
+    confirming the preference for flat design with clean, controlled depth.

--- a/docs/design-kb/foundations/grid.yaml
+++ b/docs/design-kb/foundations/grid.yaml
@@ -1,0 +1,110 @@
+# =============================================================
+# NODO Design System — Grid & Layout
+# Source: Canva brand manual (nodo-mm), CHACO_NODO_Design_Manual.md
+# =============================================================
+
+meta:
+  status: "PARTIAL — Exact grid margins and gutter values in px pending documentation"
+  layout_model: "Sidebar + Topbar + Content Area (fixed two-column)"
+
+# -------------------------------------------------------------
+# APPLICATION SHELL LAYOUT
+# -------------------------------------------------------------
+app_shell:
+  model: "sidebar-left + fixed-topbar + scrollable-content"
+
+  topbar:
+    position: "fixed top"
+    height: "72–76px"
+    content_left: "Logo (collapses with sidebar)"
+    content_right: "Notification bell + User avatar with dropdown"
+    z_index: 10
+
+  sidebar:
+    position: "fixed left"
+    width_expanded: "~290–300px"
+    width_collapsed: "UNKNOWN"
+    collapsible: true
+    collapse_trigger: "Minimizar button at sidebar footer"
+    breakpoint_behavior: "Fixed on desktop / behavior on mobile UNKNOWN"
+    background: "Gradient (var(--fondo-sidebar))"
+
+  content_area:
+    margin_left: "300px"
+    min_height: "calc(100vh - 182px)"
+    padding: "UNKNOWN"
+    overflow: "scrollable"
+
+# -------------------------------------------------------------
+# CONTENT COLUMN GRID (from Canva brand manual)
+# -------------------------------------------------------------
+content_grid:
+  column_unit: "243px"
+  sidebar_unit: "290px"
+  gap: "33px"
+  model: "Multi-column with consistent 243px column width"
+  note: >
+    The Canva brand manual shows a 3-column content grid.
+    Sidebar (290px) + gap (33px) + content columns (243px each).
+
+# -------------------------------------------------------------
+# LAYOUT PATTERNS BY SCREEN TYPE
+# -------------------------------------------------------------
+screen_layouts:
+  access_screens:
+    pattern: "split-screen"
+    left: "60% — Illustration / decorative"
+    right: "40% — Form / content"
+    note: "ONLY for login and password recovery. Never for internal screens."
+
+  internal_single_column:
+    pattern: "sidebar + full-width content"
+    examples: [home, ciudadanos-en-tratamiento]
+    content_max_width: "UNKNOWN"
+
+  internal_two_column:
+    pattern: "sidebar + content with inner two columns"
+    examples: [confirmar-datos-ciudadano]
+    left_column: "~35%"
+    right_column: "~65%"
+
+  form_screens:
+    pattern: "sidebar + centered form"
+    form_max_width: "~700px"
+    form_alignment: "centered"
+
+# -------------------------------------------------------------
+# STAT CARD GRID
+# -------------------------------------------------------------
+stat_card_grid:
+  columns: 4
+  layout: "horizontal grid"
+  gap: "UNKNOWN"
+  note: "Dashboard home shows 4 stat cards in a horizontal row"
+
+  ciudadanos_screen:
+    columns: 6
+    layout: "horizontal grid"
+    note: "Ciudadanos en Tratamiento shows 6 stat cards"
+
+# -------------------------------------------------------------
+# FORM LAYOUT RULES
+# -------------------------------------------------------------
+form_layout:
+  max_width: "~700px"
+  alignment: "centered within content area"
+  field_gap: "20px"
+  section_gap: "32px"
+  inline_fields: "DNI + Sexo fields appear in the same row"
+
+# -------------------------------------------------------------
+# RESPONSIVE RULES
+# -------------------------------------------------------------
+responsive:
+  status: "PARTIAL — Mobile behavior not fully documented"
+  sidebar_mobile: "UNKNOWN — desktop fixed, mobile behavior TBD"
+  breakpoints:
+    lg_plus: "Sidebar visible and fixed at 300px"
+    below_lg: "UNKNOWN"
+  mobile_css_files: [mobile-forms.css, mobile-modals.css, mobile-tables.css]
+  note: "Dedicated mobile CSS files exist, indicating mobile-first awareness"

--- a/docs/design-kb/foundations/iconography.yaml
+++ b/docs/design-kb/foundations/iconography.yaml
@@ -1,0 +1,238 @@
+# =============================================================
+# NODO Design System — Iconography
+# Source: CHACO_NODO_Design_Manual.md §16, NODO DS.md §10
+# =============================================================
+
+meta:
+  primary_library: "Heroicons (via Flowbite)"
+  reference_url: "https://heroicons.com"
+  npm_package: "@heroicons/react"
+  flowbite_docs: "https://flowbite.com/icons/"
+  secondary_library: "Font Awesome 6.4.0"
+  secondary_note: "Font Awesome is used in legacy templates and the CRM sidebar"
+  critical_rule: "Icons NEVER have their own color — they inherit via text color tokens"
+
+# -------------------------------------------------------------
+# ICON STYLES
+# -------------------------------------------------------------
+styles:
+  outline:
+    status: "DEFAULT"
+    use: "Navigation, actions, states — all default icon contexts"
+    heroicons_import: "@heroicons/react/24/outline"
+
+  solid:
+    status: "RESERVED"
+    use: "Active state icons only (e.g., active sidebar nav item)"
+    heroicons_import: "@heroicons/react/24/solid"
+    forbidden: "Do not use as default style throughout the UI"
+
+  mini:
+    size: "16px"
+    use: "Inline text badges, labels, small chips"
+    heroicons_import: "@heroicons/react/16/solid"
+
+# -------------------------------------------------------------
+# SIZE SCALE
+# -------------------------------------------------------------
+sizes:
+  "w-4 h-4":
+    px: "16px"
+    tailwind: "w-4 h-4"
+    use: "Inline text icons, badges, chips"
+
+  "w-5 h-5":
+    px: "20px"
+    tailwind: "w-5 h-5"
+    use: "Input prefix icons, small button icons"
+
+  "w-6 h-6":
+    px: "24px"
+    tailwind: "w-6 h-6"
+    use: "Navigation icons, stat cards, table action icons (BASE SIZE)"
+    note: "This is the default/base icon size"
+
+  "w-8 h-8":
+    px: "32px"
+    tailwind: "w-8 h-8"
+    use: "Section icons, page header icons"
+
+  "w-12 h-12":
+    px: "48px"
+    tailwind: "w-12 h-12"
+    use: "Empty state illustrations, error state illustrations"
+
+# Font Awesome sizes (legacy templates)
+font_awesome_sizes:
+  fa-sm:
+    use: "Inline icons next to text in legacy templates"
+  fa-lg:
+    use: "Standalone icons in components (metric cards, lists)"
+  fa-xl:
+    use: "Featured/highlighted icons"
+
+# -------------------------------------------------------------
+# COLOR RULES
+# -------------------------------------------------------------
+color_contexts:
+  navigation_default:
+    token: "text-body"
+    value_light: "#4b5563"
+    use: "Inactive sidebar nav items"
+
+  navigation_active:
+    token: "text-white"
+    value: "#ffffff"
+    context: "On bg-brand background"
+    use: "Active sidebar nav item icon"
+
+  input_prefix:
+    token: "text-body-subtle"
+    value_light: "#6b7280"
+    use: "Leading icon inside form inputs"
+
+  table_actions:
+    token: "text-fg-brand"
+    value_light: "#5059bc"
+    use: "Action icons in table rows (view, edit)"
+
+  success:
+    token: "text-fg-success"
+    value_light: "#007a55"
+    use: "Success state icons"
+
+  danger:
+    token: "text-fg-danger"
+    value_light: "#c70036"
+    use: "Error/critical state icons"
+
+  warning:
+    token: "text-fg-warning-subtle"
+    value_light: "#d03801"
+    use: "Warning/caution icons"
+
+  disabled:
+    token: "text-fg-disabled"
+    value_light: "#9ca3af"
+    use: "Disabled state icons"
+
+  brand_on_gradient:
+    token: "text-white"
+    value: "#ffffff"
+    use: "Icons on brand gradient backgrounds (sidebar logo, metric card icon shapes)"
+
+# -------------------------------------------------------------
+# OBSERVED ICON CATALOG (from documented screens)
+# -------------------------------------------------------------
+observed_icons:
+  BellIcon:
+    heroicon: "BellIcon"
+    use: "Notifications in topbar"
+
+  UserGroupIcon:
+    heroicon: "UserGroupIcon"
+    use: "Total citizens stat, Citizens nav item"
+
+  FolderOpenIcon:
+    heroicon: "FolderOpenIcon"
+    use: "Active case files"
+
+  BellAlertIcon:
+    heroicon: "BellAlertIcon"
+    use: "Critical alerts panel"
+
+  CalendarDaysIcon:
+    heroicon: "CalendarDaysIcon"
+    use: "Follow-up dates"
+
+  ChartBarIcon:
+    heroicon: "ChartBarIcon"
+    use: "Adherence rate metric, Reports nav item"
+
+  HeartIcon:
+    heroicon: "HeartIcon"
+    use: "High-risk cases metric"
+
+  HomeIcon:
+    heroicon: "HomeIcon"
+    use: "Home / Inicio in sidebar"
+
+  Squares2X2Icon:
+    heroicon: "Squares2X2Icon"
+    use: "Dashboard in sidebar"
+
+  EyeIcon:
+    heroicon: "EyeIcon"
+    use: "View detail action in tables"
+
+  ArrowLeftIcon:
+    heroicon: "ArrowLeftIcon"
+    use: "Back button"
+
+  PlusCircleIcon:
+    heroicon: "PlusCircleIcon"
+    use: "New record CTA, Create citizen"
+
+  ChevronRightIcon:
+    heroicon: "ChevronRightIcon"
+    use: "Breadcrumb separator, submenus"
+
+  ChevronDownIcon:
+    heroicon: "ChevronDownIcon"
+    use: "Collapsed expandable submenus"
+
+  ChevronUpIcon:
+    heroicon: "ChevronUpIcon"
+    use: "Expanded submenus"
+
+  ArrowDownTrayIcon:
+    heroicon: "ArrowDownTrayIcon"
+    use: "Export button"
+
+  ShieldCheckIcon:
+    heroicon: "ShieldCheckIcon"
+    use: "Security system status indicator"
+
+  ServerIcon:
+    heroicon: "ServerIcon"
+    use: "Server system status indicator"
+
+  EnvelopeIcon:
+    heroicon: "EnvelopeIcon"
+    use: "Email input field prefix"
+
+  LockClosedIcon:
+    heroicon: "LockClosedIcon"
+    use: "Password input field prefix"
+
+  MagnifyingGlassIcon:
+    heroicon: "MagnifyingGlassIcon"
+    use: "Search bar"
+
+  UserPencilIcon:
+    heroicon: "UserPencilIcon"
+    use: "New citizen flow"
+
+  ChatBubbleLeftRightIcon:
+    heroicon: "ChatBubbleLeftRightIcon"
+    use: "Conversations, floating chat"
+
+# -------------------------------------------------------------
+# RULES
+# -------------------------------------------------------------
+rules:
+  dos:
+    - "Use Heroicons outline style by default everywhere"
+    - "Apply color via token (text-fg-brand, text-body-subtle, etc.)"
+    - "Use w-6 h-6 as the base size for navigation and cards"
+    - "Use solid style ONLY for the active state of an icon"
+    - "Maintain Heroicons default stroke-width"
+    - "Icon-only buttons must include aria-label"
+
+  donts:
+    - "Mixing icon libraries (Font Awesome + Heroicons in the same component)"
+    - "Hardcoding color: #5059bc in SVG or element"
+    - "Scaling icons with font-size instead of width/height"
+    - "Using solid style as default throughout the UI"
+    - "Modifying stroke-width manually"
+    - "Using Font Awesome in new templates (Heroicons only)"

--- a/docs/design-kb/foundations/motion.yaml
+++ b/docs/design-kb/foundations/motion.yaml
@@ -1,0 +1,100 @@
+# =============================================================
+# NODO Design System — Motion & Animation
+# Source: paleta-unificada.css, portal-modern.css, NODO DS.md
+# =============================================================
+
+meta:
+  philosophy: >
+    Motion is used to reinforce interaction feedback (hover, focus, open/close).
+    Portal uses richer entry animations for citizen-facing screens.
+    Backoffice uses minimal transitions for state changes only.
+
+# -------------------------------------------------------------
+# TRANSITION TOKENS
+# (Defined in paleta-unificada.css)
+# -------------------------------------------------------------
+transitions:
+  fast:
+    css_var: "--transicion-rapida"
+    value: "150ms ease-in-out"
+    use: "Button hover/focus state changes, sidebar chevron rotation, icon color changes"
+
+  normal:
+    css_var: "--transicion-normal"
+    value: "300ms ease-in-out"
+    use: "Card shadow transitions (default → hover), sidebar expand/collapse"
+
+  slow:
+    css_var: "--transicion-lenta"
+    value: "500ms ease-in-out"
+    use: "UNKNOWN — larger layout transitions"
+
+# -------------------------------------------------------------
+# COMPONENT-SPECIFIC MOTION
+# (Derived from design manual and CSS inspection)
+# -------------------------------------------------------------
+component_motion:
+  button_state_change:
+    duration: "150ms"
+    easing: "ease"
+    properties: [background, color, border-color, box-shadow]
+    note: "All button state transitions use 150ms ease"
+
+  sidebar_chevron:
+    duration: "150ms"
+    easing: "ease"
+    transform: "rotate(180deg)"
+    trigger: "when parent nav group is expanded"
+
+  card_hover:
+    transition: "var(--transicion-normal)"
+    shadow_change: "var(--sombra-sm) → var(--sombra-md)"
+
+  notification_dot:
+    animation: "pulse"
+    note: "Live activity indicator uses pulsing green dot"
+
+# -------------------------------------------------------------
+# PORTAL ANIMATIONS
+# (Defined in portal-modern.css — citizen-facing surfaces only)
+# -------------------------------------------------------------
+portal_animations:
+  fadeInUp:
+    keyframes: "opacity 0→1, transform translateY(30px)→0"
+    duration: "UNKNOWN"
+    use: "Section entry on portal pages"
+
+  slideInLeft:
+    keyframes: "transform translateX(-100%)→0"
+    duration: "UNKNOWN"
+    use: "Panel entry from left"
+
+  slideInRight:
+    keyframes: "transform translateX(100%)→0"
+    duration: "UNKNOWN"
+    use: "Panel entry from right"
+
+  pulse_glow:
+    use: "Brand accent elements, CTAs on portal"
+
+  gradient_shift:
+    use: "Animated gradient backgrounds on portal hero sections"
+
+  glassmorphism:
+    use: "Card effects on portal (backdrop-filter: blur)"
+
+# -------------------------------------------------------------
+# RULES
+# -------------------------------------------------------------
+rules:
+  dos:
+    - "Use transition tokens (--transicion-rapida, etc.) — never write raw ms values"
+    - "Apply 150ms transitions to all interactive state changes"
+    - "Animate only meaningful properties (bg, border, shadow, opacity, transform)"
+    - "Use portal animations only on portal-facing templates"
+
+  donts:
+    - "Adding animations to backoffice components (reserved for portal)"
+    - "Using transitions longer than 500ms for UI interactions"
+    - "Animating layout properties (width, height) that cause reflow"
+    - "Removing transitions entirely — they provide accessibility feedback"

--- a/docs/design-kb/foundations/spacing.yaml
+++ b/docs/design-kb/foundations/spacing.yaml
@@ -1,0 +1,192 @@
+# =============================================================
+# NODO Design System — Spacing Foundations
+# Source: chaco-tokens.json, NODO DS.md (component specs), Canva brand manual
+# Note: No explicit spacing token scale was exported from Figma.
+# Values below are derived from component specifications.
+# =============================================================
+
+meta:
+  status: "PARTIAL — Spacing tokens not yet exported from Figma"
+  pending: "Grid margins, padding internal values in px/rem pending documentation"
+  base_unit: 4  # inferred from component specs (multiples of 4)
+
+# -------------------------------------------------------------
+# BORDER RADIUS
+# (Fully documented in design tokens)
+# -------------------------------------------------------------
+border_radius:
+  "0":
+    value: "0px"
+    css_var: "--rounded-0"
+    tailwind: "rounded-0"
+    use: "Sharp corners — no defined use case in current system"
+  sm:
+    value: "2px"
+    css_var: "--rounded-sm"
+    tailwind: "rounded-sm"
+    use: "UNKNOWN"
+  base:
+    value: "4px"
+    css_var: "--rounded"
+    tailwind: "rounded"
+    use: "Small elements"
+  md:
+    value: "6px"
+    css_var: "--rounded-md"
+    tailwind: "rounded-md"
+    use: "Badges, filter chips"
+  lg:
+    value: "8px"
+    css_var: "--rounded-lg"
+    tailwind: "rounded-lg"
+    use: "Inputs, cards, subitems in sidebar active state"
+  xl:
+    value: "12px"
+    css_var: "--rounded-xl"
+    tailwind: "rounded-xl"
+    use: "Cards (main), buttons, sidebar logo, metric cards, entity headers"
+  "2xl":
+    value: "16px"
+    css_var: "--rounded-2xl"
+    tailwind: "rounded-2xl"
+    use: "UNKNOWN"
+  "3xl":
+    value: "24px"
+    css_var: "--rounded-3xl"
+    tailwind: "rounded-3xl"
+    use: "UNKNOWN"
+  full:
+    value: "9999px"
+    css_var: "--rounded-full"
+    tailwind: "rounded-full"
+    use: "Buttons (pill shape), badges, avatars, notification dots"
+
+# -------------------------------------------------------------
+# BORDER WIDTHS
+# -------------------------------------------------------------
+border_widths:
+  "0":
+    value: "0px"
+    css_var: "--border-width-0"
+    use: "No border"
+  base:
+    value: "1px"
+    css_var: "--border-width"
+    use: "Default border for all components"
+  "2":
+    value: "2px"
+    css_var: "--border-width-2"
+    use: "Focus state outlines (button focus ring)"
+  "4":
+    value: "4px"
+    css_var: "--border-width-4"
+    use: "UNKNOWN"
+  "8":
+    value: "8px"
+    css_var: "--border-width-8"
+    use: "UNKNOWN"
+
+# -------------------------------------------------------------
+# COMPONENT SPACING (inferred from specs)
+# Documented from component anatomy in design manual
+# -------------------------------------------------------------
+component_spacing:
+  button:
+    xs: { padding_v: "6px", padding_h: "12px", gap_icon: "6px", height: "32px" }
+    sm: { padding_v: "8px", padding_h: "12px", gap_icon: "6px", height: "36px" }
+    base: { padding_v: "10px", padding_h: "16px", gap_icon: "6px", height: "40px" }
+    l: { padding_v: "12px", padding_h: "20px", gap_icon: "6px", height: "48px" }
+    xl: { padding_v: "14px", padding_h: "24px", gap_icon: "6px", height: "52px" }
+
+  badge:
+    sm: { padding_v: "2px", padding_h: "4px", gap: "2px", height: "20px" }
+    lg: { padding_v: "4px", padding_h: "6px", gap: "4px", height: "24px" }
+
+  input:
+    height: "40px"
+    padding_v: "~12px"
+    padding_h: "~16px"
+    note: "Base size — height 40px"
+
+  table_row:
+    height: "~48px"
+    padding_v: "12–16px"
+
+  card:
+    padding: "~20px"
+    border_radius: "8–12px"
+
+  module_card:
+    padding_top: "15px"
+    padding_bottom: "15px"
+    padding_left: "28px"
+    padding_right: "28px"
+    internal_spacing: "24px"
+
+  form:
+    gap_between_fields: "20px"
+    gap_between_sections: "32px"
+
+  sidebar_logo:
+    padding: "16px"
+    border_radius: "12px"
+
+# -------------------------------------------------------------
+# MAX WIDTH SCALE
+# -------------------------------------------------------------
+max_widths:
+  xs:
+    value: "320px"
+    css_var: "--max-w-xs"
+    tailwind: "max-w-xs"
+  sm:
+    value: "384px"
+    css_var: "--max-w-sm"
+    tailwind: "max-w-sm"
+  md:
+    value: "448px"
+    css_var: "--max-w-md"
+    tailwind: "max-w-md"
+  lg:
+    value: "512px"
+    css_var: "--max-w-lg"
+    tailwind: "max-w-lg"
+  xl:
+    value: "576px"
+    css_var: "--max-w-xl"
+    tailwind: "max-w-xl"
+  "2xl":
+    value: "672px"
+    css_var: "--max-w-2xl"
+    tailwind: "max-w-2xl"
+  "3xl":
+    value: "768px"
+    css_var: "--max-w-3xl"
+    tailwind: "max-w-3xl"
+  "4xl":
+    value: "896px"
+    css_var: "--max-w-4xl"
+    tailwind: "max-w-4xl"
+  "5xl":
+    value: "1024px"
+    css_var: "--max-w-5xl"
+    tailwind: "max-w-5xl"
+  "6xl":
+    value: "1152px"
+    css_var: "--max-w-6xl"
+    tailwind: "max-w-6xl"
+  "7xl":
+    value: "1280px"
+    css_var: "--max-w-7xl"
+    tailwind: "max-w-7xl"
+
+# -------------------------------------------------------------
+# CONTAINER BREAKPOINTS
+# -------------------------------------------------------------
+containers:
+  xs: { value: "380px", css_var: "--container-xs" }
+  sm: { value: "640px", css_var: "--container-sm" }
+  md: { value: "768px", css_var: "--container-md" }
+  lg: { value: "1024px", css_var: "--container-lg" }
+  xl: { value: "1280px", css_var: "--container-xl" }
+  "2xl": { value: "1563px", css_var: "--container-2xl" }

--- a/docs/design-kb/foundations/typography.yaml
+++ b/docs/design-kb/foundations/typography.yaml
@@ -1,0 +1,268 @@
+# =============================================================
+# NODO Design System — Typography Foundations
+# Source: chaco-tokens.json, CHACO_NODO_Design_Manual.md, NODO DS.md
+# =============================================================
+
+meta:
+  critical_rule: "Inter is the ONLY font for all UI components. Gellat is ONLY for hero headings on login/access screens."
+
+# -------------------------------------------------------------
+# FONT FAMILIES
+# -------------------------------------------------------------
+font_families:
+  base:
+    name: "Inter"
+    fallback: "sans-serif"
+    css_var: "--font-family-base"
+    tailwind: "font-sans"
+    use: "All UI components, body text, headings, labels, buttons — everything"
+    source: "Google Fonts"
+
+  brand:
+    name: "Gellat"
+    fallback: "sans-serif"
+    css_var: "--font-family-brand"
+    tailwind: "font-brand"
+    use: "EXCLUSIVELY for hero headings on login and password recovery screens"
+    forbidden: "Body text, labels, UI components, any internal screen"
+    note: "Gellat Extra Bold 42 only — text color #00203A on access screens"
+
+# -------------------------------------------------------------
+# FONT SIZES
+# -------------------------------------------------------------
+font_sizes:
+  xxs:
+    value: "8px"
+    css_var: "--font-size-xxs"
+    tailwind: "text-xxs"
+    use: "UNKNOWN — not explicitly mapped in documentation"
+  xs:
+    value: "12px"
+    css_var: "--font-size-xs"
+    tailwind: "text-xs"
+    use: "Badge labels, stat card labels (uppercase), helper text, pagination"
+  sm:
+    value: "14px"
+    css_var: "--font-size-sm"
+    tailwind: "text-sm"
+    use: "Input labels, body text in cards, link text, form helper text"
+  base:
+    value: "16px"
+    css_var: "--font-size-base"
+    tailwind: "text-base"
+    use: "Paragraphs, large buttons"
+  lg:
+    value: "18px"
+    css_var: "--font-size-lg"
+    tailwind: "text-lg"
+    use: "UNKNOWN"
+  xl:
+    value: "20px"
+    css_var: "--font-size-xl"
+    tailwind: "text-xl"
+    use: "UNKNOWN"
+  "2xl":
+    value: "24px"
+    css_var: "--font-size-2xl"
+    tailwind: "text-2xl"
+    use: "UNKNOWN"
+  "3xl":
+    value: "30px"
+    css_var: "--font-size-3xl"
+    tailwind: "text-3xl"
+    use: "Stat card numbers (large metrics)"
+  "4xl":
+    value: "36px"
+    css_var: "--font-size-4xl"
+    tailwind: "text-4xl"
+    use: "Block headings, section titles"
+  "5xl":
+    value: "48px"
+    css_var: "--font-size-5xl"
+    tailwind: "text-5xl"
+    use: "UNKNOWN"
+  "6xl":
+    value: "60px"
+    css_var: "--font-size-6xl"
+    tailwind: "text-6xl"
+    use: "Hero H1 headings"
+
+# Extended (Tailwind config only, not in token JSON)
+  "7xl":
+    value: "72px"
+    tailwind: "text-7xl"
+    use: "UNKNOWN"
+  "8xl":
+    value: "96px"
+    tailwind: "text-8xl"
+    use: "UNKNOWN"
+  "9xl":
+    value: "128px"
+    tailwind: "text-9xl"
+    use: "UNKNOWN"
+
+# -------------------------------------------------------------
+# FONT WEIGHTS
+# -------------------------------------------------------------
+font_weights:
+  normal:
+    value: 400
+    css_var: "--font-weight-normal"
+    tailwind: "font-normal"
+    use: "Paragraphs, helper texts, articles, placeholder text"
+  medium:
+    value: 500
+    css_var: "--font-weight-medium"
+    tailwind: "font-medium"
+    use: "Button labels, form labels, CTAs, some headings, badge text"
+  semibold:
+    value: 600
+    css_var: "--font-weight-semibold"
+    tailwind: "font-semibold"
+    use: "Primary headings (H1–H3 in content), table column headers"
+  bold:
+    value: 700
+    css_var: "--font-weight-bold"
+    tailwind: "font-bold"
+    use: "H1 in hero sections, stat card numbers"
+  extrabold:
+    value: 800
+    css_var: "--font-weight-extrabold"
+    tailwind: "font-extrabold"
+    use: "H1 in high-impact hero sections"
+
+# -------------------------------------------------------------
+# LETTER SPACING
+# -------------------------------------------------------------
+letter_spacing:
+  tighter:
+    value: "-0.8px"
+    css_var: "--letter-spacing-tighter"
+    tailwind: "tracking-tighter"
+    use: "Large H1s — improves readability and visual polish"
+  tight:
+    value: "-0.4px"
+    css_var: "--letter-spacing-tight"
+    tailwind: "tracking-tight"
+    use: "Section and card headings"
+  normal:
+    value: "0px"
+    css_var: "--letter-spacing-normal"
+    tailwind: "tracking-normal"
+    use: "Body text, UI labels (default)"
+  wide:
+    value: "0.4px"
+    tailwind: "tracking-wide"
+    use: "UNKNOWN"
+  wider:
+    value: "0.8px"
+    tailwind: "tracking-wider"
+    use: "UNKNOWN"
+  widest:
+    value: "1.6px"
+    tailwind: "tracking-widest"
+    use: "UNKNOWN"
+
+# -------------------------------------------------------------
+# TYPOGRAPHIC COMBINATIONS (documented patterns)
+# -------------------------------------------------------------
+combinations:
+  hero_h1:
+    font: "Gellat"
+    size: "text-6xl"
+    weight: "font-bold or font-extrabold"
+    tracking: "tracking-tighter"
+    color: "text-heading (#00203A on access screens)"
+    context: "Login, password recovery screens ONLY"
+
+  section_heading:
+    font: "Inter"
+    size: "text-4xl"
+    weight: "font-semibold"
+    tracking: "tracking-tight"
+    color: "text-heading"
+    context: "Page section titles inside the app"
+
+  stat_card_number:
+    font: "Inter"
+    size: "text-3xl or text-4xl"
+    weight: "font-bold"
+    color: "text-heading"
+    context: "Large metric numbers in stat cards"
+
+  stat_card_label:
+    font: "Inter"
+    size: "text-xs"
+    weight: "font-medium"
+    transform: "uppercase"
+    color: "text-body-subtle"
+    context: "Labels beneath stat card numbers"
+
+  button_label:
+    font: "Inter"
+    weight: "font-medium"
+    sizes:
+      xs: "12px"
+      sm: "14px"
+      base: "14px"
+      l: "16px"
+      xl: "16px"
+    context: "All button variants at all sizes"
+    forbidden: "font-normal on button labels"
+
+  table_header:
+    font: "Inter"
+    size: "text-xs"
+    weight: "font-semibold"
+    transform: "uppercase"
+    color: "text-body-subtle"
+    context: "Data table column headers"
+
+  table_body:
+    font: "Inter"
+    size: "text-sm"
+    weight: "font-normal"
+    color: "text-body or text-heading"
+    context: "Data table cell content"
+
+  input_label:
+    font: "Inter"
+    size: "text-sm"
+    weight: "font-medium"
+    color: "text-heading"
+    context: "Form field labels"
+
+  input_placeholder:
+    font: "Inter"
+    size: "text-sm"
+    weight: "font-normal"
+    color: "text-body-subtle"
+    context: "Input placeholder text"
+
+  badge:
+    font: "Inter"
+    weight: "font-medium"
+    sizes:
+      sm: "12px"
+      lg: "14px"
+    context: "Status badges"
+
+# -------------------------------------------------------------
+# DO's & DON'Ts
+# -------------------------------------------------------------
+rules:
+  dos:
+    - "Use text-6xl + font-bold for H1 hero sections"
+    - "Use tracking-tighter on large H1s"
+    - "Use Gellat Extra Bold ONLY on login/access/hero screens"
+    - "Use font-medium for button labels and CTAs"
+    - "Use text-xs + font-medium + uppercase for stat card labels"
+    - "Pair tracking-tight with section and card headings"
+
+  donts:
+    - "Using Gellat for body text or UI labels"
+    - "Using arbitrary sizes outside the defined scale"
+    - "Applying letter-spacing manually (use tokens)"
+    - "Using font-normal on button labels"
+    - "Using text-body as heading color"
+    - "Using placeholder as field label"

--- a/docs/design-kb/implicit-rules.md
+++ b/docs/design-kb/implicit-rules.md
@@ -129,8 +129,8 @@ Each rule includes confidence level, evidence, and rationale.
 **Rationale:** This allows icons to automatically adapt to dark mode and state changes.
 **How to apply:** Apply `text-[token]` class to the icon element. Never use `fill` or `stroke` with hardcoded values.
 
-### IR-CP04: The brand color in NODO DS.md is magenta (#FF0080) while the final design tokens use Jacaranda (#5059BC) as brand
+### IR-CP04: NODO DS.md es la versión anterior del sistema (proyecto padre). CHACO_NODO_Design_Manual.md y chaco-tokens.json son la fuente autorizada
 **Confidence:** HIGH
-**Evidence:** NODO DS.md §1 states brand color = `#FF0080`. chaco-tokens.json/css uses `--color-brand-*` as Jacaranda/purple (`#5059BC`). The button gradient uses both.
-**Rationale:** There appear to be two versions of the design system — an earlier one (NODO DS.md, magenta-first) and a newer one (chaco-tokens.json, Jacaranda/purple-first). The newer token system should be considered authoritative.
-**How to apply:** Use `chaco-tokens.json` / `chaco-tokens.css` tokens as the source of truth. The gradient button in both versions uses the purple→pink combination, so both systems are consistent on that.
+**Evidence:** NODO DS.md corresponde al proyecto NODO del que derivó CHACO. Toda especificación de CHACO (chaco-tokens.json, CHACO_NODO_Design_Manual.md) supera a NODO DS.md en caso de conflicto. Donde NODO DS.md tiene datos que CHACO no documenta, se incorporan como valores de fallback.
+**Rationale:** CHACO es una adaptación de NODO con su propia identidad de marca. El color de marca es Jacaranda (#5059BC), no magenta (#FF0080). El gradiente del botón Brand es `#5059BC → #598DFF`.
+**How to apply:** Usar exclusivamente `chaco-tokens.json` / `chaco-tokens.css` / `CHACO_NODO_Design_Manual.md` como fuentes. Consultar NODO DS.md únicamente para componentes sin documentar en CHACO (tamaños exactos de botón, especificaciones de badge en hex).

--- a/docs/design-kb/implicit-rules.md
+++ b/docs/design-kb/implicit-rules.md
@@ -117,11 +117,11 @@ Each rule includes confidence level, evidence, and rationale.
 **Rationale:** Accessibility requires visible focus. UX requires hover feedback. These are non-negotiable.
 **How to apply:** When creating any clickable or focusable element, define all three states before shipping.
 
-### IR-CP02: Brand gradient always goes purple→pink, never reversed
+### IR-CP02: Brand gradient always goes Jacaranda→BG Pink, never reversed
 **Confidence:** HIGH
-**Evidence:** All documented gradients: `linear-gradient(45deg, #7928CA, #FF0080)` or `linear-gradient(45deg, #5059BC, #F26DF9)`.
+**Evidence:** Confirmed by designer: `linear-gradient(45deg, #5059BC, #F98DFF)` — Jacaranda as start, BG Pink (#F98DFF / `var(--bg-pink)`) as end.
 **Rationale:** Direction encodes brand identity. Reversing it would be inconsistent.
-**How to apply:** Always purple/jacaranda as the start color, pink/rosa as the end color. Never reversed.
+**How to apply:** Always Jacaranda (#5059BC) as the start color, BG Pink (#F98DFF) as the end color. Never reversed. CSS: `linear-gradient(45deg, var(--bg-brand), var(--bg-pink))`.
 
 ### IR-CP03: Icon color always inherits from text token, never hardcoded
 **Confidence:** HIGH
@@ -132,5 +132,5 @@ Each rule includes confidence level, evidence, and rationale.
 ### IR-CP04: NODO DS.md es la versión anterior del sistema (proyecto padre). CHACO_NODO_Design_Manual.md y chaco-tokens.json son la fuente autorizada
 **Confidence:** HIGH
 **Evidence:** NODO DS.md corresponde al proyecto NODO del que derivó CHACO. Toda especificación de CHACO (chaco-tokens.json, CHACO_NODO_Design_Manual.md) supera a NODO DS.md en caso de conflicto. Donde NODO DS.md tiene datos que CHACO no documenta, se incorporan como valores de fallback.
-**Rationale:** CHACO es una adaptación de NODO con su propia identidad de marca. El color de marca es Jacaranda (#5059BC), no magenta (#FF0080). El gradiente del botón Brand es `#5059BC → #598DFF`.
+**Rationale:** CHACO es una adaptación de NODO con su propia identidad de marca. El color de marca es Jacaranda (#5059BC), no magenta (#FF0080). El gradiente del botón Brand es `#5059BC → #F98DFF` (Jacaranda → BG Pink, confirmado por la diseñadora; token: `var(--bg-pink)`).
 **How to apply:** Usar exclusivamente `chaco-tokens.json` / `chaco-tokens.css` / `CHACO_NODO_Design_Manual.md` como fuentes. Consultar NODO DS.md únicamente para componentes sin documentar en CHACO (tamaños exactos de botón, especificaciones de badge en hex).

--- a/docs/design-kb/implicit-rules.md
+++ b/docs/design-kb/implicit-rules.md
@@ -1,0 +1,136 @@
+# Implicit Rules
+**Inferred Design Principles — NODO Design System**
+
+Each rule includes confidence level, evidence, and rationale.
+
+---
+
+## Spacing Behavior
+
+### IR-S01: Base unit is 4px
+**Confidence:** HIGH
+**Evidence:** Component spacing values (2px, 4px, 6px, 8px, 10px, 12px, 16px, 20px, 24px, 28px, 32px) are all multiples of 4px.
+**Rationale:** A 4px base grid is the most common convention in modern design systems. The badge padding (2px/4px/6px) and button padding (6px/8px/10px/12px/14px) confirm the 4px step pattern.
+**How to apply:** When choosing a spacing value not documented, default to the nearest 4px multiple.
+
+### IR-S02: Form spacing follows an 8px rhythm
+**Confidence:** MEDIUM
+**Evidence:** Field gap 20px (5×4), section gap 32px (8×4). These are larger 4px multiples.
+**Rationale:** Forms use wider spacing for clarity between elements to prevent visual crowding on data-dense screens.
+**How to apply:** Between form fields: 20px. Between form sections: 32px. These are non-negotiable.
+
+### IR-S03: Internal card padding is ~20px
+**Confidence:** MEDIUM
+**Evidence:** Module card spec (15px/28px padding) and stat card spec (~20px padding).
+**Rationale:** Cards need enough breathing room for content hierarchy without wasting space.
+**How to apply:** Default card padding: 20–24px on all sides.
+
+---
+
+## Layout Behavior
+
+### IR-L01: Content hierarchy flows top-to-bottom, left-to-right
+**Confidence:** HIGH
+**Evidence:** Every documented screen (home, list view, detail view) follows: heading → context (stat cards) → search/filter → detail (table/charts) → actions.
+**Rationale:** Users scan top-to-bottom. Overview first, detail second. Context before interaction.
+**How to apply:** Never place search or filters above the summary/stat cards. Actions go at the end of a flow.
+
+### IR-L02: Right-alignment signals primary action
+**Confidence:** HIGH
+**Evidence:** All primary CTAs (⊕ Nuevo legajo, Crear Ciudadano, Export) are right-aligned on their row. Cancel/back buttons are left of primary.
+**Rationale:** Users read left-to-right. Heading/context on the left; the thing they need to "do" on the right.
+**How to apply:** Section heading + right-aligned Brand CTA is the default pattern. Never center the primary CTA.
+
+### IR-L03: Forms have a maximum width and are centered
+**Confidence:** HIGH
+**Evidence:** New Citizen form "~700px centered". Confirm Data form uses two columns within a limited width.
+**Rationale:** Wide forms are hard to scan. The eye needs to travel too far between label and input.
+**How to apply:** max-width ~700px for single-column forms. Multi-column forms may be slightly wider.
+
+### IR-L04: The sidebar is never hidden on desktop
+**Confidence:** HIGH
+**Evidence:** All authenticated screens show sidebar + content layout. No documented exception for internal screens.
+**Rationale:** The sidebar provides persistent navigation orientation. Hiding it creates disorientation.
+**How to apply:** Sidebar appears on all authenticated (post-login) screens. Never hide it programmatically on desktop.
+
+---
+
+## Hierarchy Behavior
+
+### IR-H01: One brand gradient element per visible area
+**Confidence:** HIGH
+**Evidence:** "One Brand button per section" rule. The gradient is visually dominant — its power comes from exclusivity.
+**Rationale:** The brand gradient is attention-commanding. Using it multiple times in the same view dilutes its impact and creates visual noise.
+**How to apply:** One gradient button per section. One gradient background element (total banner, sidebar logo). Multiple gradients = no gradient.
+
+### IR-H02: Text hierarchy: Heading → Body → Subtle — never mixed
+**Confidence:** HIGH
+**Evidence:** Explicit token mapping: `text-heading` for H1–H3, `text-body` for paragraphs, `text-body-subtle` for optional/secondary text.
+**Rationale:** Three levels of text contrast create a clear scanning hierarchy. Mixing them creates ambiguity.
+**How to apply:** Never use `text-body-subtle` for content that the user must read. Never use `text-heading` for helper/optional text.
+
+### IR-H03: State badges use both color AND text label
+**Confidence:** HIGH
+**Evidence:** Badges always show text ("BAJO", "ALTO", "Completa") alongside color coding.
+**Rationale:** Color alone fails accessibility requirements and is ambiguous for users with color vision deficiency.
+**How to apply:** Every status indicator must have a text label. Color reinforces, never replaces, the label.
+
+---
+
+## Visual Rhythm
+
+### IR-VR01: Border radius scales with element prominence
+**Confidence:** MEDIUM
+**Evidence:** Buttons: rounded-full (pills). Cards/modals: rounded-xl (12px). Inputs: rounded-lg (8px). Badges: rounded-md (6px) or rounded-full.
+**Rationale:** More prominent interactive elements (buttons) get maximum softness (pill). Containers get a significant but controlled radius. Small elements get proportional radius.
+**How to apply:** Interactive: rounded-full. Card containers: rounded-xl. Form inputs: rounded-lg. Small tags/badges: rounded-md to rounded-full.
+
+### IR-VR02: Shadow intensity scales with content importance
+**Confidence:** MEDIUM
+**Evidence:** Cards: sombra-sm default → sombra-md on hover. Modals/dropdowns: sombra-lg. The system deliberately avoids heavy shadows.
+**Rationale:** Minimal shadows keep the aesthetic clean. Shadow escalation on hover provides subtle affordance cues.
+**How to apply:** Resting surfaces: no shadow or sombra-sm. Hovered/active surfaces: sombra-md. Floating/overlay surfaces: sombra-lg or sombra-xl.
+
+---
+
+## Responsiveness Logic
+
+### IR-R01: The CSS files suggest mobile is a secondary concern
+**Confidence:** MEDIUM
+**Evidence:** Dedicated CSS files exist (mobile-forms.css, mobile-tables.css, mobile-modals.css) suggesting mobile was retrofitted rather than mobile-first. The sidebar behavior on mobile is undocumented.
+**Rationale:** The backoffice is primarily a desktop tool for government workers. Mobile is needed but not the primary use case.
+**How to apply:** Desktop design is primary. Mobile adaptations should be tested but the core experience assumes desktop.
+
+### IR-R02: New templates use Tailwind; legacy templates use Bootstrap
+**Confidence:** HIGH
+**Evidence:** NODO DS.md explicitly states: "Templates nuevos → Tailwind CSS. Templates legacy → Bootstrap 5.3.2 + AdminLTE."
+**Rationale:** The project is migrating from Bootstrap/AdminLTE to Tailwind incrementally. Both coexist.
+**How to apply:** NEVER mix Tailwind and Bootstrap classes in the same component. Check if the template is "new" or "legacy" before choosing the CSS approach.
+
+---
+
+## Consistency Patterns
+
+### IR-CP01: Every interactive element has three minimum states
+**Confidence:** HIGH
+**Evidence:** All documented components (button, input, sidebar item, table row) explicitly show default, hover, and focus states.
+**Rationale:** Accessibility requires visible focus. UX requires hover feedback. These are non-negotiable.
+**How to apply:** When creating any clickable or focusable element, define all three states before shipping.
+
+### IR-CP02: Brand gradient always goes purple→pink, never reversed
+**Confidence:** HIGH
+**Evidence:** All documented gradients: `linear-gradient(45deg, #7928CA, #FF0080)` or `linear-gradient(45deg, #5059BC, #F26DF9)`.
+**Rationale:** Direction encodes brand identity. Reversing it would be inconsistent.
+**How to apply:** Always purple/jacaranda as the start color, pink/rosa as the end color. Never reversed.
+
+### IR-CP03: Icon color always inherits from text token, never hardcoded
+**Confidence:** HIGH
+**Evidence:** Icon section states "Icons never have their own color — they inherit via text color tokens."
+**Rationale:** This allows icons to automatically adapt to dark mode and state changes.
+**How to apply:** Apply `text-[token]` class to the icon element. Never use `fill` or `stroke` with hardcoded values.
+
+### IR-CP04: The brand color in NODO DS.md is magenta (#FF0080) while the final design tokens use Jacaranda (#5059BC) as brand
+**Confidence:** HIGH
+**Evidence:** NODO DS.md §1 states brand color = `#FF0080`. chaco-tokens.json/css uses `--color-brand-*` as Jacaranda/purple (`#5059BC`). The button gradient uses both.
+**Rationale:** There appear to be two versions of the design system — an earlier one (NODO DS.md, magenta-first) and a newer one (chaco-tokens.json, Jacaranda/purple-first). The newer token system should be considered authoritative.
+**How to apply:** Use `chaco-tokens.json` / `chaco-tokens.css` tokens as the source of truth. The gradient button in both versions uses the purple→pink combination, so both systems are consistent on that.

--- a/docs/design-kb/patterns/authentication.md
+++ b/docs/design-kb/patterns/authentication.md
@@ -1,0 +1,71 @@
+# Pattern: Authentication
+**Source: CHACO_NODO_Design_Manual.md §13.1, §13.2**
+
+---
+
+## Overview
+
+Authentication screens (login, password recovery) use the **split-screen pattern** — the only place in the system where this layout is permitted.
+
+---
+
+## Login Screen
+
+**Layout:** Split screen
+- **Left (60%):** Decorative illustration area
+  - Background: wavy line texture in Jacaranda blue at low opacity
+  - Flat illustration: people working with development blocks (pink/magenta accents, black silhouettes)
+- **Right (40%):** Authentication form
+
+**Form content (top to bottom):**
+1. Heading: "Bienvenido a Nodo, tu Sistema Integral" — Gellat Extra Bold, `text-heading (#00203A)`
+2. Subheading: "Inicia Sesion" — Inter, smaller size
+3. Email field: input with EnvelopeIcon prefix, label "Email institucional"
+4. Password field: input with LockClosedIcon prefix, label "Contraseña"
+5. "¿Olvidaste tu contraseña?" link — `text-fg-brand`, `text-sm`
+6. "Recordarme" checkbox
+7. Primary CTA: Brand button — "Create account" (or localized equivalent) → arrow right
+8. "¿No estas registrado? Crear cuenta" — `text-body` with `text-fg-brand` link
+9. NODO logo + "Powered by ICom" text below
+
+---
+
+## Password Recovery Screen
+
+**Layout:** Centered on screen (not split-screen), with wavy texture on both sides
+
+**Content (top to bottom):**
+1. Heading: "Restablecer Contraseña" — Gellat Extra Bold, `text-heading`
+2. Email field: input with icon prefix
+3. reCAPTCHA widget (embedded)
+4. Instructional helper text: `text-body`, `text-sm`
+5. Primary CTA: Brand button — "Reestablecer contraseña"
+6. NODO logo below
+
+---
+
+## Rules
+
+- The split-screen layout is **exclusively for authentication screens**
+- Never apply split-screen layout to authenticated/internal screens
+- The Gellat font is **only for hero headings** on these screens
+- The NODO logo always appears on authentication screens
+- Password field must have toggle visibility option (UNKNOWN — not confirmed in specs)
+
+---
+
+## States
+
+- **Default:** Empty form, placeholder text visible
+- **Validation error:** Inline error below field, `border-danger`, `bg-danger-soft`
+- **Success:** Redirect to home or confirmation message
+- **CAPTCHA:** Embedded reCAPTCHA on recovery screen
+
+---
+
+## Accessibility
+
+- Form fields have visible labels (not just placeholders)
+- Required fields marked with `*` in `text-fg-danger`
+- Focus states visible on all inputs
+- CTA button announces action clearly

--- a/docs/design-kb/patterns/dashboard.md
+++ b/docs/design-kb/patterns/dashboard.md
@@ -1,0 +1,93 @@
+# Pattern: Dashboard (Home Screen)
+**Source: CHACO_NODO_Design_Manual.md §13.3**
+
+---
+
+## Overview
+
+The home screen is an information-dense dashboard that provides situational awareness at a glance. It follows a strict vertical section order and uses the sidebar + single content area layout.
+
+---
+
+## Layout
+
+```
+[TOPBAR — fixed]
+[SIDEBAR — fixed left, ~300px]
+[CONTENT AREA — scrollable]
+  Section 1: Personalized greeting
+  Section 2: Banner (reserved)
+  Section 3: Critical Alerts (conditional)
+  Section 4: Stat Cards grid (4 metrics)
+  Section 5: Monthly Trends chart
+  Section 6: Case Status chart (donut)
+  Section 7: Geographic Distribution (reserved)
+  Section 8: Real-Time Activity feed
+  Section 9: Quick Access shortcuts
+  Section 10: System Status indicators
+```
+
+---
+
+## Section Specifications
+
+### Section 1: Greeting
+- Personalized salutation + current date
+- "Sistema activo" badge: circle dot in `bg-success` (pulsing) + text, badge-success variant
+- No CTA
+
+### Section 2: Banner
+- Reserved area for announcements and communications
+- Empty by default until content is published
+
+### Section 3: Critical Alerts Panel
+- **Conditional** — rendered ONLY when alerts exist
+- See: `components/alert-panel.yaml`
+
+### Section 4: Stat Cards Grid
+- 4 cards in a horizontal row
+- See: `components/stat-card.yaml`
+- Metrics: Total Ciudadanos, Legajos Activos, Alertas Críticas, Seguimientos
+- Cards may have alert dot when category has active critical items
+
+### Section 5: Monthly Trends Chart
+- Line chart (Chart.js or ApexCharts)
+- Time selector: 7D / 30D / 90D
+- Colors: categorical token palette
+
+### Section 6: Case Status Chart
+- Donut chart with legend
+- Segment colors: categorical token palette
+
+### Section 7: Geographic Distribution
+- Map visualization — area reserved
+- Shows when map integration is available
+
+### Section 8: Real-Time Activity Feed
+- Header badge: "● En vivo" — pulsing green dot (`bg-success`) + text
+- Vertical list of recent events
+- Each item: circular icon + event name + actor + relative timestamp
+- Separator: `border-base` between items
+
+### Section 9: Quick Access Shortcuts
+- 4 icon shortcuts in a horizontal row
+- Examples: Gestionar Ciudadanos / Nuevo Registro / Reportes / Configuración
+- Icon: Heroicons, brand colored, larger size (w-8 h-8)
+- Label below icon: `text-xs`, `font-medium`, `text-body`
+
+### Section 10: System Status
+- 4 indicators with:
+  - Icon/illustration
+  - Progress bar: background `bg-quaternary`, fill with brand gradient
+  - Percentage text: `text-xs`, `text-body-subtle`
+- Examples: Servidor, Seguridad, etc.
+
+---
+
+## Rules
+
+- Section order must not be changed
+- Critical alerts section appears ONLY when alerts exist
+- Charts must have time selectors when showing temporal data
+- Geographic section is reserved — placeholder renders when map is unavailable
+- Real-time feed must handle the "no recent activity" empty state

--- a/docs/design-kb/patterns/empty-states.md
+++ b/docs/design-kb/patterns/empty-states.md
@@ -1,0 +1,85 @@
+# Pattern: Empty States
+**Source: NODO DS.md (pending documentation), CHACO_NODO_Design_Manual.md**
+
+---
+
+## Overview
+
+Empty states communicate the absence of data with context and (when applicable) a path forward. A blank space is never an acceptable empty state.
+
+---
+
+## When Empty States Are Required
+
+- Every data table with zero results
+- Every list view with no records
+- Real-time activity feed with no recent events
+- Search with no matching results
+- Notification panel with no notifications
+
+---
+
+## Structure
+
+```
+┌────────────────────────────┐
+│                            │
+│    [Illustration]          │
+│    w-12 h-12 or larger     │
+│                            │
+│    [Primary message]       │   ← text-heading, font-semibold, text-center
+│    No hay X registrados    │
+│                            │
+│    [Secondary message]     │   ← text-body, text-sm, text-center (optional)
+│    Crea el primero para    │
+│    empezar.                │
+│                            │
+│    [CTA (optional)]        │   ← Brand button if user can create
+│    ⊕ Nuevo X               │
+│                            │
+└────────────────────────────┘
+```
+
+---
+
+## Specifications
+
+| Element | Value |
+|---------|-------|
+| Illustration | Heroicons w-12 h-12, `text-fg-brand` or `text-body-subtle` |
+| Illustration alternative | Full illustrated SVG (larger, for prominent empty states) |
+| Primary message font | `text-base` or `text-lg`, `font-semibold`, `text-heading` |
+| Secondary message font | `text-sm`, `text-body` |
+| CTA | Brand button, only when creation is possible |
+| Container | centered vertically and horizontally within the table/list area |
+
+---
+
+## Specific Cases
+
+### Search empty state
+- Message: "Sin resultados para '[query]'"
+- No CTA (can't create from search)
+- Secondary: "Intenta con otros términos"
+
+### Filter empty state
+- Message: "No hay [entity] con estos filtros"
+- CTA: "Limpiar filtros" (Tertiary button, not Brand)
+
+### New entity (no records yet)
+- Message: "No hay [entity] registrados"
+- CTA: "⊕ Nuevo [entity]" — Brand button
+
+### Observations panel (citizen detail)
+- Shows illustration when no observations exist
+- No CTA unless user can add observations
+
+---
+
+## Rules
+
+- **Never** show a blank white area where content should be
+- **Never** show generic "No results" — always contextualize
+- **Never** show a CTA that the user doesn't have permission to use
+- Empty state illustrations use system icon colors (`text-fg-brand` or `text-body-subtle`)
+- Empty states should maintain the table/list structure (header visible, body replaced)

--- a/docs/design-kb/patterns/errors.md
+++ b/docs/design-kb/patterns/errors.md
@@ -1,0 +1,95 @@
+# Pattern: Error States & Feedback
+**Source: NODO DS.md (general rules), CHACO_NODO_Design_Manual.md**
+
+---
+
+## Overview
+
+Errors in NODO are handled at three layers: inline field validation, toast notifications, and confirmation modals for destructive actions. Each layer has a specific role and must not be substituted.
+
+---
+
+## Layer 1: Inline Field Validation
+
+**When:** Form field has invalid input
+**Where:** Immediately below the problematic field
+
+```
+[Label]
+[Input field — border-danger, bg-danger-soft]
+⚠ El email no es válido                          ← text-fg-danger, text-xs, with icon
+```
+
+**Rules:**
+- Error text is specific: "El email no es válido" not "Error"
+- Error icon: `ExclamationCircleIcon` or `fa-circle-exclamation` preceding the message
+- Border: `border-danger (#c70036) 1px`
+- Background: `bg-danger-soft (#fef0f2)`
+- Text: `text-fg-danger (#c70036)`, `text-xs`
+- Validation on blur (not on submit for known errors)
+- Never use `color: red` or non-tokenized values
+
+---
+
+## Layer 2: Toast Notifications (Toastr)
+
+**When:** Async operations complete (save, delete, network error)
+**Position:** Top-right corner, overlaying the interface
+
+| Type | Token | Example |
+|------|-------|---------|
+| Success | `bg-success` | "Ciudadano creado exitosamente" |
+| Error | `bg-danger` | "Error al guardar. Intenta nuevamente." |
+| Warning | `bg-warning` | "No se pudo sincronizar con RENAPER" |
+| Info | `bg-brand` | "Cambios guardados automáticamente" |
+
+**Rules:**
+- Auto-dismiss after a few seconds
+- Error toasts should persist until dismissed (never auto-dismiss errors silently)
+- Never show IDs, stack traces, or technical details to the user
+- Message format: clear, action-oriented, in Spanish
+
+---
+
+## Layer 3: Destructive Action Confirmation (SweetAlert2)
+
+**When:** User triggers a delete, hard reset, or any irreversible action
+
+```
+┌────────────────────────────────────┐
+│  ¿Estás seguro?                    │
+│  Esta acción no se puede deshacer. │
+│                                    │
+│     [Cancelar]    [Eliminar]       │
+│     (Secondary)   (Danger/Brand)   │
+└────────────────────────────────────┘
+```
+
+**Rules:**
+- **Always** use SweetAlert2 — never `window.confirm()`
+- **Always** use for: delete, deactivate, archive, bulk operations
+- Secondary button: "Cancelar" — cancels the action
+- Primary confirm button: "Eliminar" or action-specific label — proceeds
+- The confirm button style for destructive actions: Danger-styled (bg-danger or equivalent) NOT Brand button
+- Dialog title is always a question format
+
+---
+
+## Layer 4: System-Level Errors (Future)
+
+For network errors, server errors, or unavailable features:
+- Empty state with error illustration
+- Clear message: "No se pudo cargar la información. Intenta más tarde."
+- Retry CTA if applicable
+- Never show technical HTTP status codes or stack traces
+
+---
+
+## What Never to Do
+
+- Show `window.confirm()` for destructive actions
+- Show error messages only through color change
+- Use generic "Error" as the full error message
+- Show technical IDs or stack traces in user-facing messages
+- Allow destructive actions to proceed without confirmation
+- Auto-dismiss error toast notifications

--- a/docs/design-kb/patterns/forms.md
+++ b/docs/design-kb/patterns/forms.md
@@ -1,0 +1,116 @@
+# Pattern: Forms
+**Source: CHACO_NODO_Design_Manual.md §12.1, §13.5, §13.6, NODO DS.md §13**
+
+---
+
+## Overview
+
+Forms in NODO follow a strict set of layout and validation rules to ensure consistency and usability across all data entry screens.
+
+---
+
+## Layout Pattern
+
+```
+[Section title / heading]
+
+[Card wrapper — rounded-xl, border-base, bg-white]
+  [Form section heading — font-semibold]
+  
+  [Label *]        [Label *]
+  [Input]          [Input]         ← Inline row for related fields
+  
+  [Label *]
+  [Input — full width]
+  
+  [Helper / error text]
+  
+  [Label *]
+  [Select ∨]
+
+[Action row — right-aligned]
+  [← Volver (Tertiary)]   [Submit CTA (Brand)]
+```
+
+---
+
+## Field Rules
+
+- Label is **always above** the field — never floating or inside
+- Required fields: `*` in `text-fg-brand` next to label text
+- Placeholder: only for hint text, never as label replacement
+- Gap between fields: **20px**
+- Gap between form sections: **32px**
+
+---
+
+## Inline Fields
+
+Related fields appear on the same row:
+- Example: DNI + Sex (type/select) — 50/50 split width
+
+---
+
+## Validation Rules
+
+- **Inline validation** — error appears below the field that failed
+- **Error style:** `border-danger`, `bg-danger-soft` on field + `text-fg-danger` + exclamation icon below
+- **Error message format:** Specific and actionable ("El email no es válido") — never generic ("Error")
+- **Required indicator before submission** — marked upfront, not revealed after failure
+- **Library:**
+  - New templates: HTML5 native validation
+  - Legacy templates: `jquery-validate 1.19.5`
+
+---
+
+## Action Row
+
+- Positioned at the **bottom** of the form card
+- Right-aligned
+- Structure: `[← Volver (Tertiary)]` space `[Primary CTA (Brand)]`
+- Tertiary button for going back/canceling
+- Brand button for the primary submit action
+
+---
+
+## Multi-Step Forms
+
+Observed in: New Citizen flow (Step 1: DNI query → Step 2: Confirm data)
+
+- Breadcrumb/step indicator at top of page — see `components/breadcrumb.yaml`
+- Step 1 (Nuevo Ciudadano):
+  - Card: icon + title + subtitle ("Consulta automática con RENAPER")
+  - Fields: DNI + Sex (inline row)
+  - Actions: `← Volver` (Tertiary) + `Consulta Renaper` (Brand)
+  
+- Step 2 (Confirmar Datos):
+  - Two-column layout (35% RENAPER data / 65% editable form)
+  - Left: read-only RENAPER card (see `components/card-renaper.yaml`)
+  - Right: editable form with sections (Datos del Ciudadano, Contacto, Domicilio)
+  - Actions: `← Volver` (Tertiary) + `⊕ Crear Ciudadano` (Brand)
+
+---
+
+## RENAPER Integration Pattern
+
+Pre-filled data from RENAPER must be visually distinguished:
+- Read-only style: `bg-white` with helper text explaining the lock
+- Helper text: brief note in `text-xs`, `text-body-subtle` about RENAPER source
+- Editable fields: normal input styling
+- The user should never confuse locked data for editable data
+
+---
+
+## Form Width
+
+- **Max width: ~700px**
+- **Centered** within the content area
+- Not full-width — forms that stretch 100% are a design violation
+
+---
+
+## Empty / Pre-filled States
+
+- New entity: all fields empty with placeholder hints
+- Edit entity: pre-filled with current values, editable
+- RENAPER query result: some fields pre-filled (read-only), user completes the rest

--- a/docs/design-kb/patterns/forms.md
+++ b/docs/design-kb/patterns/forms.md
@@ -37,7 +37,7 @@ Forms in NODO follow a strict set of layout and validation rules to ensure consi
 ## Field Rules
 
 - Label is **always above** the field — never floating or inside
-- Required fields: `*` in `text-fg-brand` next to label text
+- Required fields: `*` in `text-fg-danger` (#c70036) next to label text
 - Placeholder: only for hint text, never as label replacement
 - Gap between fields: **20px**
 - Gap between form sections: **32px**
@@ -103,9 +103,12 @@ Pre-filled data from RENAPER must be visually distinguished:
 
 ## Form Width
 
-- **Max width: ~700px**
-- **Centered** within the content area
+- **Max width: 768px** (Tailwind `max-w-3xl` — 48rem)
+- This value is **FIXED and uniform** — it must not be adjusted per-form, per-section, or per-screen
 - Not full-width — forms that stretch 100% are a design violation
+- Not narrower than 768px — narrowing for aesthetic or content reasons creates inconsistency
+
+**Anti-pattern:** Adjusting form max-width to fit content is a common failure mode. When different forms in the same flow have different widths, the UI feels broken even if each screen looks fine in isolation. 768px is the system constant — apply it to every form, always.
 
 ---
 

--- a/docs/design-kb/patterns/loading-states.md
+++ b/docs/design-kb/patterns/loading-states.md
@@ -1,0 +1,56 @@
+# Pattern: Loading States
+**Source: NODO DS.md (general rules), CHACO_NODO_Design_Manual.md**
+
+---
+
+## Overview
+
+Loading states preserve layout stability and prevent jarring shifts. The system uses skeletons for content areas and inline spinners for button-triggered actions.
+
+---
+
+## Types
+
+### 1. Button Loading State
+- **Trigger:** User clicks a Brand or Tertiary button that initiates an async operation
+- **Behavior:** Spinner replaces the button label text
+- **Rule:** Button width does NOT change during loading
+- **Style:** Spinner in the same color as the normal button text (white for Brand, brand color for Tertiary)
+- **Disabled:** Button should be disabled during loading to prevent double-submission
+
+### 2. Table / List Skeleton
+- **Trigger:** Table data is being fetched
+- **Behavior:** Column headers remain visible; rows replaced with skeleton rows
+- **Skeleton rows:** Neutral gray animated pulse bars at the approximate width/height of actual content
+- **Number of skeleton rows:** Should match the expected page size (e.g., 10 rows)
+
+### 3. Card Skeleton
+- **Trigger:** Card data is being fetched
+- **Behavior:** Card border and container visible; content replaced with pulse bars
+- **Style:** `bg-quaternary` animated pulse matching content zones
+
+### 4. Stat Card Loading
+- **Trigger:** Dashboard metrics loading
+- **Behavior:** Stat card shape preserved; number and label replaced with skeleton bars
+
+---
+
+## Skeleton Styling
+
+| Element | Value |
+|---------|-------|
+| Background | `bg-quaternary (#e5e7eb)` |
+| Animation | CSS pulse (opacity or shimmer) |
+| Border radius | Matches the content it replaces |
+| Duration | Loading until data arrives — not time-based |
+
+---
+
+## Rules
+
+- **Never** replace an entire section with a full-page spinner
+- **Never** change button size during loading
+- **Always** maintain layout structure during loads (skeleton shapes match actual content geometry)
+- **Never** show a loading state for less than 200ms — instant responses don't need loading feedback
+- **Table loads:** Keep table header visible while rows skeleton-load
+- **Form submits:** Disable submit button and show spinner — re-enable only on error, navigate on success

--- a/docs/design-kb/patterns/tables.md
+++ b/docs/design-kb/patterns/tables.md
@@ -1,0 +1,93 @@
+# Pattern: Tables (List Views)
+**Source: CHACO_NODO_Design_Manual.md §12.4, §12.7, §13.4, NODO DS.md §9**
+
+---
+
+## Overview
+
+List views follow a consistent pattern: **stat cards → search → filters → table**.
+This pattern appears for all entity list screens (Citizens, Organizations, Programs, etc.).
+
+---
+
+## Screen Layout (Ciudadanos en Tratamiento example)
+
+```
+[Heading] [Subtitle]                    [⊕ Nuevo legajo (Brand →)]
+
+[Stat Card] [Stat Card] [Stat Card] [Stat Card] [Stat Card] [Stat Card]
+
+[🔍 Search input — full width]
+
+[Filter ∨] [Filter ∨] [Toggle] [Toggle]          [↓ Exportar (Tertiary)]
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ CIUDADANO │ DNI │ DISPOSITIVO │ RESPONSABLE │ RIESGO │ ESTADO │ ⓘ  │
+├───────────┼─────┼─────────────┼─────────────┼────────┼────────┼────┤
+│ [avatar]  │     │             │             │ badge  │ badge  │ 👁  │
+│ Nombre    │     │             │             │        │        │     │
+└─────────────────────────────────────────────────────────────────────┘
+│ Mostrando 1-10 of 247              [‹] [1 de 25] [›]               │
+```
+
+---
+
+## Section Rules
+
+### Heading Row
+- Left: Section H1 + subtitle (smaller, `text-body-subtle`)
+- Right: Primary CTA Brand button (e.g., "⊕ Nuevo legajo")
+- **CTA always right-aligned** — never centered, never left
+
+### Stat Cards
+- 4–6 cards depending on the entity
+- Above the search/filter row
+- Provide aggregate context before the user interacts with the table
+
+### Search Bar
+- Full-width input
+- MagnifyingGlassIcon prefix
+- Placeholder: descriptive with minimum character hint (e.g., "Buscar por nombre, DNI...")
+- Style: Secondary input (bg-secondary-soft, border-base)
+
+### Filter Row
+- Horizontal row of filter controls
+- Chip/button style (bg-white, border-base, rounded-md)
+- Active filter: `border-brand`, `text-fg-brand`
+- Export button: right-aligned, Tertiary style + download icon
+- Filter examples: "Todos los riesgos ∨", "Todos los estados ∨", "🔔 Con alertas", "📅 Sin plan vigente"
+
+### Data Table
+- See: `components/data-table.yaml`
+- No alternating row colors
+- Hover: `bg-tertiary`
+- Status column: badge variants (success/warning/danger)
+- Actions column: always last, fixed width
+
+### Pagination
+- "Mostrando X-Y of Z" left
+- [‹] [Page indicator] [›] — Tertiary buttons, centered or right
+
+---
+
+## Empty State
+
+Every table must have an empty state:
+- Illustration (w-12 h-12 or larger, `text-fg-brand` or neutral)
+- Message: contextual ("No hay ciudadanos registrados" not "No results")
+- Optional CTA: if the user can create a new record, show the Brand button
+
+---
+
+## Loading State
+
+- Skeleton rows while data loads
+- Maintains table structure (header visible, rows as skeletons)
+- No spinner in place of the entire table
+
+---
+
+## Responsive
+
+- Table scrolls horizontally on small screens (UNKNOWN — dedicated mobile-tables.css exists)
+- Stat cards grid collapses (UNKNOWN — exact breakpoint not documented)

--- a/docs/design-kb/tokens/chaco-tokens.json
+++ b/docs/design-kb/tokens/chaco-tokens.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://design-tokens.github.io/community-group/format/",
+  "$metadata": {
+    "product": "CHACO NODO",
+    "version": "1.0",
+    "source": "Figma Variables",
+    "modes": ["light", "dark"]
+  },
+  "color": {
+    "primitive": {
+      "brand": {
+        "050": { "$type": "color", "$value": "#f5f3ff" },
+        "100": { "$type": "color", "$value": "#ede9fe" },
+        "200": { "$type": "color", "$value": "#ddd6fe" },
+        "500": { "$type": "color", "$value": "#5059bc" },
+        "600": { "$type": "color", "$value": "#5059bc" },
+        "700": { "$type": "color", "$value": "#5059bc" },
+        "800": { "$type": "color", "$value": "#4338ca" },
+        "900": { "$type": "color", "$value": "#3730a3" },
+        "950": { "$type": "color", "$value": "#1e1b4b" }
+      },
+      "pink": {
+        "050": { "$type": "color", "$value": "#fef3ff" },
+        "100": { "$type": "color", "$value": "#fee9ff" },
+        "200": { "$type": "color", "$value": "#fee3ff" },
+        "600": { "$type": "color", "$value": "#f98dff" },
+        "700": { "$type": "color", "$value": "#f26df9" },
+        "800": { "$type": "color", "$value": "#dd5fe4" },
+        "900": { "$type": "color", "$value": "#bf57c4" },
+        "950": { "$type": "color", "$value": "#9b499f" }
+      },
+      "gray": {
+        "050": { "$type": "color", "$value": "#f9fafb" },
+        "100": { "$type": "color", "$value": "#f3f4f6" },
+        "200": { "$type": "color", "$value": "#e5e7eb" },
+        "300": { "$type": "color", "$value": "#d1d5db" },
+        "400": { "$type": "color", "$value": "#9ca3af" },
+        "500": { "$type": "color", "$value": "#6b7280" },
+        "600": { "$type": "color", "$value": "#4b5563" },
+        "700": { "$type": "color", "$value": "#374151" },
+        "800": { "$type": "color", "$value": "#1f2937" },
+        "900": { "$type": "color", "$value": "#111827" },
+        "950": { "$type": "color", "$value": "#030712" }
+      },
+      "emerald": {
+        "050": { "$type": "color", "$value": "#ecfdf5" },
+        "100": { "$type": "color", "$value": "#d0fae5" },
+        "200": { "$type": "color", "$value": "#a4f4cf" },
+        "600": { "$type": "color", "$value": "#009966" },
+        "700": { "$type": "color", "$value": "#007a55" },
+        "800": { "$type": "color", "$value": "#006045" },
+        "900": { "$type": "color", "$value": "#004f3b" },
+        "950": { "$type": "color", "$value": "#002c22" }
+      },
+      "rose": {
+        "050": { "$type": "color", "$value": "#fef0f2" },
+        "100": { "$type": "color", "$value": "#ffe4e6" },
+        "200": { "$type": "color", "$value": "#ffccd3" },
+        "500": { "$type": "color", "$value": "#ff2056" },
+        "600": { "$type": "color", "$value": "#ec003f" },
+        "700": { "$type": "color", "$value": "#c70036" },
+        "800": { "$type": "color", "$value": "#a50036" },
+        "900": { "$type": "color", "$value": "#8b0836" },
+        "950": { "$type": "color", "$value": "#4d0218" }
+      },
+      "orange": {
+        "050": { "$type": "color", "$value": "#fff8f1" },
+        "100": { "$type": "color", "$value": "#feecdc" },
+        "200": { "$type": "color", "$value": "#fcd9bd" },
+        "400": { "$type": "color", "$value": "#ff8a4c" },
+        "500": { "$type": "color", "$value": "#ff5a1f" },
+        "600": { "$type": "color", "$value": "#d03801" },
+        "700": { "$type": "color", "$value": "#b43403" },
+        "900": { "$type": "color", "$value": "#771d1d" }
+      }
+    },
+    "semantic": {
+      "background": {
+        "light": {
+          "bg-white":             { "$type": "color", "$value": "#ffffff" },
+          "bg-primary":           { "$type": "color", "$value": "#ffffff" },
+          "bg-primary-soft":      { "$type": "color", "$value": "#ffffff" },
+          "bg-secondary-soft":    { "$type": "color", "$value": "#f9fafb" },
+          "bg-secondary":         { "$type": "color", "$value": "#f9fafb" },
+          "bg-tertiary":          { "$type": "color", "$value": "#f3f4f6" },
+          "bg-quaternary":        { "$type": "color", "$value": "#e5e7eb" },
+          "bg-gray":              { "$type": "color", "$value": "#d1d5db" },
+          "bg-brand-softer":      { "$type": "color", "$value": "#fef3ff" },
+          "bg-brand-soft":        { "$type": "color", "$value": "#fee9ff" },
+          "bg-brand-medium":      { "$type": "color", "$value": "#fee3ff" },
+          "bg-brand":             { "$type": "color", "$value": "#5059bc" },
+          "bg-brand-strong":      { "$type": "color", "$value": "#4338ca" },
+          "bg-success-soft":      { "$type": "color", "$value": "#ecfdf5" },
+          "bg-success-medium":    { "$type": "color", "$value": "#d0fae5" },
+          "bg-success":           { "$type": "color", "$value": "#007a55" },
+          "bg-success-strong":    { "$type": "color", "$value": "#006045" },
+          "bg-danger-soft":       { "$type": "color", "$value": "#fef0f2" },
+          "bg-danger-medium":     { "$type": "color", "$value": "#ffe4e6" },
+          "bg-danger":            { "$type": "color", "$value": "#c70036" },
+          "bg-danger-strong":     { "$type": "color", "$value": "#a50036" },
+          "bg-warning-soft":      { "$type": "color", "$value": "#fff8f1" },
+          "bg-warning-medium":    { "$type": "color", "$value": "#feecdc" },
+          "bg-warning":           { "$type": "color", "$value": "#ff5a1f" },
+          "bg-warning-strong":    { "$type": "color", "$value": "#b43403" },
+          "bg-disabled":          { "$type": "color", "$value": "#f3f4f6" },
+          "bg-dark":              { "$type": "color", "$value": "#1f2937" },
+          "bg-dark-strong":       { "$type": "color", "$value": "#111827" }
+        },
+        "dark": {
+          "bg-primary-soft":      { "$type": "color", "$value": "#111827" },
+          "bg-primary":           { "$type": "color", "$value": "#030712" },
+          "bg-secondary-soft":    { "$type": "color", "$value": "#111827" },
+          "bg-secondary":         { "$type": "color", "$value": "#030712" },
+          "bg-tertiary":          { "$type": "color", "$value": "#1f2937" },
+          "bg-quaternary":        { "$type": "color", "$value": "#374151" },
+          "bg-gray":              { "$type": "color", "$value": "#4b5563" },
+          "bg-brand-softer":      { "$type": "color", "$value": "#1e1b4b" },
+          "bg-brand":             { "$type": "color", "$value": "#5059bc" },
+          "bg-success-soft":      { "$type": "color", "$value": "#002c22" },
+          "bg-success":           { "$type": "color", "$value": "#009966" },
+          "bg-danger-soft":       { "$type": "color", "$value": "#4d0218" },
+          "bg-danger":            { "$type": "color", "$value": "#c70036" },
+          "bg-warning-soft":      { "$type": "color", "$value": "#441306" },
+          "bg-warning":           { "$type": "color", "$value": "#d03801" },
+          "bg-disabled":          { "$type": "color", "$value": "#1f2937" }
+        }
+      },
+      "text": {
+        "light": {
+          "text-heading":           { "$type": "color", "$value": "#111827" },
+          "text-body":              { "$type": "color", "$value": "#4b5563" },
+          "text-body-subtle":       { "$type": "color", "$value": "#6b7280" },
+          "text-fg-brand":          { "$type": "color", "$value": "#5059bc" },
+          "text-fg-brand-strong":   { "$type": "color", "$value": "#3730a3" },
+          "text-fg-success":        { "$type": "color", "$value": "#007a55" },
+          "text-fg-success-strong": { "$type": "color", "$value": "#004f3b" },
+          "text-fg-danger":         { "$type": "color", "$value": "#c70036" },
+          "text-fg-danger-strong":  { "$type": "color", "$value": "#8b0836" },
+          "text-fg-warning-subtle": { "$type": "color", "$value": "#d03801" },
+          "text-fg-warning":        { "$type": "color", "$value": "#771d1d" },
+          "text-fg-disabled":       { "$type": "color", "$value": "#9ca3af" }
+        },
+        "dark": {
+          "text-heading":           { "$type": "color", "$value": "#ffffff" },
+          "text-body":              { "$type": "color", "$value": "#9ca3af" },
+          "text-body-subtle":       { "$type": "color", "$value": "#9ca3af" },
+          "text-fg-brand":          { "$type": "color", "$value": "#5059bc" },
+          "text-fg-danger":         { "$type": "color", "$value": "#ff2056" },
+          "text-fg-disabled":       { "$type": "color", "$value": "#4b5563" }
+        }
+      }
+    }
+  },
+  "typography": {
+    "fontFamily": {
+      "base":  { "$type": "fontFamily", "$value": ["Inter", "sans-serif"] },
+      "brand": { "$type": "fontFamily", "$value": ["Gellat", "sans-serif"], "$description": "Solo para hero headings en pantallas de acceso" }
+    },
+    "fontSize": {
+      "xxs":  { "$type": "dimension", "$value": "8px" },
+      "xs":   { "$type": "dimension", "$value": "12px" },
+      "sm":   { "$type": "dimension", "$value": "14px" },
+      "base": { "$type": "dimension", "$value": "16px" },
+      "lg":   { "$type": "dimension", "$value": "18px" },
+      "xl":   { "$type": "dimension", "$value": "20px" },
+      "2xl":  { "$type": "dimension", "$value": "24px" },
+      "3xl":  { "$type": "dimension", "$value": "30px" },
+      "4xl":  { "$type": "dimension", "$value": "36px" },
+      "5xl":  { "$type": "dimension", "$value": "48px" },
+      "6xl":  { "$type": "dimension", "$value": "60px" }
+    },
+    "fontWeight": {
+      "normal":    { "$type": "fontWeight", "$value": 400 },
+      "medium":    { "$type": "fontWeight", "$value": 500 },
+      "semibold":  { "$type": "fontWeight", "$value": 600 },
+      "bold":      { "$type": "fontWeight", "$value": 700 },
+      "extrabold": { "$type": "fontWeight", "$value": 800 }
+    },
+    "letterSpacing": {
+      "tighter": { "$type": "dimension", "$value": "-0.8px" },
+      "tight":   { "$type": "dimension", "$value": "-0.4px" },
+      "normal":  { "$type": "dimension", "$value": "0px" }
+    }
+  },
+  "border": {
+    "radius": {
+      "0":    { "$type": "dimension", "$value": "0px" },
+      "sm":   { "$type": "dimension", "$value": "2px" },
+      "base": { "$type": "dimension", "$value": "4px" },
+      "md":   { "$type": "dimension", "$value": "6px" },
+      "lg":   { "$type": "dimension", "$value": "8px" },
+      "xl":   { "$type": "dimension", "$value": "12px" },
+      "2xl":  { "$type": "dimension", "$value": "16px" },
+      "3xl":  { "$type": "dimension", "$value": "24px" },
+      "full": { "$type": "dimension", "$value": "9999px" }
+    },
+    "width": {
+      "0":  { "$type": "dimension", "$value": "0px" },
+      "1":  { "$type": "dimension", "$value": "1px" },
+      "2":  { "$type": "dimension", "$value": "2px" },
+      "4":  { "$type": "dimension", "$value": "4px" },
+      "8":  { "$type": "dimension", "$value": "8px" }
+    }
+  },
+  "layout": {
+    "maxWidth": {
+      "xs":  { "$type": "dimension", "$value": "320px" },
+      "sm":  { "$type": "dimension", "$value": "384px" },
+      "md":  { "$type": "dimension", "$value": "448px" },
+      "lg":  { "$type": "dimension", "$value": "512px" },
+      "xl":  { "$type": "dimension", "$value": "576px" },
+      "2xl": { "$type": "dimension", "$value": "672px" },
+      "3xl": { "$type": "dimension", "$value": "768px" },
+      "4xl": { "$type": "dimension", "$value": "896px" },
+      "5xl": { "$type": "dimension", "$value": "1024px" },
+      "6xl": { "$type": "dimension", "$value": "1152px" },
+      "7xl": { "$type": "dimension", "$value": "1280px" }
+    },
+    "container": {
+      "xs":  { "$type": "dimension", "$value": "380px" },
+      "sm":  { "$type": "dimension", "$value": "640px" },
+      "md":  { "$type": "dimension", "$value": "768px" },
+      "lg":  { "$type": "dimension", "$value": "1024px" },
+      "xl":  { "$type": "dimension", "$value": "1280px" },
+      "2xl": { "$type": "dimension", "$value": "1563px" }
+    }
+  }
+}

--- a/docs/design-kb/tokens/design-tokens.yaml
+++ b/docs/design-kb/tokens/design-tokens.yaml
@@ -1,0 +1,419 @@
+# =============================================================
+# NODO Design System — Consolidated Design Tokens
+# Source: chaco-tokens.json (W3C Design Tokens Format)
+# Implementation: chaco-tokens.css, chaco-tailwind.config.js
+# =============================================================
+#
+# HOW TO USE:
+# - CSS: import chaco-tokens.css, reference via var(--token-name)
+# - Tailwind: extend tailwind.config.js from chaco-tailwind.config.js
+# - Style Dictionary: source chaco-tokens.json
+# - Dark mode: add data-theme="dark" or .dark class to <html>/<body>
+#
+# CRITICAL RULE:
+# Never hardcode hex values in components.
+# Always use semantic tokens. Primitive scales are internal reference only.
+#
+# NAMING CONVENTIONS:
+# bg-[role]-[modifier]    → background tokens
+# border-[role]-[modifier] → border tokens
+# text-[role]              → neutral text tokens (no -fg prefix)
+# text-fg-[role]-[modifier] → colored/semantic text tokens
+# --font-*                 → typography tokens
+# --rounded-*              → border radius tokens
+# --border-width-*         → border width tokens
+# --max-w-*                → max width layout tokens
+# --container-*            → container breakpoints
+# =============================================================
+
+meta:
+  schema: "https://design-tokens.github.io/community-group/format/"
+  product: "CHACO NODO"
+  version: "1.0"
+  source: "Figma Variables"
+  modes: [light, dark]
+  files:
+    css: "chaco-tokens.css"
+    tailwind: "chaco-tailwind.config.js"
+    json: "chaco-tokens.json"
+  dark_mode_trigger:
+    attribute: 'data-theme="dark"'
+    class: ".dark"
+
+# -------------------------------------------------------------
+# COMPLETE TOKEN INVENTORY
+# -------------------------------------------------------------
+
+# Background tokens (--bg-*)
+background_tokens:
+  # Neutral
+  - token: "bg-white"
+    css_var: "--bg-white"
+    tailwind: "bg-bg-white"
+    light: "#ffffff"
+    dark: "#ffffff"
+
+  - token: "bg-primary-soft"
+    css_var: "--bg-primary-soft"
+    tailwind: "bg-bg-primary-soft"
+    light: "#ffffff"
+    dark: "var(--color-gray-900)"
+
+  - token: "bg-primary"
+    css_var: "--bg-primary"
+    tailwind: "bg-bg-primary"
+    light: "#ffffff"
+    dark: "var(--color-gray-950)"
+
+  - token: "bg-primary-medium"
+    css_var: "--bg-primary-medium"
+    tailwind: "bg-bg-primary-medium"
+    light: "#ffffff"
+    dark: "var(--color-gray-800)"
+
+  - token: "bg-primary-strong"
+    css_var: "--bg-primary-strong"
+    tailwind: "bg-bg-primary-strong"
+    light: "#ffffff"
+    dark: "var(--color-gray-700)"
+
+  - token: "bg-secondary-soft"
+    css_var: "--bg-secondary-soft"
+    tailwind: "bg-bg-secondary-soft"
+    light: "var(--color-gray-050)"
+    dark: "var(--color-gray-900)"
+
+  - token: "bg-secondary"
+    css_var: "--bg-secondary"
+    tailwind: "bg-bg-secondary"
+    light: "var(--color-gray-050)"
+    dark: "var(--color-gray-950)"
+
+  - token: "bg-secondary-medium"
+    css_var: "--bg-secondary-medium"
+    tailwind: "bg-bg-secondary-medium"
+    light: "var(--color-gray-050)"
+    dark: "var(--color-gray-800)"
+
+  - token: "bg-secondary-strong"
+    css_var: "--bg-secondary-strong"
+    tailwind: "bg-bg-secondary-strong"
+    light: "var(--color-gray-050)"
+    dark: "var(--color-gray-700)"
+
+  - token: "bg-tertiary-soft"
+    css_var: "--bg-tertiary-soft"
+    tailwind: "bg-bg-tertiary-soft"
+    light: "var(--color-gray-100)"
+    dark: "var(--color-gray-900)"
+
+  - token: "bg-tertiary"
+    css_var: "--bg-tertiary"
+    tailwind: "bg-bg-tertiary"
+    light: "var(--color-gray-100)"
+    dark: "var(--color-gray-800)"
+
+  - token: "bg-tertiary-medium"
+    css_var: "--bg-tertiary-medium"
+    tailwind: "bg-bg-tertiary-medium"
+    light: "var(--color-gray-100)"
+    dark: "var(--color-gray-700)"
+
+  - token: "bg-quaternary"
+    css_var: "--bg-quaternary"
+    tailwind: "bg-bg-quaternary"
+    light: "var(--color-gray-200)"
+    dark: "var(--color-gray-700)"
+
+  - token: "bg-quaternary-medium"
+    css_var: "--bg-quaternary-medium"
+    tailwind: "bg-bg-quaternary-medium"
+    light: "var(--color-gray-200)"
+    dark: "var(--color-gray-600)"
+
+  - token: "bg-gray"
+    css_var: "--bg-gray"
+    tailwind: "bg-bg-gray"
+    light: "var(--color-gray-300)"
+    dark: "var(--color-gray-600)"
+
+  - token: "bg-disabled"
+    css_var: "--bg-disabled"
+    tailwind: "bg-bg-disabled"
+    light: "var(--color-gray-100)"
+    dark: "var(--color-gray-800)"
+
+  - token: "bg-dark"
+    css_var: "--bg-dark"
+    tailwind: "bg-bg-dark"
+    light: "var(--color-gray-800)"
+    dark: "var(--color-gray-800)"
+
+  - token: "bg-dark-strong"
+    css_var: "--bg-dark-strong"
+    tailwind: "bg-bg-dark-strong"
+    light: "var(--color-gray-900)"
+    dark: "var(--color-gray-800)"
+
+  # Brand
+  - token: "bg-brand-softer"
+    css_var: "--bg-brand-softer"
+    tailwind: "bg-bg-brand-softer"
+    light: "var(--color-pink-050)"
+    dark: "var(--color-brand-950)"
+
+  - token: "bg-brand-soft"
+    css_var: "--bg-brand-soft"
+    tailwind: "bg-bg-brand-soft"
+    light: "var(--color-pink-100)"
+    dark: "var(--color-brand-900)"
+
+  - token: "bg-brand-medium"
+    css_var: "--bg-brand-medium"
+    tailwind: "bg-bg-brand-medium"
+    light: "var(--color-pink-200)"
+    dark: "var(--color-brand-900)"
+
+  - token: "bg-brand"
+    css_var: "--bg-brand"
+    tailwind: "bg-bg-brand"
+    light: "var(--color-brand-700)"
+    dark: "var(--color-brand-600)"
+
+  - token: "bg-brand-strong"
+    css_var: "--bg-brand-strong"
+    tailwind: "bg-bg-brand-strong"
+    light: "var(--color-brand-800)"
+    dark: "var(--color-brand-700)"
+
+  # Success
+  - token: "bg-success-soft"
+    css_var: "--bg-success-soft"
+    tailwind: "bg-bg-success-soft"
+    light: "var(--color-emerald-050)"
+    dark: "var(--color-emerald-950)"
+
+  - token: "bg-success-medium"
+    css_var: "--bg-success-medium"
+    tailwind: "bg-bg-success-medium"
+    light: "var(--color-emerald-100)"
+    dark: "var(--color-emerald-800)"
+
+  - token: "bg-success"
+    css_var: "--bg-success"
+    tailwind: "bg-bg-success"
+    light: "var(--color-emerald-700)"
+    dark: "var(--color-emerald-600)"
+
+  - token: "bg-success-strong"
+    css_var: "--bg-success-strong"
+    tailwind: "bg-bg-success-strong"
+    light: "var(--color-emerald-800)"
+    dark: "var(--color-emerald-700)"
+
+  # Danger
+  - token: "bg-danger-soft"
+    css_var: "--bg-danger-soft"
+    tailwind: "bg-bg-danger-soft"
+    light: "var(--color-rose-050)"
+    dark: "var(--color-rose-950)"
+
+  - token: "bg-danger-medium"
+    css_var: "--bg-danger-medium"
+    tailwind: "bg-bg-danger-medium"
+    light: "var(--color-rose-100)"
+    dark: "var(--color-rose-900)"
+
+  - token: "bg-danger"
+    css_var: "--bg-danger"
+    tailwind: "bg-bg-danger"
+    light: "var(--color-rose-700)"
+    dark: "var(--color-rose-700)"
+
+  - token: "bg-danger-strong"
+    css_var: "--bg-danger-strong"
+    tailwind: "bg-bg-danger-strong"
+    light: "var(--color-rose-800)"
+    dark: "var(--color-rose-700)"
+
+  # Warning
+  - token: "bg-warning-soft"
+    css_var: "--bg-warning-soft"
+    tailwind: "bg-bg-warning-soft"
+    light: "var(--color-orange-050)"
+    dark: "#441306"
+
+  - token: "bg-warning-medium"
+    css_var: "--bg-warning-medium"
+    tailwind: "bg-bg-warning-medium"
+    light: "var(--color-orange-100)"
+    dark: "var(--color-orange-900)"
+
+  - token: "bg-warning"
+    css_var: "--bg-warning"
+    tailwind: "bg-bg-warning"
+    light: "var(--color-orange-500)"
+    dark: "var(--color-orange-600)"
+
+  - token: "bg-warning-strong"
+    css_var: "--bg-warning-strong"
+    tailwind: "bg-bg-warning-strong"
+    light: "var(--color-orange-700)"
+    dark: "UNKNOWN"
+
+  # Categorical
+  - token: "bg-purple"
+    css_var: "--bg-purple"
+    tailwind: "bg-bg-purple"
+    value: "var(--color-purple-500)"
+    use: "Data visualization only"
+
+  - token: "bg-sky"
+    css_var: "--bg-sky"
+    tailwind: "bg-bg-sky"
+    value: "var(--color-sky-500)"
+    use: "Data visualization only"
+
+  - token: "bg-teal"
+    css_var: "--bg-teal"
+    tailwind: "bg-bg-teal"
+    value: "var(--color-teal-600)"
+    use: "Data visualization only"
+
+  - token: "bg-pink"
+    css_var: "--bg-pink"
+    tailwind: "bg-bg-pink"
+    value: "var(--color-pink-600)"
+    use: "Data visualization only"
+
+  - token: "bg-cyan"
+    css_var: "--bg-cyan"
+    tailwind: "bg-bg-cyan"
+    value: "var(--color-cyan-500)"
+    use: "Data visualization only"
+
+  - token: "bg-fuchsia"
+    css_var: "--bg-fuchsia"
+    tailwind: "bg-bg-fuchsia"
+    value: "var(--color-fuchsia-600)"
+    use: "Data visualization only"
+
+  - token: "bg-indigo"
+    css_var: "--bg-indigo"
+    tailwind: "bg-bg-indigo"
+    value: "var(--color-indigo-600)"
+    use: "Data visualization only"
+
+  - token: "bg-orange"
+    css_var: "--bg-orange"
+    tailwind: "bg-bg-orange"
+    value: "var(--color-orange-400)"
+    use: "Data visualization only"
+
+# Typography tokens (--font-*)
+typography_tokens:
+  - token: "font-family-base"
+    css_var: "--font-family-base"
+    value: "'Inter', sans-serif"
+  - token: "font-family-brand"
+    css_var: "--font-family-brand"
+    value: "'Gellat', sans-serif"
+  - token: "font-size-xxs"
+    css_var: "--font-size-xxs"
+    value: "8px"
+  - token: "font-size-xs"
+    css_var: "--font-size-xs"
+    value: "12px"
+  - token: "font-size-sm"
+    css_var: "--font-size-sm"
+    value: "14px"
+  - token: "font-size-base"
+    css_var: "--font-size-base"
+    value: "16px"
+  - token: "font-size-lg"
+    css_var: "--font-size-lg"
+    value: "18px"
+  - token: "font-size-xl"
+    css_var: "--font-size-xl"
+    value: "20px"
+  - token: "font-size-2xl"
+    css_var: "--font-size-2xl"
+    value: "24px"
+  - token: "font-size-3xl"
+    css_var: "--font-size-3xl"
+    value: "30px"
+  - token: "font-size-4xl"
+    css_var: "--font-size-4xl"
+    value: "36px"
+  - token: "font-size-5xl"
+    css_var: "--font-size-5xl"
+    value: "48px"
+  - token: "font-size-6xl"
+    css_var: "--font-size-6xl"
+    value: "60px"
+  - token: "font-weight-normal"
+    css_var: "--font-weight-normal"
+    value: 400
+  - token: "font-weight-medium"
+    css_var: "--font-weight-medium"
+    value: 500
+  - token: "font-weight-semibold"
+    css_var: "--font-weight-semibold"
+    value: 600
+  - token: "font-weight-bold"
+    css_var: "--font-weight-bold"
+    value: 700
+  - token: "font-weight-extrabold"
+    css_var: "--font-weight-extrabold"
+    value: 800
+  - token: "letter-spacing-tighter"
+    css_var: "--letter-spacing-tighter"
+    value: "-0.8px"
+  - token: "letter-spacing-tight"
+    css_var: "--letter-spacing-tight"
+    value: "-0.4px"
+  - token: "letter-spacing-normal"
+    css_var: "--letter-spacing-normal"
+    value: "0px"
+
+# Border radius tokens (--rounded-*)
+border_radius_tokens:
+  - { token: "rounded-0",    css_var: "--rounded-0",    value: "0px"    }
+  - { token: "rounded-sm",   css_var: "--rounded-sm",   value: "2px"    }
+  - { token: "rounded",      css_var: "--rounded",      value: "4px"    }
+  - { token: "rounded-md",   css_var: "--rounded-md",   value: "6px"    }
+  - { token: "rounded-lg",   css_var: "--rounded-lg",   value: "8px"    }
+  - { token: "rounded-xl",   css_var: "--rounded-xl",   value: "12px"   }
+  - { token: "rounded-2xl",  css_var: "--rounded-2xl",  value: "16px"   }
+  - { token: "rounded-3xl",  css_var: "--rounded-3xl",  value: "24px"   }
+  - { token: "rounded-full", css_var: "--rounded-full", value: "9999px" }
+
+# Border width tokens (--border-width-*)
+border_width_tokens:
+  - { token: "border-width-0", css_var: "--border-width-0", value: "0px" }
+  - { token: "border-width",   css_var: "--border-width",   value: "1px" }
+  - { token: "border-width-2", css_var: "--border-width-2", value: "2px" }
+  - { token: "border-width-4", css_var: "--border-width-4", value: "4px" }
+  - { token: "border-width-8", css_var: "--border-width-8", value: "8px" }
+
+# Layout tokens
+layout_tokens:
+  max_width:
+    - { token: "max-w-xs",  css_var: "--max-w-xs",  value: "320px"  }
+    - { token: "max-w-sm",  css_var: "--max-w-sm",  value: "384px"  }
+    - { token: "max-w-md",  css_var: "--max-w-md",  value: "448px"  }
+    - { token: "max-w-lg",  css_var: "--max-w-lg",  value: "512px"  }
+    - { token: "max-w-xl",  css_var: "--max-w-xl",  value: "576px"  }
+    - { token: "max-w-2xl", css_var: "--max-w-2xl", value: "672px"  }
+    - { token: "max-w-3xl", css_var: "--max-w-3xl", value: "768px"  }
+    - { token: "max-w-4xl", css_var: "--max-w-4xl", value: "896px"  }
+    - { token: "max-w-5xl", css_var: "--max-w-5xl", value: "1024px" }
+    - { token: "max-w-6xl", css_var: "--max-w-6xl", value: "1152px" }
+    - { token: "max-w-7xl", css_var: "--max-w-7xl", value: "1280px" }
+  containers:
+    - { token: "container-xs",  css_var: "--container-xs",  value: "380px"  }
+    - { token: "container-sm",  css_var: "--container-sm",  value: "640px"  }
+    - { token: "container-md",  css_var: "--container-md",  value: "768px"  }
+    - { token: "container-lg",  css_var: "--container-lg",  value: "1024px" }
+    - { token: "container-xl",  css_var: "--container-xl",  value: "1280px" }
+    - { token: "container-2xl", css_var: "--container-2xl", value: "1563px" }

--- a/docs/design-kb/ux-principles.md
+++ b/docs/design-kb/ux-principles.md
@@ -1,0 +1,106 @@
+# NODO UX Principles
+**Gobierno del Chaco — Sistema Integral**
+
+---
+
+## Navigation Philosophy
+
+NODO uses **hierarchical, sidebar-anchored navigation** designed for power users who manage complex case data daily.
+
+- **Sidebar is always present** in authenticated screens — never hidden by default on desktop
+- **Active state is unambiguous** — a branded pill indicator (bg-brand, white text) marks exactly one active item at all times
+- **Expandable groups** use chevrons (∨/∧) and show/hide subitems in-place — no page reload, no separate navigation level
+- **Subitems inherit the active pill** when selected — the group parent shows active styling when any of its children is active
+- **Logo always navigates to home** — never triggers modal or dropdown
+- **Collapse is available** but desktop is assumed to be expanded by default
+
+---
+
+## Information Architecture Patterns
+
+The system is organized around **entities** (Ciudadanos, Comedores, Centros de Familia, Instituciones) with consistent IA across each entity type:
+
+1. **List view** — searchable, filterable table with stat cards above
+2. **Detail view** — profile header + tabbed or vertically-stacked data panels
+3. **Create flow** — multi-step form with RENAPER integration for citizen creation
+4. **Edit flow** — pre-filled form distinguishing read-only (RENAPER) from editable fields
+
+Key IA rules:
+- Stat cards always appear above the data table — they provide context before detail
+- Search and filters always appear between stat cards and the table — progressive refinement
+- CTA buttons align to the RIGHT of section headings — never center or left
+- Breadcrumbs/steppers appear at the top of multi-step flows
+
+---
+
+## Progressive Disclosure Rules
+
+The system reveals complexity gradually:
+
+1. **Dashboard → List → Detail** — The home screen is an overview. Clicking drills into specifics.
+2. **Expandable nav groups** — Submenus are hidden until explicitly opened
+3. **Filters default to "All"** — Users see everything first, filter down by intent
+4. **Alert panels are opt-in** — Critical alerts appear prominently only when they exist; the panel is absent when there are none
+5. **RENAPER data is pre-filled, not asked** — The new citizen flow queries RENAPER automatically to minimize data entry
+6. **Confirmation gates for destructive actions** — Complexity (and risk) is revealed only when needed (SweetAlert2 dialog)
+
+---
+
+## Error Handling Philosophy
+
+- **Errors are specific and actionable** — "El email no es válido" not "Error en el formulario"
+- **Errors appear inline** — below the field that caused the issue, in `text-fg-danger` with an exclamation icon
+- **Required fields are marked upfront** — `*` in `text-fg-danger` before submission, not after failed validation
+- **Error state styling is distinct** — border changes to `border-danger`, background to `bg-danger-soft`
+- **Success feedback confirms** — Toast notifications (Toastr) confirm successful saves
+- **System status is visible** — System health indicators on the dashboard surface problems proactively
+
+---
+
+## Onboarding Philosophy
+
+NODO has no guided onboarding flow currently documented. The system assumes trained government employees. Key assumptions built into the design:
+
+- Users know what RENAPER is and why DNI/Sex is needed for citizen creation
+- Users understand the entity hierarchy (Legajos → Ciudadanos → Programs)
+- The wavy decoration and illustration on the login screen provide the only "first impression" moment
+- Role information in the sidebar user card orients users within the permission model
+
+---
+
+## Decision-Making Philosophy
+
+The design makes decisions on the user's behalf to reduce cognitive load:
+
+| Decision | System's Choice | Rationale |
+|----------|-----------------|-----------|
+| Required vs optional fields | Required marked with `*` | Users must complete required fields first |
+| Which action is primary | Single Brand button per section | Prevents decision paralysis |
+| How to show states | Semantic token badges | Users read state from color/label consistently |
+| How to confirm destructive actions | SweetAlert2 modal with two buttons | Forces conscious confirmation |
+| How to show empty vs loaded | Skeleton + empty state pattern | Distinguishes "loading" from "truly empty" |
+| How to handle RENAPER data | Read-only styled fields with helper text | Protects data integrity, explains why fields are locked |
+
+---
+
+## Form UX Rules
+
+- Label always above the field — never use placeholder as label
+- Required indicator: `*` in `text-fg-danger` next to the label
+- Gap between fields: 20px
+- Gap between form sections: 32px
+- Related fields appear on the same row (e.g., DNI + Sex)
+- Primary CTA: Brand button, right-aligned at the bottom of the form
+- Secondary CTA: Tertiary button (← Volver), left of primary button
+- Validation: inline, below the field, on blur (not on submit for known errors)
+
+---
+
+## Data Visualization UX
+
+- Charts always have a title and legend
+- Time selectors (7D/30D/90D) allow temporal context switching
+- Donut charts include a legend with category labels
+- Bar charts handle empty months gracefully (no bar, not an error)
+- Geographic distribution section is reserved even when map is pending
+- Categorical colors for data viz: bg-purple, bg-sky, bg-teal, bg-pink, bg-cyan, bg-fuchsia, bg-indigo, bg-orange

--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -8,6 +8,8 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     {% load static %}
+    <!-- CHACO Design Tokens — CSS variables para componentes del portal -->
+    <link href="{% static 'custom/css/chaco-tokens.css' %}" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; }
         @keyframes fadeInUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }

--- a/static/custom/css/chaco-tokens.css
+++ b/static/custom/css/chaco-tokens.css
@@ -1,0 +1,356 @@
+/* ============================================================
+   CHACO NODO — Design Tokens
+   CSS Custom Properties (Light Mode default / Dark Mode override)
+   Versión 1.0 — Generado desde Figma Variables
+   ============================================================ */
+
+/* ----------------------------------------------------------
+   PRIMITIVE COLOR SCALE (base palette — do not use directly)
+   ---------------------------------------------------------- */
+:root {
+  /* Brand (Jacaranda/Purple) */
+  --color-brand-050: #f5f3ff;
+  --color-brand-100: #ede9fe;
+  --color-brand-200: #ddd6fe;
+  --color-brand-300: #c4b5fd;
+  --color-brand-400: #a78bfa;
+  --color-brand-500: #5059bc;
+  --color-brand-600: #5059bc;
+  --color-brand-700: #5059bc;
+  --color-brand-800: #4338ca;
+  --color-brand-900: #3730a3;
+  --color-brand-950: #1e1b4b;
+
+  /* Pink (Rosa) */
+  --color-pink-050: #fef3ff;
+  --color-pink-100: #fee9ff;
+  --color-pink-200: #fee3ff;
+  --color-pink-300: #fdcfff;
+  --color-pink-400: #fcc3ff;
+  --color-pink-500: #fbafff;
+  --color-pink-600: #f98dff;
+  --color-pink-700: #f26df9;
+  --color-pink-800: #dd5fe4;
+  --color-pink-900: #bf57c4;
+  --color-pink-950: #9b499f;
+
+  /* Gray */
+  --color-gray-050: #f9fafb;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
+  --color-gray-800: #1f2937;
+  --color-gray-850: #18212f;
+  --color-gray-900: #111827;
+  --color-gray-950: #030712;
+
+  /* Emerald (Success) */
+  --color-emerald-050: #ecfdf5;
+  --color-emerald-100: #d0fae5;
+  --color-emerald-200: #a4f4cf;
+  --color-emerald-300: #5ee9b5;
+  --color-emerald-400: #00d492;
+  --color-emerald-500: #00bc7d;
+  --color-emerald-600: #009966;
+  --color-emerald-700: #007a55;
+  --color-emerald-800: #006045;
+  --color-emerald-900: #004f3b;
+  --color-emerald-950: #002c22;
+
+  /* Rose (Danger) */
+  --color-rose-050: #fef0f2;
+  --color-rose-100: #ffe4e6;
+  --color-rose-200: #ffccd3;
+  --color-rose-300: #ffa1ad;
+  --color-rose-400: #ff637e;
+  --color-rose-500: #ff2056;
+  --color-rose-600: #ec003f;
+  --color-rose-700: #c70036;
+  --color-rose-800: #a50036;
+  --color-rose-900: #8b0836;
+  --color-rose-950: #4d0218;
+
+  /* Orange (Warning) */
+  --color-orange-050: #fff8f1;
+  --color-orange-100: #feecdc;
+  --color-orange-200: #fcd9bd;
+  --color-orange-300: #fdba8c;
+  --color-orange-400: #ff8a4c;
+  --color-orange-500: #ff5a1f;
+  --color-orange-600: #d03801;
+  --color-orange-700: #b43403;
+  --color-orange-800: #8a2c0d;
+  --color-orange-900: #771d1d;
+
+  /* Purple */
+  --color-purple-500: #a855f7;
+  --color-purple-600: #9333ea;
+
+  /* Sky */
+  --color-sky-500: #00579d;
+
+  /* Teal */
+  --color-teal-600: #c8d29c;
+
+  /* Cyan */
+  --color-cyan-500: #00b8db;
+  --color-cyan-600: #0092b8;
+
+  /* Fuchsia */
+  --color-fuchsia-600: #c800de;
+
+  /* Indigo */
+  --color-indigo-500: #6366f1;
+  --color-indigo-600: #4f46e5;
+
+  /* Yellow */
+  --color-yellow-400: #fdc700;
+
+  /* Lime */
+  --color-lime-500: #7ccf00;
+  --color-lime-600: #5ea500;
+}
+
+/* ----------------------------------------------------------
+   SEMANTIC TOKENS — LIGHT MODE (default)
+   ---------------------------------------------------------- */
+:root {
+  /* === BACKGROUND === */
+  --bg-white: #ffffff;
+  --bg-primary-soft: #ffffff;
+  --bg-primary: #ffffff;
+  --bg-primary-medium: #ffffff;
+  --bg-primary-strong: #ffffff;
+  --bg-secondary-soft: var(--color-gray-050);
+  --bg-secondary: var(--color-gray-050);
+  --bg-secondary-medium: var(--color-gray-050);
+  --bg-secondary-strong: var(--color-gray-050);
+  --bg-tertiary-soft: var(--color-gray-100);
+  --bg-tertiary: var(--color-gray-100);
+  --bg-tertiary-medium: var(--color-gray-100);
+  --bg-quaternary: var(--color-gray-200);
+  --bg-quaternary-medium: var(--color-gray-200);
+  --bg-gray: var(--color-gray-300);
+  --bg-brand-softer: var(--color-pink-050);
+  --bg-brand-soft: var(--color-pink-100);
+  --bg-brand-medium: var(--color-pink-200);
+  --bg-brand: var(--color-brand-700);
+  --bg-brand-strong: var(--color-brand-800);
+  --bg-success-soft: var(--color-emerald-050);
+  --bg-success-medium: var(--color-emerald-100);
+  --bg-success: var(--color-emerald-700);
+  --bg-success-strong: var(--color-emerald-800);
+  --bg-danger-soft: var(--color-rose-050);
+  --bg-danger-medium: var(--color-rose-100);
+  --bg-danger: var(--color-rose-700);
+  --bg-danger-strong: var(--color-rose-800);
+  --bg-warning-soft: var(--color-orange-050);
+  --bg-warning-medium: var(--color-orange-100);
+  --bg-warning: var(--color-orange-500);
+  --bg-warning-strong: var(--color-orange-700);
+  --bg-dark: var(--color-gray-800);
+  --bg-dark-strong: var(--color-gray-900);
+  --bg-disabled: var(--color-gray-100);
+  --bg-purple: var(--color-purple-500);
+  --bg-sky: var(--color-sky-500);
+  --bg-teal: var(--color-teal-600);
+  --bg-pink: var(--color-pink-600);
+  --bg-cyan: var(--color-cyan-500);
+  --bg-fuchsia: var(--color-fuchsia-600);
+  --bg-indigo: var(--color-indigo-600);
+  --bg-orange: var(--color-orange-400);
+
+  /* === BORDER === */
+  --border-dark: var(--color-gray-600);
+  --border-buffer: #ffffff;
+  --border-buffer-medium: #ffffff;
+  --border-buffer-strong: #ffffff;
+  --border-muted: var(--color-gray-050);
+  --border-light-subtle: var(--color-gray-100);
+  --border-light: var(--color-gray-100);
+  --border-light-medium: var(--color-gray-100);
+  --border-base-soft: var(--color-gray-200);
+  --border-base: var(--color-gray-200);
+  --border-base-medium: var(--color-gray-200);
+  --border-base-strong: var(--color-gray-200);
+  --border-success-subtle: var(--color-emerald-200);
+  --border-success: var(--color-emerald-700);
+  --border-danger-subtle: var(--color-rose-200);
+  --border-danger: var(--color-rose-700);
+  --border-warning-subtle: var(--color-orange-200);
+  --border-warning: var(--color-orange-600);
+  --border-brand-subtle: var(--color-pink-200);
+  --border-brand-light: var(--color-pink-600);
+  --border-brand: var(--color-brand-700);
+  --border-dark-subtle: var(--color-gray-800);
+  --border-purple: var(--color-purple-500);
+  --border-orange: var(--color-orange-400);
+
+  /* === TEXT === */
+  --text-white: #ffffff;
+  --text-black: var(--color-gray-900);
+  --text-heading: var(--color-gray-900);
+  --text-body: var(--color-gray-600);
+  --text-body-subtle: var(--color-gray-500);
+  --text-fg-brand-subtle: var(--color-pink-200);
+  --text-fg-brand: var(--color-brand-700);
+  --text-fg-brand-strong: var(--color-brand-900);
+  --text-fg-success: var(--color-emerald-700);
+  --text-fg-success-strong: var(--color-emerald-900);
+  --text-fg-danger: var(--color-rose-700);
+  --text-fg-danger-strong: var(--color-rose-900);
+  --text-fg-warning-subtle: var(--color-orange-600);
+  --text-fg-warning: var(--color-orange-900);
+  --text-fg-yellow: var(--color-yellow-400);
+  --text-fg-info: var(--color-brand-900);
+  --text-fg-disabled: var(--color-gray-400);
+  --text-fg-purple: var(--color-purple-600);
+  --text-fg-cyan: var(--color-cyan-600);
+  --text-fg-indigo: var(--color-indigo-600);
+  --text-fg-pink: var(--color-pink-600);
+  --text-fg-lime: var(--color-lime-600);
+
+  /* === TYPOGRAPHY === */
+  --font-family-base: 'Inter', sans-serif;
+  --font-family-brand: 'Gellat', sans-serif;
+  --font-size-xxs: 8px;
+  --font-size-xs: 12px;
+  --font-size-sm: 14px;
+  --font-size-base: 16px;
+  --font-size-lg: 18px;
+  --font-size-xl: 20px;
+  --font-size-2xl: 24px;
+  --font-size-3xl: 30px;
+  --font-size-4xl: 36px;
+  --font-size-5xl: 48px;
+  --font-size-6xl: 60px;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
+  --letter-spacing-tighter: -0.8px;
+  --letter-spacing-tight: -0.4px;
+  --letter-spacing-normal: 0px;
+
+  /* === BORDER RADIUS === */
+  --rounded-0: 0px;
+  --rounded-sm: 2px;
+  --rounded: 4px;
+  --rounded-md: 6px;
+  --rounded-lg: 8px;
+  --rounded-xl: 12px;
+  --rounded-2xl: 16px;
+  --rounded-3xl: 24px;
+  --rounded-full: 9999px;
+
+  /* === BORDER WIDTH === */
+  --border-width-0: 0px;
+  --border-width: 1px;
+  --border-width-2: 2px;
+  --border-width-4: 4px;
+  --border-width-8: 8px;
+
+  /* === MAX WIDTH === */
+  --max-w-xs: 320px;
+  --max-w-sm: 384px;
+  --max-w-md: 448px;
+  --max-w-lg: 512px;
+  --max-w-xl: 576px;
+  --max-w-2xl: 672px;
+  --max-w-3xl: 768px;
+  --max-w-4xl: 896px;
+  --max-w-5xl: 1024px;
+  --max-w-6xl: 1152px;
+  --max-w-7xl: 1280px;
+
+  /* === CONTAINERS === */
+  --container-xs: 380px;
+  --container-sm: 640px;
+  --container-md: 768px;
+  --container-lg: 1024px;
+  --container-xl: 1280px;
+  --container-2xl: 1563px;
+}
+
+/* ----------------------------------------------------------
+   SEMANTIC TOKENS — DARK MODE OVERRIDES
+   ---------------------------------------------------------- */
+[data-theme="dark"],
+.dark {
+  --bg-white: #ffffff; /* intentionally stays white */
+  --bg-primary-soft: var(--color-gray-900);
+  --bg-primary: var(--color-gray-950);
+  --bg-primary-medium: var(--color-gray-800);
+  --bg-primary-strong: var(--color-gray-700);
+  --bg-secondary-soft: var(--color-gray-900);
+  --bg-secondary: var(--color-gray-950);
+  --bg-secondary-medium: var(--color-gray-800);
+  --bg-secondary-strong: var(--color-gray-700);
+  --bg-tertiary-soft: var(--color-gray-900);
+  --bg-tertiary: var(--color-gray-800);
+  --bg-tertiary-medium: var(--color-gray-700);
+  --bg-quaternary: var(--color-gray-700);
+  --bg-quaternary-medium: var(--color-gray-600);
+  --bg-gray: var(--color-gray-600);
+  --bg-brand-softer: var(--color-brand-950);
+  --bg-brand-soft: var(--color-brand-900);
+  --bg-brand-medium: var(--color-brand-900);
+  --bg-brand: var(--color-brand-600);
+  --bg-brand-strong: var(--color-brand-700);
+  --bg-success-soft: var(--color-emerald-950);
+  --bg-success-medium: var(--color-emerald-800);
+  --bg-success: var(--color-emerald-600);
+  --bg-success-strong: var(--color-emerald-700);
+  --bg-danger-soft: var(--color-rose-950);
+  --bg-danger-medium: var(--color-rose-900);
+  --bg-danger: var(--color-rose-700);
+  --bg-danger-strong: var(--color-rose-700);
+  --bg-warning-soft: var(--color-orange-950);
+  --bg-warning-medium: var(--color-orange-900);
+  --bg-warning: var(--color-orange-600);
+  --bg-dark: var(--color-gray-800);
+  --bg-dark-strong: var(--color-gray-800);
+  --bg-disabled: var(--color-gray-800);
+  --border-dark: var(--color-gray-600);
+  --border-buffer: var(--color-gray-950);
+  --border-buffer-medium: var(--color-gray-900);
+  --border-buffer-strong: var(--color-gray-800);
+  --border-muted: var(--color-gray-900);
+  --border-light-subtle: var(--color-gray-900);
+  --border-light: var(--color-gray-800);
+  --border-light-medium: var(--color-gray-700);
+  --border-base-soft: var(--color-gray-900);
+  --border-base: var(--color-gray-800);
+  --border-base-medium: var(--color-gray-700);
+  --border-base-strong: var(--color-gray-600);
+  --border-success-subtle: var(--color-emerald-900);
+  --border-success: var(--color-emerald-600);
+  --border-danger-subtle: var(--color-rose-900);
+  --border-danger: var(--color-rose-600);
+  --border-warning-subtle: var(--color-orange-900);
+  --border-warning: var(--color-orange-500);
+  --border-brand-subtle: var(--color-brand-900);
+  --border-brand-light: var(--color-brand-600);
+  --border-brand: var(--color-brand-500);
+  --border-dark-subtle: var(--color-gray-700);
+  --text-heading: #ffffff;
+  --text-body: var(--color-gray-400);
+  --text-body-subtle: var(--color-gray-400);
+  --text-fg-brand: var(--color-brand-500);
+  --text-fg-brand-strong: var(--color-brand-400);
+  --text-fg-success: var(--color-emerald-600);
+  --text-fg-success-strong: var(--color-emerald-300);
+  --text-fg-danger: var(--color-rose-500);
+  --text-fg-danger-strong: var(--color-rose-300);
+  --text-fg-warning-subtle: var(--color-orange-500);
+  --text-fg-warning: var(--color-orange-300);
+  --text-fg-disabled: var(--color-gray-600);
+  --text-fg-purple: var(--color-purple-500);
+  --text-fg-cyan: var(--color-cyan-500);
+  --text-fg-lime: var(--color-lime-500);
+}

--- a/static/custom/js/chaco-tailwind.config.js
+++ b/static/custom/js/chaco-tailwind.config.js
@@ -1,0 +1,196 @@
+// ============================================================
+// CHACO NODO — Tailwind CSS Config
+// Extiende los defaults de Tailwind con los tokens del sistema
+// Versión 1.0 — Generado desde Figma Variables
+// ============================================================
+// IMPORTANTE: Este archivo extiende Tailwind — no reemplaza.
+// Las clases utilitarias del sistema de diseño usan el prefijo
+// de los tokens (ej: bg-brand, text-fg-danger, border-base).
+// ============================================================
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['class', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+
+      // --------------------------------------------------------
+      // FONT FAMILY
+      // --------------------------------------------------------
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        brand: ['Gellat', 'sans-serif'], // Solo para hero headings
+      },
+
+      // --------------------------------------------------------
+      // FONT SIZE — valores exactos del sistema
+      // --------------------------------------------------------
+      fontSize: {
+        'xxs': '8px',
+        'xs':  '12px',
+        'sm':  '14px',
+        'base':'16px',
+        'lg':  '18px',
+        'xl':  '20px',
+        '2xl': '24px',
+        '3xl': '30px',
+        '4xl': '36px',
+        '5xl': '48px',
+        '6xl': '60px',
+        '7xl': '72px',
+        '8xl': '96px',
+        '9xl': '128px',
+      },
+
+      // --------------------------------------------------------
+      // LETTER SPACING
+      // --------------------------------------------------------
+      letterSpacing: {
+        tighter: '-0.8px',
+        tight:   '-0.4px',
+        normal:  '0px',
+        wide:    '0.4px',
+        wider:   '0.8px',
+        widest:  '1.6px',
+      },
+
+      // --------------------------------------------------------
+      // BORDER RADIUS
+      // --------------------------------------------------------
+      borderRadius: {
+        '0':    '0px',
+        'sm':   '2px',
+        DEFAULT:'4px',
+        'md':   '6px',
+        'lg':   '8px',
+        'xl':   '12px',
+        '2xl':  '16px',
+        '3xl':  '24px',
+        'full': '9999px',
+      },
+
+      // --------------------------------------------------------
+      // MAX WIDTH
+      // --------------------------------------------------------
+      maxWidth: {
+        'xs':  '320px',
+        'sm':  '384px',
+        'md':  '448px',
+        'lg':  '512px',
+        'xl':  '576px',
+        '2xl': '672px',
+        '3xl': '768px',
+        '4xl': '896px',
+        '5xl': '1024px',
+        '6xl': '1152px',
+        '7xl': '1280px',
+      },
+
+      // --------------------------------------------------------
+      // COLORS — paleta primitiva + tokens semánticos
+      // Uso: bg-brand, text-fg-danger, border-base, etc.
+      // ⚠️ No usar las escalas numéricas directamente en componentes.
+      //    Usar siempre los tokens semánticos.
+      // --------------------------------------------------------
+      colors: {
+
+        // --- Semantic tokens (light mode defaults via CSS vars) ---
+        // Background
+        'bg-white':             'var(--bg-white)',
+        'bg-primary':           'var(--bg-primary)',
+        'bg-primary-soft':      'var(--bg-primary-soft)',
+        'bg-primary-medium':    'var(--bg-primary-medium)',
+        'bg-primary-strong':    'var(--bg-primary-strong)',
+        'bg-secondary':         'var(--bg-secondary)',
+        'bg-secondary-soft':    'var(--bg-secondary-soft)',
+        'bg-secondary-medium':  'var(--bg-secondary-medium)',
+        'bg-secondary-strong':  'var(--bg-secondary-strong)',
+        'bg-tertiary':          'var(--bg-tertiary)',
+        'bg-tertiary-soft':     'var(--bg-tertiary-soft)',
+        'bg-tertiary-medium':   'var(--bg-tertiary-medium)',
+        'bg-quaternary':        'var(--bg-quaternary)',
+        'bg-quaternary-medium': 'var(--bg-quaternary-medium)',
+        'bg-gray':              'var(--bg-gray)',
+        'bg-brand-softer':      'var(--bg-brand-softer)',
+        'bg-brand-soft':        'var(--bg-brand-soft)',
+        'bg-brand-medium':      'var(--bg-brand-medium)',
+        'bg-brand':             'var(--bg-brand)',
+        'bg-brand-strong':      'var(--bg-brand-strong)',
+        'bg-success-soft':      'var(--bg-success-soft)',
+        'bg-success-medium':    'var(--bg-success-medium)',
+        'bg-success':           'var(--bg-success)',
+        'bg-success-strong':    'var(--bg-success-strong)',
+        'bg-danger-soft':       'var(--bg-danger-soft)',
+        'bg-danger-medium':     'var(--bg-danger-medium)',
+        'bg-danger':            'var(--bg-danger)',
+        'bg-danger-strong':     'var(--bg-danger-strong)',
+        'bg-warning-soft':      'var(--bg-warning-soft)',
+        'bg-warning-medium':    'var(--bg-warning-medium)',
+        'bg-warning':           'var(--bg-warning)',
+        'bg-warning-strong':    'var(--bg-warning-strong)',
+        'bg-dark':              'var(--bg-dark)',
+        'bg-dark-strong':       'var(--bg-dark-strong)',
+        'bg-disabled':          'var(--bg-disabled)',
+        'bg-purple':            'var(--bg-purple)',
+        'bg-sky':               'var(--bg-sky)',
+        'bg-teal':              'var(--bg-teal)',
+        'bg-pink':              'var(--bg-pink)',
+        'bg-cyan':              'var(--bg-cyan)',
+        'bg-fuchsia':           'var(--bg-fuchsia)',
+        'bg-indigo':            'var(--bg-indigo)',
+        'bg-orange':            'var(--bg-orange)',
+
+        // Border
+        'border-dark':           'var(--border-dark)',
+        'border-buffer':         'var(--border-buffer)',
+        'border-buffer-medium':  'var(--border-buffer-medium)',
+        'border-buffer-strong':  'var(--border-buffer-strong)',
+        'border-muted':          'var(--border-muted)',
+        'border-light-subtle':   'var(--border-light-subtle)',
+        'border-light':          'var(--border-light)',
+        'border-light-medium':   'var(--border-light-medium)',
+        'border-base-soft':      'var(--border-base-soft)',
+        'border-base':           'var(--border-base)',
+        'border-base-medium':    'var(--border-base-medium)',
+        'border-base-strong':    'var(--border-base-strong)',
+        'border-success-subtle': 'var(--border-success-subtle)',
+        'border-success':        'var(--border-success)',
+        'border-danger-subtle':  'var(--border-danger-subtle)',
+        'border-danger':         'var(--border-danger)',
+        'border-warning-subtle': 'var(--border-warning-subtle)',
+        'border-warning':        'var(--border-warning)',
+        'border-brand-subtle':   'var(--border-brand-subtle)',
+        'border-brand-light':    'var(--border-brand-light)',
+        'border-brand':          'var(--border-brand)',
+        'border-dark-subtle':    'var(--border-dark-subtle)',
+        'border-purple':         'var(--border-purple)',
+        'border-orange':         'var(--border-orange)',
+
+        // Text / Foreground
+        'text-white':             'var(--text-white)',
+        'text-black':             'var(--text-black)',
+        'text-heading':           'var(--text-heading)',
+        'text-body':              'var(--text-body)',
+        'text-body-subtle':       'var(--text-body-subtle)',
+        'text-fg-brand-subtle':   'var(--text-fg-brand-subtle)',
+        'text-fg-brand':          'var(--text-fg-brand)',
+        'text-fg-brand-strong':   'var(--text-fg-brand-strong)',
+        'text-fg-success':        'var(--text-fg-success)',
+        'text-fg-success-strong': 'var(--text-fg-success-strong)',
+        'text-fg-danger':         'var(--text-fg-danger)',
+        'text-fg-danger-strong':  'var(--text-fg-danger-strong)',
+        'text-fg-warning-subtle': 'var(--text-fg-warning-subtle)',
+        'text-fg-warning':        'var(--text-fg-warning)',
+        'text-fg-yellow':         'var(--text-fg-yellow)',
+        'text-fg-info':           'var(--text-fg-info)',
+        'text-fg-disabled':       'var(--text-fg-disabled)',
+        'text-fg-purple':         'var(--text-fg-purple)',
+        'text-fg-cyan':           'var(--text-fg-cyan)',
+        'text-fg-indigo':         'var(--text-fg-indigo)',
+        'text-fg-pink':           'var(--text-fg-pink)',
+        'text-fg-lime':           'var(--text-fg-lime)',
+      },
+    },
+  },
+  plugins: [],
+}

--- a/templates/includes/base.html
+++ b/templates/includes/base.html
@@ -11,32 +11,97 @@
         <script src="https://cdn.tailwindcss.com"></script>
         <script>
             tailwind.config = {
+                darkMode: ['class', '[data-theme="dark"]'],
                 theme: {
                     extend: {
-                        colors: {
-                            // Paleta NODO
-                            'magenta': '{{ branding.colors.nodo_magenta }}',
-                            'nodo-purple': '{{ branding.colors.nodo_purple }}',
-                            'nodo-cyan': '{{ branding.colors.nodo_cyan }}',
-                            // Compatibilidad anterior
-                            'primario': '{{ branding.colors.color_primario }}',
-                            'primario-claro': '{{ branding.colors.color_primario_claro }}',
-                            'primario-oscuro': '{{ branding.colors.color_primario_oscuro }}',
-                            'secundario': '{{ branding.colors.color_secundario }}',
-                            'secundario-claro': '{{ branding.colors.color_secundario_claro }}',
-                            'secundario-oscuro': '{{ branding.colors.color_secundario_oscuro }}',
-                            'acento': '{{ branding.colors.color_acento }}',
-                            'acento-claro': '{{ branding.colors.color_acento_claro }}',
-                            'acento-oscuro': '{{ branding.colors.color_acento_oscuro }}',
-                            'arg-azul': '{{ branding.colors.color_primario }}',
-                            'arg-secundario': '{{ branding.colors.color_secundario }}',
-                            primary: '{{ branding.colors.color_primario }}',
-                            secondary: '{{ branding.colors.color_secundario }}',
-                        },
+                        // ── CHACO Design System tokens ────────────────────────────
                         fontFamily: {
-                            'lora': ['Lora', 'serif'],
-                            'montserrat': ['Montserrat', 'sans-serif'],
-                        }
+                            sans:        ['Inter', 'sans-serif'],
+                            brand:       ['Gellat', 'sans-serif'],
+                            // legacy (mantener para compatibilidad con templates existentes)
+                            lora:        ['Lora', 'serif'],
+                            montserrat:  ['Montserrat', 'sans-serif'],
+                        },
+                        fontSize: {
+                            xxs: '8px', xs: '12px', sm: '14px', base: '16px',
+                            lg: '18px', xl: '20px', '2xl': '24px', '3xl': '30px',
+                            '4xl': '36px', '5xl': '48px', '6xl': '60px',
+                        },
+                        borderRadius: {
+                            '0': '0px', sm: '2px', DEFAULT: '4px', md: '6px',
+                            lg: '8px', xl: '12px', '2xl': '16px', '3xl': '24px', full: '9999px',
+                        },
+                        maxWidth: {
+                            xs: '320px', sm: '384px', md: '448px', lg: '512px',
+                            xl: '576px', '2xl': '672px', '3xl': '768px', '4xl': '896px',
+                            '5xl': '1024px', '6xl': '1152px', '7xl': '1280px',
+                        },
+                        colors: {
+                            // ── Semantic background tokens (via CSS vars en chaco-tokens.css) ──
+                            'bg-white':             'var(--bg-white)',
+                            'bg-primary':           'var(--bg-primary)',
+                            'bg-primary-soft':      'var(--bg-primary-soft)',
+                            'bg-secondary':         'var(--bg-secondary)',
+                            'bg-secondary-soft':    'var(--bg-secondary-soft)',
+                            'bg-tertiary':          'var(--bg-tertiary)',
+                            'bg-quaternary':        'var(--bg-quaternary)',
+                            'bg-gray':              'var(--bg-gray)',
+                            'bg-brand-softer':      'var(--bg-brand-softer)',
+                            'bg-brand-soft':        'var(--bg-brand-soft)',
+                            'bg-brand-medium':      'var(--bg-brand-medium)',
+                            'bg-brand':             'var(--bg-brand)',
+                            'bg-brand-strong':      'var(--bg-brand-strong)',
+                            'bg-success-soft':      'var(--bg-success-soft)',
+                            'bg-success':           'var(--bg-success)',
+                            'bg-danger-soft':       'var(--bg-danger-soft)',
+                            'bg-danger-medium':     'var(--bg-danger-medium)',
+                            'bg-danger':            'var(--bg-danger)',
+                            'bg-warning-soft':      'var(--bg-warning-soft)',
+                            'bg-warning':           'var(--bg-warning)',
+                            'bg-dark':              'var(--bg-dark)',
+                            'bg-disabled':          'var(--bg-disabled)',
+                            'bg-pink':              'var(--bg-pink)',
+                            // ── Semantic border tokens ──
+                            'border-base':          'var(--border-base)',
+                            'border-base-soft':     'var(--border-base-soft)',
+                            'border-light':         'var(--border-light)',
+                            'border-brand':         'var(--border-brand)',
+                            'border-brand-subtle':  'var(--border-brand-subtle)',
+                            'border-brand-light':   'var(--border-brand-light)',
+                            'border-danger':        'var(--border-danger)',
+                            'border-danger-subtle': 'var(--border-danger-subtle)',
+                            'border-success':       'var(--border-success)',
+                            'border-warning':       'var(--border-warning)',
+                            // ── Semantic text tokens ──
+                            'text-heading':          'var(--text-heading)',
+                            'text-body':             'var(--text-body)',
+                            'text-body-subtle':      'var(--text-body-subtle)',
+                            'text-fg-brand':         'var(--text-fg-brand)',
+                            'text-fg-brand-subtle':  'var(--text-fg-brand-subtle)',
+                            'text-fg-brand-strong':  'var(--text-fg-brand-strong)',
+                            'text-fg-danger':        'var(--text-fg-danger)',
+                            'text-fg-danger-strong': 'var(--text-fg-danger-strong)',
+                            'text-fg-success':       'var(--text-fg-success)',
+                            'text-fg-warning':       'var(--text-fg-warning)',
+                            'text-fg-warning-subtle':'var(--text-fg-warning-subtle)',
+                            'text-fg-disabled':      'var(--text-fg-disabled)',
+                            'text-fg-info':          'var(--text-fg-info)',
+                            // ── Legacy branding (mantener para templates existentes) ──
+                            'magenta':          '{{ branding.colors.nodo_magenta }}',
+                            'nodo-purple':      '{{ branding.colors.nodo_purple }}',
+                            'nodo-cyan':        '{{ branding.colors.nodo_cyan }}',
+                            'primario':         '{{ branding.colors.color_primario }}',
+                            'primario-claro':   '{{ branding.colors.color_primario_claro }}',
+                            'primario-oscuro':  '{{ branding.colors.color_primario_oscuro }}',
+                            'secundario':       '{{ branding.colors.color_secundario }}',
+                            'secundario-claro': '{{ branding.colors.color_secundario_claro }}',
+                            'secundario-oscuro':'{{ branding.colors.color_secundario_oscuro }}',
+                            'acento':           '{{ branding.colors.color_acento }}',
+                            'acento-claro':     '{{ branding.colors.color_acento_claro }}',
+                            'acento-oscuro':    '{{ branding.colors.color_acento_oscuro }}',
+                            primary:            '{{ branding.colors.color_primario }}',
+                            secondary:          '{{ branding.colors.color_secundario }}',
+                        },
                     }
                 }
             }
@@ -45,7 +110,7 @@
         <!-- Google Fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Lora:wght@400;500;600;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
         
         <!-- Font Awesome -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
@@ -53,7 +118,10 @@
         <!-- Alpine.js for interactivity -->
         <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
         
-        <!-- Paleta de colores unificada (DEBE IR PRIMERO) -->
+        <!-- CHACO Design Tokens — DEBE IR PRIMERO (define todas las CSS variables) -->
+        <link rel="stylesheet" href="{% static 'custom/css/chaco-tokens.css' %}" />
+
+        <!-- Paleta de colores unificada (sombras, transiciones) -->
         <link rel="stylesheet" href="{% static 'custom/css/paleta-unificada.css' %}" />
         
         <!-- NODO Brand Manual de Marca -->


### PR DESCRIPTION
## Resumen

Establece el Design System de NODO para el Gobierno del Chaco: desde la base de conocimiento hasta la integración de tokens en los templates.

### Qué incluye este PR

**Knowledge Base (`docs/design-kb/`) — 30 archivos**
- 7 foundations: colors, typography, spacing, elevation, motion, grid, iconography
- Inventario completo de tokens (`tokens/design-tokens.yaml` + fuentes en JSON/CSS/JS)
- 13 componentes especificados: button, badge, input, sidebar, stat-card, data-table, alert-panel, card-entity, breadcrumb, toast, modal, avatar, select
- 5 patrones: authentication, dashboard, forms, tables, empty-states, loading-states, errors
- Principios de marca, UX, anti-patrones, reglas implícitas
- Design Constitution (10 artículos + 3 enmiendas)
- Prompt de implementación listo para ejecutar en nueva sesión

**Token integration**
- `static/custom/css/chaco-tokens.css` — 357 líneas, CSS custom properties (light + dark mode), generado desde Figma Variables
- `static/custom/js/chaco-tailwind.config.js` — extensión Tailwind con todos los semantic tokens
- `docs/design-kb/tokens/chaco-tokens.json` — formato W3C Design Tokens (fuente para tooling)
- `templates/includes/base.html` — Inter font, chaco-tokens.css como primer import, tailwind.config extendido con bg-*, border-*, text-fg-* tokens + darkMode activado
- `portal/templates/portal/base.html` — chaco-tokens.css wired (light mode)

### Decisiones de diseño cerradas

| Valor | Decisión |
|-------|----------|
| Brand gradient | `linear-gradient(45deg, #5059BC, #F98DFF)` (Jacaranda → BG Pink) |
| Sidebar width | 288px (w-72) |
| Form max-width | 768px fijo (max-w-3xl) |
| Avatar | 31×31px circular |
| Toast | Centrado, gray-600 al 70%, 10s |
| Modal backdrop | gray-300 al 70% |
| Dark mode | Backoffice únicamente |

### Qué NO hace este PR

No modifica ningún template de vista existente. Los tokens están disponibles pero no aplicados todavía. La implementación visual se ejecuta en la próxima sesión usando `docs/design-kb/IMPLEMENT_DESIGN_SYSTEM.md`.

### Compatibilidad

- Los legacy branding tokens (`primario`, `secundario`, `acento`, etc.) se mantienen en el tailwind.config inline — ningún template existente se rompe.
- `chaco-tokens.css` solo define CSS custom properties — no aplica estilos a selectores existentes.

## Test plan

- [ ] `python manage.py check` sin errores (requiere `.env` con `DJANGO_SECRET_KEY`)
- [ ] El backoffice renderiza sin cambios visuales (los tokens son aditivos)
- [ ] Los CSS vars de `chaco-tokens.css` están disponibles en DevTools > `:root`
- [ ] Las clases `bg-brand`, `text-fg-danger`, `border-base` resuelven correctamente en Tailwind

🤖 Generated with [Claude Code](https://claude.com/claude-code)