### PR TITLE
docs: colecciones Postman para todos los modulos API -> development

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,66 @@
+# Colecciones Postman — Chaco API
+
+Colecciones de Postman v2.1 para documentar y probar todos los endpoints del sistema.
+Una colección por módulo, sin variables de entorno.
+
+## Módulos
+
+| Archivo | Módulo | Endpoints | Descripción |
+|---------|--------|-----------|-------------|
+| [healthcheck.postman_collection.json](healthcheck.postman_collection.json) | Healthcheck | 1 | Monitoreo de salud del sistema |
+| [core.postman_collection.json](core.postman_collection.json) | Core | ~25 | AJAX helpers, performance, API geográfica |
+| [users.postman_collection.json](users.postman_collection.json) | Users | ~30 | Auth operadores, CRUD usuarios/roles, API DRF |
+| [configuracion.postman_collection.json](configuracion.postman_collection.json) | Configuración | ~40 | Geografía, secretarías, programas (wizard 4 pasos) |
+| [conversaciones.postman_collection.json](conversaciones.postman_collection.json) | Conversaciones | ~20 | Chat público, backoffice operadores, API alertas |
+| [legajos.postman_collection.json](legajos.postman_collection.json) | Legajos | ~70 | Ciudadanos, archivos, alertas, NACHEC, API DRF |
+| [portal.postman_collection.json](portal.postman_collection.json) | Portal Ciudadano | ~25 | Auth ciudadano, registro, perfil, consultas |
+| [dashboard.postman_collection.json](dashboard.postman_collection.json) | Dashboard | 8 | Panel principal, APIs de métricas |
+
+## Cómo importar
+
+1. Abrir Postman → **Import**
+2. Seleccionar uno o más archivos `.json` de esta carpeta
+3. La colección aparece en el panel izquierdo lista para usar
+
+## Autenticación
+
+El sistema usa **autenticación por sesión Django** (cookies), no tokens Bearer.
+
+### Para endpoints de backoffice (operadores)
+
+1. Hacer GET a `http://localhost:8000/` para obtener la cookie `csrftoken`
+2. Hacer POST al login con las credenciales y el `csrfmiddlewaretoken`
+3. Copiar la cookie `sessionid` de la respuesta
+4. Setearla en el header `Cookie: sessionid=<valor>` de los requests subsiguientes
+
+Para requests POST/PATCH/DELETE a la API DRF, agregar también:
+```
+X-CSRFToken: <valor-de-la-cookie-csrftoken>
+```
+
+### Para endpoints del portal ciudadano
+
+Misma mecánica pero usando `POST /portal/mi-perfil/login/` con DNI como username.
+
+### Endpoints públicos (sin autenticación)
+
+- `GET /health/` — healthcheck
+- `GET /conversaciones/chat/` — pantalla de chat
+- `POST /conversaciones/consultar-renaper/` — verificación RENAPER
+- `POST /conversaciones/iniciar/` — iniciar conversación
+- `GET|POST /portal/mi-perfil/login/` — login ciudadano
+- `GET|POST /portal/mi-perfil/registro/` — registro paso 1 y 2
+
+## Convenciones de los request bodies
+
+| Tipo de endpoint | Content-Type | Body |
+|-----------------|--------------|------|
+| Vistas HTML (backoffice) | `application/x-www-form-urlencoded` | Incluye `csrfmiddlewaretoken` |
+| API DRF (GET) | — | Sin body |
+| API DRF (POST/PATCH) | `application/json` | JSON |
+| Subida de archivos | `multipart/form-data` | Campo `archivo` tipo file |
+
+## URL base
+
+Todos los requests apuntan a `http://localhost:8000`. Para apuntar a otro entorno,
+usar la función **Find & Replace** de Postman sobre la colección importada.

--- a/docs/api/configuracion.postman_collection.json
+++ b/docs/api/configuracion.postman_collection.json
@@ -1,0 +1,735 @@
+{
+  "info": {
+    "name": "Chaco — Configuración",
+    "description": "Gestión de la configuración del sistema: geografía (provincias, municipios, localidades), estructura organizacional (secretarías, subsecretarías) y programas sociales.\n\nTodos los endpoints requieren sesión Django activa (cookie 'sessionid'). Los POST requieren 'csrfmiddlewaretoken' en el body del formulario.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Provincias",
+      "item": [
+        {
+          "name": "Listar provincias",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/provincias/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "provincias", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario crear provincia (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/provincias/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "provincias", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear provincia (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Chaco" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/provincias/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "provincias", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario editar provincia (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/provincias/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "provincias", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar provincia (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Chaco Actualizado" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/provincias/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "provincias", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar provincia",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/provincias/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "provincias", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Municipios",
+      "item": [
+        {
+          "name": "Listar municipios",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/municipios/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "municipios", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear municipio (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Resistencia" },
+                { "key": "provincia", "value": "1", "description": "ID de la provincia" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/municipios/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "municipios", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar municipio (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Resistencia Actualizado" },
+                { "key": "provincia", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/municipios/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "municipios", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar municipio",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/municipios/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "municipios", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Localidades",
+      "item": [
+        {
+          "name": "Listar localidades",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/localidades/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "localidades", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear localidad (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Villa del Rosario" },
+                { "key": "municipio", "value": "1", "description": "ID del municipio" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/localidades/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "localidades", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar localidad (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Villa del Rosario Actualizado" },
+                { "key": "municipio", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/localidades/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "localidades", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar localidad",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/localidades/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "localidades", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Secretarías",
+      "item": [
+        {
+          "name": "Listar secretarías",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/secretarias/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "secretarias", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear secretaría (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Secretaría de Desarrollo Social" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/secretarias/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "secretarias", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar secretaría (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Ministerio de Desarrollo Social" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/secretarias/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "secretarias", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar secretaría",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/secretarias/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "secretarias", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Subsecretarías",
+      "item": [
+        {
+          "name": "Listar subsecretarías",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/subsecretarias/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "subsecretarias", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear subsecretaría (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Subsecretaría de Inclusión Social" },
+                { "key": "secretaria", "value": "1", "description": "ID de la secretaría" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/subsecretarias/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "subsecretarias", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar subsecretaría (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Subsecretaría de Inclusión Social Actualizada" },
+                { "key": "secretaria", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/subsecretarias/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "subsecretarias", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar subsecretaría",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/subsecretarias/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "subsecretarias", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Programas",
+      "description": "Programas sociales. Creación en wizard de 4 pasos. El estado de sesión del wizard se mantiene server-side entre pasos.",
+      "item": [
+        {
+          "name": "Listar programas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", ""],
+              "query": [
+                { "key": "estado", "value": "activo", "disabled": true, "description": "Filtro por estado" },
+                { "key": "subsecretaria", "value": "1", "disabled": true, "description": "Filtro por subsecretaría" },
+                { "key": "q", "value": "inclusion", "disabled": true, "description": "Búsqueda por texto" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wizard Paso 1 — Datos básicos (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/nuevo/paso1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "nuevo", "paso1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wizard Paso 1 — Datos básicos (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Programa de Inclusión Alimentaria" },
+                { "key": "codigo", "value": "PIA-2024" },
+                { "key": "descripcion", "value": "Programa de asistencia alimentaria para familias en situación de vulnerabilidad" },
+                { "key": "secretaria", "value": "1", "description": "ID de la secretaría" },
+                { "key": "subsecretaria", "value": "1", "description": "ID de la subsecretaría" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/nuevo/paso1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "nuevo", "paso1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wizard Paso 2 — Naturaleza (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "naturaleza", "value": "PRESTACION", "description": "Valor de Programa.Naturaleza.choices (ej: PRESTACION, CAPACITACION, SUBSIDIO)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/nuevo/paso2/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "nuevo", "paso2", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wizard Paso 3 — Cupo y lista de espera (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "cupo_maximo", "value": "500", "description": "Número entero >= 1, opcional" },
+                { "key": "tiene_lista_espera", "value": "on", "description": "Checkbox: 'on' para true, omitir para false" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/nuevo/paso3/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "nuevo", "paso3", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wizard Paso 4 — Apariencia (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "icono", "value": "fa-utensils", "description": "Nombre de ícono FontAwesome (max 50 chars)" },
+                { "key": "color", "value": "#e74c3c", "description": "Color HEX o nombre CSS (max 20 chars)" },
+                { "key": "orden", "value": "1", "description": "Entero >= 0 para ordenamiento en listas" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/nuevo/paso4/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "nuevo", "paso4", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar programa — Paso 1 (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Programa Actualizado" },
+                { "key": "codigo", "value": "PIA-2024-V2" },
+                { "key": "descripcion", "value": "Descripción actualizada" },
+                { "key": "secretaria", "value": "1" },
+                { "key": "subsecretaria", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/1/editar/paso1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "1", "editar", "paso1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cambiar estado de programa",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"estado\": \"activo\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/configuracion/programas/1/estado/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["configuracion", "programas", "1", "estado", ""]
+            },
+            "description": "Cambia el estado del programa. Retorna JSON o redirige según implementación."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/conversaciones.postman_collection.json
+++ b/docs/api/conversaciones.postman_collection.json
@@ -1,0 +1,494 @@
+{
+  "info": {
+    "name": "Chaco — Conversaciones",
+    "description": "Sistema de chat entre ciudadanos y operadores del backoffice.\n\nDos superficies:\n1. **Chat público** (sin autenticación): endpoints para que el ciudadano consulte RENAPER, inicie la conversación, envíe y reciba mensajes.\n2. **Backoffice** (requiere sesión y capacidad): vistas HTML para gestión de conversaciones, asignación a operadores, respuesta, cierre y evaluación.\n3. **API JSON** (requiere sesión): métricas, estadísticas en tiempo real y alertas de conversaciones.\n\nNotas:\n- Los endpoints del chat ciudadano son públicos y reciben JSON.\n- Los endpoints de backoffice usan formularios HTML con CSRF.\n- Los endpoints API JSON usan sesión + X-CSRFToken para escrituras.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Chat ciudadano (público)",
+      "description": "Endpoints públicos para el flujo de chat del ciudadano. No requieren autenticación.",
+      "item": [
+        {
+          "name": "Pantalla de chat",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/chat/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "chat", ""]
+            },
+            "description": "Carga la interfaz HTML del chat para el ciudadano."
+          },
+          "response": []
+        },
+        {
+          "name": "Consultar RENAPER",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dni\": \"28901234\",\n  \"sexo\": \"M\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/consultar-renaper/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "consultar-renaper", ""]
+            },
+            "description": "Verifica identidad del ciudadano contra RENAPER.\nRetorna: {success: bool, datos: {nombre, apellido, fecha_nacimiento, domicilio}}\nSexo: M | F | X"
+          },
+          "response": []
+        },
+        {
+          "name": "Iniciar conversación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tipo\": \"CONSULTA\",\n  \"dni\": \"28901234\",\n  \"sexo\": \"M\",\n  \"datos_renaper\": {\n    \"nombre\": \"Juan\",\n    \"apellido\": \"Pérez\",\n    \"fecha_nacimiento\": \"1985-03-15\"\n  },\n  \"prioridad\": \"NORMAL\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/iniciar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "iniciar", ""]
+            },
+            "description": "Crea una nueva conversación para el ciudadano.\nRetorna: {success: bool, conversacion_id: int}\nTipos posibles: CONSULTA, RECLAMO, etc. (ver Conversacion.TIPO_CHOICES)\nPrioridades: NORMAL, ALTA, URGENTE (ver Conversacion.PRIORIDAD_CHOICES)"
+          },
+          "response": []
+        },
+        {
+          "name": "Enviar mensaje (ciudadano)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"mensaje\": \"Necesito información sobre el programa de asistencia alimentaria\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/enviar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "enviar", ""]
+            },
+            "description": "Envía un mensaje del ciudadano a la conversación indicada.\nRetorna: {success: bool, mensaje: {id, contenido, fecha}}"
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener mensajes (ciudadano)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/mensajes/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "mensajes", ""]
+            },
+            "description": "Polling de mensajes de la conversación para el ciudadano.\nRetorna: {mensajes: [{id, remitente, contenido, fecha}]}"
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Backoffice — Gestión de conversaciones",
+      "description": "Vistas del backoffice para operadores. Requieren sesión y capacidad de acceso a conversaciones.",
+      "item": [
+        {
+          "name": "Listar conversaciones",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de conversación",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Asignar conversación a operador",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "operador_id", "value": "5", "description": "ID del operador al que se asigna (opcional: si vacío puede auto-asignar)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/asignar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "asignar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Reasignar conversación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "operador_id", "value": "7", "description": "ID del nuevo operador" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/reasignar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "reasignar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Responder (operador envía mensaje)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "mensaje", "value": "Buenos días. Le informamos que puede acceder al programa desde el portal ciudadano." }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/responder/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "responder", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cerrar conversación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/cerrar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "cerrar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Evaluar conversación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "satisfaccion", "value": "4", "description": "Entero de 1 a 5 (1=muy insatisfecho, 5=muy satisfecho)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/1/evaluar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "1", "evaluar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Métricas de conversaciones",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/metricas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "metricas", ""]
+            },
+            "description": "Vista HTML con métricas de conversaciones."
+          },
+          "response": []
+        },
+        {
+          "name": "Configurar cola de atención",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "operador_id", "value": "5" },
+                { "key": "max_conversaciones", "value": "10", "description": "Entero >= 1, opcional" },
+                { "key": "activo", "value": "on", "description": "Checkbox: 'on' para activar" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/configurar-cola/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "configurar-cola", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Configurar asignación automática",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/asignacion-automatica/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "asignacion-automatica", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API JSON — Backoffice",
+      "description": "Endpoints JSON para el backoffice (métricas en tiempo real, estadísticas, detalle). Requieren sesión activa.",
+      "item": [
+        {
+          "name": "Métricas en tiempo real",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/api/metricas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "api", "metricas", ""]
+            },
+            "description": "Retorna métricas actuales del sistema de conversaciones en formato JSON."
+          },
+          "response": []
+        },
+        {
+          "name": "Estadísticas en tiempo real",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/api/estadisticas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "api", "estadisticas", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de conversación (JSON)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/conversaciones/api/conversacion/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["conversaciones", "api", "conversacion", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Alertas de conversaciones",
+      "description": "Endpoints DRF para gestión de alertas de nuevos mensajes. Base: /api/conversaciones/",
+      "item": [
+        {
+          "name": "Conteo de alertas no leídas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/conversaciones/alertas/count/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "conversaciones", "alertas", "count", ""]
+            },
+            "description": "Retorna el conteo de mensajes no leídos de conversaciones asignadas al usuario."
+          },
+          "response": []
+        },
+        {
+          "name": "Preview de alertas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/conversaciones/alertas/preview/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "conversaciones", "alertas", "preview", ""]
+            },
+            "description": "Retorna preview de conversaciones con mensajes no leídos (para dropdown de notificaciones)."
+          },
+          "response": []
+        },
+        {
+          "name": "Marcar mensajes como leídos",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/conversaciones/alertas/marcar-leidos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "conversaciones", "alertas", "marcar-leidos", "1", ""]
+            },
+            "description": "Marca todos los mensajes de la conversación indicada como leídos por el operador."
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de conversación vía API REST",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/conversaciones/conversacion/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "conversaciones", "conversacion", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/core.postman_collection.json
+++ b/docs/api/core.postman_collection.json
@@ -1,0 +1,689 @@
+{
+  "info": {
+    "name": "Chaco — Core",
+    "description": "Endpoints del módulo core: AJAX helpers para cascadas de selects, APIs de performance/métricas del sistema, y API REST de catálogos geográficos (provincias, municipios, localidades, sexos, meses, días).\n\nAutenticación: La mayoría requiere sesión Django activa. Para endpoints HTML incluir cookie 'sessionid'. Para endpoints REST incluir header 'X-CSRFToken' con el valor obtenido de la cookie 'csrftoken'.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "AJAX Helpers",
+      "description": "Endpoints de carga dinámica para cascadas de selects en formularios del backoffice.",
+      "item": [
+        {
+          "name": "Cargar municipios por provincia",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/ajax/load-municipios/?provincia_id=1",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["ajax", "load-municipios", ""],
+              "query": [
+                { "key": "provincia_id", "value": "1", "description": "ID de la provincia" }
+              ]
+            },
+            "description": "Retorna lista JSON de municipios filtrados por provincia. Usado en cascadas de selects."
+          },
+          "response": []
+        },
+        {
+          "name": "Cargar localidades por municipio",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/ajax/load-localidades/?municipio_id=1",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["ajax", "load-localidades", ""],
+              "query": [
+                { "key": "municipio_id", "value": "1", "description": "ID del municipio" }
+              ]
+            },
+            "description": "Retorna lista JSON de localidades filtradas por municipio."
+          },
+          "response": []
+        },
+        {
+          "name": "Cargar subsecretarías por secretaría",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/ajax/load-subsecretarias/?secretaria_id=1",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["ajax", "load-subsecretarias", ""],
+              "query": [
+                { "key": "secretaria_id", "value": "1", "description": "ID de la secretaría" }
+              ]
+            },
+            "description": "Retorna lista JSON de subsecretarías filtradas por secretaría."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Performance & Métricas del Sistema",
+      "description": "APIs internas de monitoreo de performance. Sin autenticación requerida.",
+      "item": [
+        {
+          "name": "Dashboard de performance",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/performance-dashboard/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["performance-dashboard", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "API de performance",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/performance-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["performance-api", ""]
+            },
+            "description": "Retorna JSON con datos de performance de la aplicación."
+          },
+          "response": []
+        },
+        {
+          "name": "Análisis de queries",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/query-analysis-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["query-analysis-api", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Sugerencias de optimización",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/optimization-suggestions-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["optimization-suggestions-api", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Métricas del sistema",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/system-metrics-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["system-metrics-api", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Alertas de sistema",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/alerts-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["alerts-api", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Métricas en tiempo real",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/realtime-metrics-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["realtime-metrics-api", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Métricas fase 2",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/phase2-metrics-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["phase2-metrics-api", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Ejecutar tests fase 2",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/run-phase2-tests-api/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["run-phase2-tests-api", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Geografía",
+      "description": "Endpoints DRF para catálogos geográficos. Requieren autenticación (sesión activa). Base: /api/core/",
+      "item": [
+        {
+          "name": "Provincias",
+          "item": [
+            {
+              "name": "Listar provincias",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/provincias/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "provincias", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Crear provincia",
+              "request": {
+                "method": "POST",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" },
+                  { "key": "Content-Type", "value": "application/json" }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"nombre\": \"Chaco\"\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/core/provincias/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "provincias", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Obtener provincia",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/provincias/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "provincias", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Actualizar provincia",
+              "request": {
+                "method": "PATCH",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" },
+                  { "key": "Content-Type", "value": "application/json" }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"nombre\": \"Chaco Actualizado\"\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/core/provincias/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "provincias", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Eliminar provincia",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/provincias/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "provincias", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Municipios de una provincia",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/provincias/1/municipios/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "provincias", "1", "municipios", ""]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Municipios",
+          "item": [
+            {
+              "name": "Listar municipios",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/municipios/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "municipios", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Crear municipio",
+              "request": {
+                "method": "POST",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" },
+                  { "key": "Content-Type", "value": "application/json" }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"nombre\": \"Resistencia\",\n  \"provincia_id\": 1\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/core/municipios/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "municipios", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Obtener municipio",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/municipios/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "municipios", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Actualizar municipio",
+              "request": {
+                "method": "PATCH",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" },
+                  { "key": "Content-Type", "value": "application/json" }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"nombre\": \"Resistencia Actualizado\",\n  \"provincia_id\": 1\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/core/municipios/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "municipios", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Eliminar municipio",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/municipios/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "municipios", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Localidades de un municipio",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/municipios/1/localidades/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "municipios", "1", "localidades", ""]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Localidades",
+          "item": [
+            {
+              "name": "Listar localidades",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/localidades/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "localidades", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Crear localidad",
+              "request": {
+                "method": "POST",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" },
+                  { "key": "Content-Type", "value": "application/json" }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"nombre\": \"Villa del Rosario\",\n  \"municipio_id\": 1\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/core/localidades/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "localidades", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Obtener localidad",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/localidades/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "localidades", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Actualizar localidad",
+              "request": {
+                "method": "PATCH",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" },
+                  { "key": "Content-Type", "value": "application/json" }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"nombre\": \"Villa del Rosario Actualizado\",\n  \"municipio_id\": 1\n}",
+                  "options": { "raw": { "language": "json" } }
+                },
+                "url": {
+                  "raw": "http://localhost:8000/api/core/localidades/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "localidades", "1", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Eliminar localidad",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" },
+                  { "key": "X-CSRFToken", "value": "<csrf-token>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/localidades/1/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "localidades", "1", ""]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Catálogos de referencia (solo lectura)",
+          "item": [
+            {
+              "name": "Listar sexos",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/sexos/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "sexos", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Listar meses",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/meses/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "meses", ""]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Listar días",
+              "request": {
+                "method": "GET",
+                "header": [
+                  { "key": "Cookie", "value": "sessionid=<session-id>" }
+                ],
+                "url": {
+                  "raw": "http://localhost:8000/api/core/dias/",
+                  "protocol": "http",
+                  "host": ["localhost"],
+                  "port": "8000",
+                  "path": ["api", "core", "dias", ""]
+                }
+              },
+              "response": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "OpenAPI / Documentación",
+      "item": [
+        {
+          "name": "Schema OpenAPI",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/api/schema/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "schema", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Swagger UI",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/api/docs/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "docs", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "ReDoc UI",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/api/redoc/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "redoc", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/dashboard.postman_collection.json
+++ b/docs/api/dashboard.postman_collection.json
@@ -1,0 +1,163 @@
+{
+  "info": {
+    "name": "Chaco — Dashboard",
+    "description": "Panel de control del backoffice. Vista principal y APIs JSON para métricas, búsqueda, alertas, actividad reciente y tendencias.\n\nTodos los endpoints requieren sesión activa (cookie 'sessionid') e IsAuthenticated.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Vista principal",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/dashboard/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["dashboard", ""]
+        },
+        "description": "Renderiza el dashboard HTML principal del backoffice."
+      },
+      "response": []
+    },
+    {
+      "name": "API — Métricas generales",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/metricas/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "metricas", ""]
+        },
+        "description": "Retorna JSON con métricas del sistema: totales de legajos, estados, usuarios conectados."
+      },
+      "response": []
+    },
+    {
+      "name": "API — Buscar ciudadanos",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/buscar-ciudadanos/?q=garcia",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "buscar-ciudadanos", ""],
+          "query": [
+            { "key": "q", "value": "garcia", "description": "Texto de búsqueda (mínimo 3 caracteres). Busca por nombre, apellido o DNI." }
+          ]
+        },
+        "description": "Búsqueda rápida de ciudadanos. Retorna: {results: [{id, nombre, dni}]}."
+      },
+      "response": []
+    },
+    {
+      "name": "API — Alertas críticas",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/alertas-criticas/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "alertas-criticas", ""]
+        },
+        "description": "Retorna JSON con alertas críticas activas: {results: [{id, ciudadano_id, ciudadano, tipo, prioridad, fecha, mensaje}]}."
+      },
+      "response": []
+    },
+    {
+      "name": "API — Actividad reciente",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/actividad-reciente/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "actividad-reciente", ""]
+        },
+        "description": "Retorna JSON con actividad reciente del sistema: {results: [{descripcion, usuario, tiempo, tipo, icono}]}."
+      },
+      "response": []
+    },
+    {
+      "name": "API — Tendencias (30 días)",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/tendencias/?periodo=30d",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "tendencias", ""],
+          "query": [
+            { "key": "periodo", "value": "30d", "description": "Período: 7d, 30d, 90d (default: 30d)" }
+          ]
+        },
+        "description": "Retorna JSON con datos de tendencias para gráficos: {labels: [], datos: []}."
+      },
+      "response": []
+    },
+    {
+      "name": "API — Tendencias (7 días)",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/tendencias/?periodo=7d",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "tendencias", ""],
+          "query": [
+            { "key": "periodo", "value": "7d" }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "API — Tendencias (90 días)",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "Cookie", "value": "sessionid=<session-id>" }
+        ],
+        "url": {
+          "raw": "http://localhost:8000/api/tendencias/?periodo=90d",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["api", "tendencias", ""],
+          "query": [
+            { "key": "periodo", "value": "90d" }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/docs/api/healthcheck.postman_collection.json
+++ b/docs/api/healthcheck.postman_collection.json
@@ -1,0 +1,25 @@
+{
+  "info": {
+    "name": "Chaco — Healthcheck",
+    "description": "Monitoreo de salud del sistema. Endpoint público sin autenticación.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health Check",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8000/health/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["health", ""]
+        },
+        "description": "Retorna el estado de salud de la aplicación. No requiere autenticación."
+      },
+      "response": []
+    }
+  ]
+}

--- a/docs/api/legajos.postman_collection.json
+++ b/docs/api/legajos.postman_collection.json
@@ -1,0 +1,1741 @@
+{
+  "info": {
+    "name": "Chaco — Legajos",
+    "description": "Gestión de legajos y ciudadanos. El módulo más completo del sistema. Incluye:\n\n1. **Ciudadanos**: búsqueda, CRUD, consulta RENAPER, alta manual/confirmada\n2. **Programas**: derivación de ciudadanos a programas sociales\n3. **Archivos**: subida y gestión de archivos por legajo/ciudadano\n4. **Alertas**: alertas por ciudadano, dashboard de alertas\n5. **Timeline y predicción**: historial de actividades y predicción de riesgo\n6. **NACHEC**: workflow completo de casos (validación, relevamiento, evaluación, seguimiento)\n7. **API REST DRF**: ciudadanos, alertas, historial de contactos, vínculos familiares\n\nAutenticación: sesión Django activa (cookie 'sessionid'). Control de acceso: CapacidadRequeridaMixin con capacidades como 'ciudadano.ver', 'ciudadano.crear', 'ciudadano.editar'.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Ciudadanos — Backoffice",
+      "item": [
+        {
+          "name": "Listar ciudadanos",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Buscar ciudadanos (AJAX)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/buscar/?q=garcia",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "buscar", ""],
+              "query": [
+                { "key": "q", "value": "garcia", "description": "Texto de búsqueda (mínimo 2 caracteres). Busca por nombre, apellido o DNI." }
+              ]
+            },
+            "description": "Retorna JSON con resultados. Usado en autocompletados."
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario nuevo ciudadano (paso 1 RENAPER)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/nuevo/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "nuevo", ""]
+            },
+            "description": "Primer paso del alta de ciudadano: formulario de consulta RENAPER."
+          },
+          "response": []
+        },
+        {
+          "name": "Consultar RENAPER para nuevo ciudadano (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "dni", "value": "28901234", "description": "DNI (max 8 caracteres)" },
+                { "key": "sexo", "value": "M", "description": "M | F | X" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/nuevo/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "nuevo", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario confirmar ciudadano (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/confirmar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "confirmar", ""]
+            },
+            "description": "Formulario pre-poblado con datos de RENAPER para que el operador confirme y complete."
+          },
+          "response": []
+        },
+        {
+          "name": "Confirmar y crear ciudadano (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "dni", "value": "28901234" },
+                { "key": "nombre", "value": "Juan" },
+                { "key": "apellido", "value": "Pérez" },
+                { "key": "fecha_nacimiento", "value": "1985-03-15" },
+                { "key": "genero", "value": "M" },
+                { "key": "telefono", "value": "3624123456" },
+                { "key": "email", "value": "juan.perez@gmail.com" },
+                { "key": "domicilio", "value": "Av. Las Heras 1234" },
+                { "key": "provincia", "value": "1" },
+                { "key": "municipio", "value": "1" },
+                { "key": "localidad", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/confirmar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "confirmar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Alta manual de ciudadano (sin RENAPER)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "dni", "value": "28901234" },
+                { "key": "nombre", "value": "María" },
+                { "key": "apellido", "value": "González" },
+                { "key": "fecha_nacimiento", "value": "1990-07-22" },
+                { "key": "genero", "value": "F" },
+                { "key": "telefono", "value": "3624654321" },
+                { "key": "email", "value": "maria.gonzalez@gmail.com" },
+                { "key": "domicilio", "value": "Sarmiento 456, B° Belgrano" },
+                { "key": "provincia", "value": "1" },
+                { "key": "municipio", "value": "1" },
+                { "key": "localidad", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/manual/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "manual", ""]
+            },
+            "description": "Alta manual sin consulta previa a RENAPER. El DNI es editable."
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de ciudadano",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario editar ciudadano (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar ciudadano (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nombre", "value": "Juan Carlos" },
+                { "key": "apellido", "value": "Pérez" },
+                { "key": "fecha_nacimiento", "value": "1985-03-15" },
+                { "key": "genero", "value": "M" },
+                { "key": "telefono", "value": "3624999000" },
+                { "key": "email", "value": "juancarlos.perez@gmail.com" },
+                { "key": "domicilio", "value": "Av. Las Heras 1234, Dpto 2A" },
+                { "key": "provincia", "value": "1" },
+                { "key": "municipio", "value": "1" },
+                { "key": "localidad", "value": "1" },
+                { "key": "tipo_vivienda", "value": "CASA", "description": "Tipo de vivienda (opcional)" },
+                { "key": "situacion_laboral", "value": "INFORMAL", "description": "Situación laboral (opcional)" },
+                { "key": "nivel_educativo", "value": "PRIMARIO_COMPLETO", "description": "Nivel educativo (opcional)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "editar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Programas — Derivaciones",
+      "item": [
+        {
+          "name": "Listar programas disponibles",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/programas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "programas", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de programa",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/programas/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "programas", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario derivar ciudadano a programa (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/derivar-programa/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "derivar-programa", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Derivar ciudadano a programa (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "programa", "value": "1", "description": "ID del programa" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/derivar-programa/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "derivar-programa", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Aceptar derivación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/derivaciones-ciudadano/1/aceptar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "derivaciones-ciudadano", "1", "aceptar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Rechazar derivación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/derivaciones-ciudadano/1/rechazar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "derivaciones-ciudadano", "1", "rechazar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Archivos",
+      "description": "Subida y consulta de archivos adjuntos por legajo o ciudadano.",
+      "item": [
+        {
+          "name": "Subir archivo a legajo",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "archivo", "type": "file", "description": "Archivo a subir (PDF, imagen, etc.)" },
+                { "key": "descripcion", "value": "Certificado médico", "type": "text" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/00000000-0000-0000-0000-000000000001/subir-archivos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "00000000-0000-0000-0000-000000000001", "subir-archivos", ""]
+            },
+            "description": "Sube uno o más archivos al legajo. La URL usa el UUID del legajo."
+          },
+          "response": []
+        },
+        {
+          "name": "Listar archivos de legajo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/00000000-0000-0000-0000-000000000001/archivos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "00000000-0000-0000-0000-000000000001", "archivos", ""]
+            },
+            "description": "Retorna JSON con lista de archivos del legajo."
+          },
+          "response": []
+        },
+        {
+          "name": "Listar archivos de ciudadano",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/archivos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "archivos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Subir archivo a ciudadano",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "archivo", "type": "file" },
+                { "key": "descripcion", "value": "DNI escaneado", "type": "text" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/subir-archivos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "subir-archivos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar archivo",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/archivos/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "archivos", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Alertas de ciudadanos",
+      "item": [
+        {
+          "name": "Dashboard de alertas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/alertas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "alertas", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Alertas de un ciudadano (AJAX)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/alertas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "alertas", ""]
+            },
+            "description": "Retorna JSON con alertas activas del ciudadano."
+          },
+          "response": []
+        },
+        {
+          "name": "Cerrar alerta (AJAX)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/alertas/1/cerrar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "alertas", "1", "cerrar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cerrar alerta (AJAX alternativo)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/alertas/1/cerrar-ajax/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "alertas", "1", "cerrar-ajax", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Conteo de alertas (navbar)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/alertas/count/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "alertas", "count", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Preview de alertas (navbar dropdown)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/alertas/preview/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "alertas", "preview", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Timeline y análisis",
+      "item": [
+        {
+          "name": "Actividades de ciudadano (AJAX)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/actividades/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "actividades", ""]
+            },
+            "description": "Retorna JSON con actividades del ciudadano para el timeline."
+          },
+          "response": []
+        },
+        {
+          "name": "Timeline de ciudadano por legajo (AJAX)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/timeline/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "timeline", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Predicción de riesgo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/ciudadanos/1/prediccion-riesgo/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "ciudadanos", "1", "prediccion-riesgo", ""]
+            },
+            "description": "Retorna JSON con predicción de nivel de riesgo del ciudadano."
+          },
+          "response": []
+        },
+        {
+          "name": "Evolución del legajo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/00000000-0000-0000-0000-000000000001/evolucion/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "00000000-0000-0000-0000-000000000001", "evolucion", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Historial de contactos del legajo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/00000000-0000-0000-0000-000000000001/historial-contactos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "00000000-0000-0000-0000-000000000001", "historial-contactos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Red de contactos del legajo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/00000000-0000-0000-0000-000000000001/red-contactos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "00000000-0000-0000-0000-000000000001", "red-contactos", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Reportes",
+      "item": [
+        {
+          "name": "Vista de reportes",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/reportes/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "reportes", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Exportar reportes CSV",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/reportes/exportar-csv/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "reportes", "exportar-csv", ""]
+            },
+            "description": "Descarga un archivo CSV con los datos del reporte. El header Content-Disposition fuerza la descarga."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "NACHEC — Gestión de casos",
+      "description": "Workflow del programa NACHEC. Flujo: Dashboard → Completar tarea → Validación → Asignación territorial → Relevamiento → Evaluación → Plan/Seguimiento → Cierre.",
+      "item": [
+        {
+          "name": "Dashboard NACHEC",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/dashboard/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "dashboard", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Completar tarea",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/tarea/1/completar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "tarea", "1", "completar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Ver tarea de validación",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/tarea-validacion/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "tarea-validacion", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Completar validación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/completar-validacion/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "completar-validacion", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Enviar a asignación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/enviar-asignacion/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "enviar-asignacion", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario asignar territorial (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/asignar-territorial/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "asignar-territorial", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Asignar territorial (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "territorial_id", "value": "3", "description": "ID del agente territorial asignado" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/asignar-territorial/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "asignar-territorial", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Reasignar territorial",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "territorial_id", "value": "5" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/reasignar-territorial/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "reasignar-territorial", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Iniciar relevamiento",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/iniciar-relevamiento/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "iniciar-relevamiento", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario de relevamiento (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/relevamiento/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "relevamiento", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Guardar relevamiento (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/relevamiento/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "relevamiento", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Autosave de relevamiento (AJAX)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"campo\": \"valor_parcial\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/relevamiento/autosave/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "relevamiento", "autosave", ""]
+            },
+            "description": "Guardado automático periódico del formulario de relevamiento. Retorna JSON."
+          },
+          "response": []
+        },
+        {
+          "name": "Adjuntar evidencias",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "evidencia", "type": "file", "description": "Archivo de evidencia (foto, documento)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/adjuntar-evidencias/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "adjuntar-evidencias", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Finalizar relevamiento",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/finalizar-relevamiento/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "finalizar-relevamiento", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario evaluar caso (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/evaluar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "evaluar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Evaluar caso (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/evaluar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "evaluar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Activar plan",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/activar-plan/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "activar-plan", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Pasar a seguimiento",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/pasar-seguimiento/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "pasar-seguimiento", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cerrar caso",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/cerrar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "cerrar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cerrar caso NACHEC (alternativo)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/cerrar-caso/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "cerrar-caso", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Reabrir caso NACHEC",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/caso/1/reabrir-caso/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "caso", "1", "reabrir-caso", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Iniciar prestación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/prestacion/1/iniciar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "prestacion", "1", "iniciar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Confirmar entrega de prestación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/prestacion/1/confirmar-entrega/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "prestacion", "1", "confirmar-entrega", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario reprogramar prestación (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/prestacion/1/reprogramar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "prestacion", "1", "reprogramar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Reprogramar prestación (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nueva_fecha", "value": "2026-07-15", "description": "Nueva fecha de prestación (YYYY-MM-DD)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/prestacion/1/reprogramar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "prestacion", "1", "reprogramar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cancelar prestación",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/legajos/nachec/prestacion/1/cancelar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["legajos", "nachec", "prestacion", "1", "cancelar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Ciudadanos",
+      "description": "DRF ViewSet. Base: /api/legajos/ciudadanos/",
+      "item": [
+        {
+          "name": "Listar ciudadanos",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/ciudadanos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "ciudadanos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear ciudadano",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dni\": \"28901234\",\n  \"nombre\": \"Juan\",\n  \"apellido\": \"Pérez\",\n  \"fecha_nacimiento\": \"1985-03-15\",\n  \"genero\": \"M\",\n  \"telefono\": \"3624123456\",\n  \"email\": \"juan.perez@gmail.com\",\n  \"domicilio\": \"Av. Las Heras 1234\",\n  \"activo\": true\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/ciudadanos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "ciudadanos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener ciudadano",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/ciudadanos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "ciudadanos", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar ciudadano (PATCH)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"telefono\": \"3624999000\",\n  \"email\": \"nuevo.email@gmail.com\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/ciudadanos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "ciudadanos", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar ciudadano",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/ciudadanos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "ciudadanos", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Alertas",
+      "description": "DRF ReadOnlyModelViewSet (solo lectura). Base: /api/legajos/alertas/",
+      "item": [
+        {
+          "name": "Listar alertas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/alertas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "alertas", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener alerta",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/alertas/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "alertas", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Historial de contactos",
+      "description": "DRF ViewSet. Base: /api/legajos/contactos/historial-contactos/",
+      "item": [
+        {
+          "name": "Listar historial (con filtros)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/historial-contactos/?legajo=1&tipo_contacto=PRESENCIAL&estado=REALIZADO",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "historial-contactos", ""],
+              "query": [
+                { "key": "legajo", "value": "1", "disabled": true, "description": "ID del legajo" },
+                { "key": "fecha_desde", "value": "2026-01-01", "disabled": true, "description": "Fecha desde (YYYY-MM-DD)" },
+                { "key": "fecha_hasta", "value": "2026-06-30", "disabled": true, "description": "Fecha hasta (YYYY-MM-DD)" },
+                { "key": "tipo_contacto", "value": "PRESENCIAL", "disabled": true, "description": "Tipo de contacto" },
+                { "key": "estado", "value": "REALIZADO", "disabled": true, "description": "Estado del contacto" },
+                { "key": "seguimiento_requerido", "value": "true", "disabled": true, "description": "Filtrar por seguimiento requerido" },
+                { "key": "profesional", "value": "5", "disabled": true, "description": "ID del profesional" },
+                { "key": "q", "value": "atencion", "disabled": true, "description": "Búsqueda por texto" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear entrada de historial",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"tipo_contacto\": \"PRESENCIAL\",\n  \"fecha_contacto\": \"2026-06-24T10:00:00\",\n  \"duracion_minutos\": 45,\n  \"estado\": \"REALIZADO\",\n  \"motivo\": \"Consulta sobre beneficios del programa alimentario\",\n  \"resumen\": \"El ciudadano fue informado sobre los requisitos y se le entregó la documentación necesaria.\",\n  \"acuerdos\": \"El ciudadano presentará la documentación el próximo lunes.\",\n  \"proximos_pasos\": \"Verificar documentación recibida y procesar la inscripción.\",\n  \"seguimiento_requerido\": true,\n  \"fecha_proximo_contacto\": \"2026-07-01\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/historial-contactos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "historial-contactos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener entrada de historial",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/historial-contactos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "historial-contactos", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar entrada de historial (PATCH)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resumen\": \"Resumen actualizado del contacto.\",\n  \"seguimiento_requerido\": false\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/historial-contactos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "historial-contactos", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar entrada de historial",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/historial-contactos/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "historial-contactos", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Vínculos familiares",
+      "description": "DRF ViewSet. Base: /api/legajos/contactos/vinculos-familiares/",
+      "item": [
+        {
+          "name": "Listar vínculos (con filtros)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/vinculos-familiares/?ciudadano=1&tipo_vinculo=HIJO&activo=true",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "vinculos-familiares", ""],
+              "query": [
+                { "key": "ciudadano", "value": "1", "disabled": true, "description": "ID del ciudadano principal" },
+                { "key": "tipo_vinculo", "value": "HIJO", "disabled": true, "description": "Tipo de vínculo familiar" },
+                { "key": "es_contacto_emergencia", "value": "true", "disabled": true },
+                { "key": "es_referente_tratamiento", "value": "false", "disabled": true },
+                { "key": "activo", "value": "true", "disabled": true },
+                { "key": "q", "value": "perez", "disabled": true, "description": "Búsqueda por texto (mínimo 2 caracteres)" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear vínculo familiar",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ciudadano_principal\": 1,\n  \"ciudadano_vinculado\": 2,\n  \"tipo_vinculo\": \"HIJO\",\n  \"es_contacto_emergencia\": false,\n  \"es_referente_tratamiento\": false,\n  \"activo\": true\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/vinculos-familiares/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "vinculos-familiares", ""]
+            },
+            "description": "Nota: ciudadano_principal y ciudadano_vinculado deben ser distintos (validación del servidor)."
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener vínculo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/vinculos-familiares/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "vinculos-familiares", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar vínculo (PATCH)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"es_contacto_emergencia\": true\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/vinculos-familiares/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "vinculos-familiares", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar vínculo",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/legajos/contactos/vinculos-familiares/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "legajos", "contactos", "vinculos-familiares", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/portal.postman_collection.json
+++ b/docs/api/portal.postman_collection.json
@@ -1,0 +1,592 @@
+{
+  "info": {
+    "name": "Chaco — Portal Ciudadano",
+    "description": "Portal público para ciudadanos. Incluye:\n- Autenticación propia del ciudadano (distinta al backoffice)\n- Registro en 2 pasos\n- Mi perfil: programas, consultas, datos personales\n- Gestión de contraseña y email\n- Reset de contraseña por email\n\nLa autenticación del portal es **independiente** del backoffice. El ciudadano se autentica con DNI + contraseña, no con usuario/contraseña de operador.\n\nLa cookie 'sessionid' del portal es la misma sesión Django pero con el usuario ciudadano (no operador).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Inicio del portal",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8000/portal/",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "8000",
+          "path": ["portal", ""]
+        },
+        "description": "Página de inicio pública del portal ciudadano."
+      },
+      "response": []
+    },
+    {
+      "name": "Autenticación ciudadano",
+      "item": [
+        {
+          "name": "Formulario de login (GET)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/login/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "login", ""]
+            },
+            "description": "Carga el formulario de login del ciudadano. También setea la cookie CSRF necesaria para el POST."
+          },
+          "response": []
+        },
+        {
+          "name": "Login ciudadano (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "username", "value": "28901234", "description": "DNI del ciudadano" },
+                { "key": "password", "value": "mi-contraseña-segura" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/login/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "login", ""]
+            },
+            "description": "Autentica al ciudadano. En caso de éxito redirige a 'mi-perfil' y setea cookie 'sessionid'."
+          },
+          "response": []
+        },
+        {
+          "name": "Logout ciudadano",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/logout/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "logout", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Registro de ciudadano (2 pasos)",
+      "description": "Flujo de registro en 2 pasos. Paso 1 verifica DNI/sexo en RENAPER. Paso 2 completa datos de cuenta.",
+      "item": [
+        {
+          "name": "Registro Paso 1 — Formulario (GET)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/registro/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "registro", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Registro Paso 1 — Verificar DNI (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "dni", "value": "28901234", "description": "DNI del ciudadano (max 10 caracteres)" },
+                { "key": "genero", "value": "M", "description": "M | F | X" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/registro/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "registro", ""]
+            },
+            "description": "Verifica el DNI contra RENAPER y habilita el paso 2. Si el ciudadano ya existe en el sistema carga sus datos."
+          },
+          "response": []
+        },
+        {
+          "name": "Registro Paso 2 — Formulario (GET)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/registro/verificar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "registro", "verificar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Registro Paso 2 — Completar cuenta (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "email", "value": "ciudadano@gmail.com", "description": "Email del ciudadano (requerido)" },
+                { "key": "telefono", "value": "3624123456", "description": "Teléfono (opcional, max 20 caracteres)" },
+                { "key": "password1", "value": "Contraseña1234!", "description": "Contraseña (mínimo 8 caracteres)" },
+                { "key": "password2", "value": "Contraseña1234!", "description": "Confirmación de contraseña" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/registro/verificar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "registro", "verificar", ""]
+            },
+            "description": "Completa el registro creando las credenciales de acceso al portal."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Mi perfil",
+      "description": "Área privada del ciudadano autenticado en el portal.",
+      "item": [
+        {
+          "name": "Mi perfil (inicio)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Mis programas",
+      "item": [
+        {
+          "name": "Listar mis programas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/programas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "programas", ""]
+            },
+            "description": "Lista los programas sociales a los que el ciudadano está inscripto."
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de programa",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/programas/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "programas", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Mis consultas",
+      "item": [
+        {
+          "name": "Listar mis consultas",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/consultas/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "consultas", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario nueva consulta (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/consultas/nueva/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "consultas", "nueva", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear nueva consulta (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "motivo", "value": "Necesito información sobre los requisitos para acceder al programa de asistencia alimentaria y cuáles son los pasos a seguir.", "description": "Texto del motivo (mínimo 10, máximo 2000 caracteres)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/consultas/nueva/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "consultas", "nueva", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de consulta",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/consultas/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "consultas", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Enviar mensaje en consulta",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "texto", "value": "Muchas gracias por la información. Tengo una duda adicional sobre los documentos necesarios.", "description": "Texto del mensaje (máximo 2000 caracteres)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/consultas/1/enviar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "consultas", "1", "enviar", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Mis datos personales",
+      "item": [
+        {
+          "name": "Ver mis datos",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/mis-datos/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "mis-datos", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario cambio de email (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/mis-datos/cambio-email/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "mis-datos", "cambio-email", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cambiar email (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "nuevo_email", "value": "nuevo.email@gmail.com" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/mis-datos/cambio-email/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "mis-datos", "cambio-email", ""]
+            },
+            "description": "Inicia el proceso de cambio de email. Envía un link de confirmación al nuevo email."
+          },
+          "response": []
+        },
+        {
+          "name": "Confirmar cambio de email (link)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/mis-datos/confirmar-email/00000000-0000-0000-0000-000000000001/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "mis-datos", "confirmar-email", "00000000-0000-0000-0000-000000000001", ""]
+            },
+            "description": "Token UUID enviado al nuevo email. Confirma el cambio de dirección de email."
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario cambio de contraseña (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/mis-datos/cambio-password/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "mis-datos", "cambio-password", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cambiar contraseña (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id-ciudadano>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "old_password", "value": "ContraseñaActual1234!" },
+                { "key": "new_password1", "value": "NuevaContraseña1234!", "description": "Mínimo 8 caracteres" },
+                { "key": "new_password2", "value": "NuevaContraseña1234!" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/mis-datos/cambio-password/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "mis-datos", "cambio-password", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Reset de contraseña (sin sesión)",
+      "description": "Flujo completo de recuperación de contraseña por email. No requiere sesión activa.",
+      "item": [
+        {
+          "name": "Formulario solicitar reset (GET)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/password/reset/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "password", "reset", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Solicitar reset de contraseña (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "email", "value": "ciudadano@gmail.com", "description": "Email registrado del ciudadano" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/password/reset/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "password", "reset", ""]
+            },
+            "description": "Envía un email con link para resetear la contraseña."
+          },
+          "response": []
+        },
+        {
+          "name": "Confirmación de envío",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/password/reset/enviado/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "password", "reset", "enviado", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Confirmar reset (link del email)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/password/reset/MQ/abc123-token-del-email/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "password", "reset", "MQ", "abc123-token-del-email", ""]
+            },
+            "description": "uidb64 y token son generados por Django y enviados en el email de reset."
+          },
+          "response": []
+        },
+        {
+          "name": "Establecer nueva contraseña (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "new_password1", "value": "NuevaContraseña1234!" },
+                { "key": "new_password2", "value": "NuevaContraseña1234!" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/password/reset/MQ/abc123-token-del-email/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "password", "reset", "MQ", "abc123-token-del-email", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Reset completado",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/portal/mi-perfil/password/reset/completado/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["portal", "mi-perfil", "password", "reset", "completado", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/users.postman_collection.json
+++ b/docs/api/users.postman_collection.json
@@ -1,0 +1,597 @@
+{
+  "info": {
+    "name": "Chaco — Users",
+    "description": "Gestión de usuarios del backoffice, roles y autenticación de operadores.\n\nIncluye:\n- Login/logout de operadores\n- CRUD de usuarios (vistas HTML + API REST DRF)\n- CRUD de roles con capacidades\n- API REST de grupos y perfiles\n\nAutenticación HTML: cookie 'sessionid'.\nAutenticación DRF: sesión activa + header 'X-CSRFToken' para escrituras.\nControl de acceso: AdminRequiredMixin para usuarios, RBAC capacidad 'rol.administrar' para roles.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Autenticación",
+      "item": [
+        {
+          "name": "Login (obtener sesión)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" },
+              { "key": "Referer", "value": "http://localhost:8000/" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "username", "value": "admin", "description": "Nombre de usuario del operador" },
+                { "key": "password", "value": "admin1234", "description": "Contraseña" },
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>", "description": "Token CSRF obtenido de la cookie 'csrftoken' al cargar el formulario GET" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": [""]
+            },
+            "description": "Autentica al operador. En caso de éxito redirige al dashboard y setea cookie 'sessionid'. Primero realizar GET / para obtener el csrfmiddlewaretoken."
+          },
+          "response": []
+        },
+        {
+          "name": "Logout",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/logout",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["logout"]
+            },
+            "description": "Cierra la sesión del operador y redirige al login."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Usuarios (vistas backoffice)",
+      "description": "Vistas HTML para gestión de usuarios. Requieren AdminRequiredMixin.",
+      "item": [
+        {
+          "name": "Listar usuarios",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/usuarios/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["usuarios", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario crear usuario (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/usuarios/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["usuarios", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear usuario (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "username", "value": "nuevo.operador" },
+                { "key": "first_name", "value": "Juan" },
+                { "key": "last_name", "value": "Pérez" },
+                { "key": "email", "value": "juan.perez@ejemplo.gob.ar" },
+                { "key": "password", "value": "Contraseña1234!" },
+                { "key": "groups", "value": "1", "description": "IDs de roles (puede repetirse para múltiples)" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/usuarios/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["usuarios", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario editar usuario (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/usuarios/editar/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["usuarios", "editar", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar usuario (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "username", "value": "juan.perez" },
+                { "key": "first_name", "value": "Juan" },
+                { "key": "last_name", "value": "Pérez" },
+                { "key": "email", "value": "juan.perez@ejemplo.gob.ar" },
+                { "key": "groups", "value": "1" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/usuarios/editar/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["usuarios", "editar", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Toggle activo/inactivo usuario",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/usuarios/1/toggle/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["usuarios", "1", "toggle", ""]
+            },
+            "description": "Activa o desactiva el usuario. Retorna JSON o redirige."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Roles (vistas backoffice)",
+      "description": "Vistas HTML para gestión de roles con capacidades RBAC. Requieren capacidad 'rol.administrar'.",
+      "item": [
+        {
+          "name": "Listar roles",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/roles/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario crear rol (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/roles/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear rol (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "name", "value": "Operador de Legajos" },
+                { "key": "descripcion", "value": "Rol para operadores que gestionan legajos de ciudadanos" },
+                { "key": "categoria", "value": "OPERACION", "description": "Valor de CATEGORIAS_ROL_CHOICES" },
+                { "key": "programa", "value": "", "description": "ID de programa (opcional)" },
+                { "key": "capacidades", "value": "ciudadano.ver", "description": "Puede repetirse para múltiples capacidades" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/roles/crear/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "crear", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Detalle de rol",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/roles/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Formulario editar rol (GET)",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/roles/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Editar rol (POST)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" },
+                { "key": "name", "value": "Operador de Legajos Actualizado" },
+                { "key": "descripcion", "value": "Descripción actualizada" },
+                { "key": "categoria", "value": "OPERACION" },
+                { "key": "capacidades", "value": "ciudadano.ver" },
+                { "key": "capacidades", "value": "ciudadano.editar" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/roles/1/editar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "1", "editar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar rol",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "csrfmiddlewaretoken", "value": "<csrf-token>" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:8000/roles/1/eliminar/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "1", "eliminar", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Toggle activo/inactivo rol",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/roles/1/toggle/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["roles", "1", "toggle", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Usuarios",
+      "description": "DRF ViewSet. Base: /api/users/users/",
+      "item": [
+        {
+          "name": "Listar usuarios",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/users/users/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "users", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear usuario",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"nuevo.usuario\",\n  \"email\": \"nuevo@ejemplo.gob.ar\",\n  \"first_name\": \"María\",\n  \"last_name\": \"González\",\n  \"password\": \"Contraseña1234!\",\n  \"password_confirm\": \"Contraseña1234!\",\n  \"is_active\": true,\n  \"groups\": [1]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/users/users/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "users", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener usuario",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/users/users/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "users", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar usuario (PATCH)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"actualizado@ejemplo.gob.ar\",\n  \"first_name\": \"María José\",\n  \"is_active\": true,\n  \"groups\": [1, 2]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/users/users/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "users", "1", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar usuario",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/users/users/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "users", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Grupos",
+      "description": "DRF ViewSet para grupos Django. Base: /api/users/groups/",
+      "item": [
+        {
+          "name": "Listar grupos",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/users/groups/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "groups", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Crear grupo",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Operadores Legajos\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/users/groups/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "groups", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener grupo",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/users/groups/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "groups", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "API REST — Perfiles",
+      "description": "DRF ViewSet para perfiles de usuario. Base: /api/users/profiles/",
+      "item": [
+        {
+          "name": "Listar perfiles",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/api/users/profiles/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "profiles", ""]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar perfil (modo oscuro)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Cookie", "value": "sessionid=<session-id>" },
+              { "key": "X-CSRFToken", "value": "<csrf-token>" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dark_mode\": true\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:8000/api/users/profiles/1/",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["api", "users", "profiles", "1", ""]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Lleva a `development` las colecciones Postman que se mergearon a `main` en el PR #89 (apuntado a main por error).

Cherry-pick limpio del commit ae28779 sobre development: 9 archivos nuevos en `docs/api/` (~220 endpoints, +5102 lineas): healthcheck, core, users, configuracion, conversaciones, legajos, portal, dashboard.

Cambio puramente aditivo (solo docs). Reemplaza al PR #92 (que arrastraba tambien Becas).