### PR TITLE
feat(becas): filtrado dinámico de subsegmento en formulario de convocatoria (#75)

### DIFF
--- a/programas/templates/programas/becas/relevamientos/convocatoria_form.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_form.html
@@ -1,5 +1,5 @@
 {% extends "includes/base.html" %}
-{% block title %}Becas · Nueva convocatoria{% endblock %}
+{% block title %}Becas · {% if convocatoria %}Editar convocatoria{% else %}Nueva convocatoria{% endif %}{% endblock %}
 
 {% block main-content %}
 <div class="max-w-2xl mx-auto">
@@ -8,19 +8,104 @@
     <i class="fas fa-chevron-right text-[8px] opacity-50"></i>
     <a href="{% url 'becas:convocatorias' %}" class="hover:underline">Convocatorias</a>
     <i class="fas fa-chevron-right text-[8px] opacity-50"></i>
-    <span class="font-semibold text-body">Nueva</span>
+    <span class="font-semibold text-body">{% if convocatoria %}Editar{% else %}Nueva{% endif %}</span>
   </nav>
-  <h1 class="text-3xl font-extrabold text-heading tracking-tight mb-6">Nueva convocatoria</h1>
-  <form method="post" class="bg-white rounded-xl border border-[#E5E7EB] shadow-sm p-6">
+  <h1 class="text-3xl font-extrabold text-heading tracking-tight mb-6">
+    {% if convocatoria %}Editar convocatoria{% else %}Nueva convocatoria{% endif %}
+  </h1>
+  <form method="post"
+        x-data="convocatoriaForm('{{ form.segmento.value|default:'' }}', '{{ form.subsegmento.value|default:'' }}')"
+        class="bg-white rounded-xl border border-[#E5E7EB] shadow-sm p-6">
     {% csrf_token %}
     {% if form.non_field_errors %}
       <div class="mb-4 rounded-lg bg-danger-soft p-3 text-sm text-fg-danger">{{ form.non_field_errors }}</div>
     {% endif %}
-    {% for field in form %}{% include "programas/becas/_field.html" %}{% endfor %}
+
+    {# nombre #}
+    {% with field=form.nombre %}{% include "programas/becas/_field.html" %}{% endwith %}
+
+    {# segmento — con listener Alpine para filtrar subsegmentos #}
+    <div class="mb-4">
+      <label class="block text-sm font-medium text-heading mb-1" for="{{ form.segmento.id_for_label }}">
+        {{ form.segmento.label }} <span class="text-fg-danger">*</span>
+      </label>
+      <select name="segmento"
+              id="{{ form.segmento.id_for_label }}"
+              class="nodo-field"
+              @change="onSegmentoChange($event.target.value)">
+        {% for val, label in form.segmento.field.choices %}
+          <option value="{{ val }}"{% if val|stringformat:"s" == form.segmento.value|stringformat:"s" %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      {% for error in form.segmento.errors %}<p class="mt-1 text-xs text-fg-danger">{{ error }}</p>{% endfor %}
+    </div>
+
+    {# subsegmento — se repuebla dinámicamente, deshabilitado sin segmento #}
+    <div class="mb-4">
+      <label class="block text-sm font-medium text-heading mb-1" for="{{ form.subsegmento.id_for_label }}">
+        {{ form.subsegmento.label }}
+      </label>
+      <select name="subsegmento"
+              id="{{ form.subsegmento.id_for_label }}"
+              class="nodo-field"
+              :disabled="!segmentoId">
+        <option value="">---------</option>
+        <template x-for="sub in subsegmentos" :key="sub.id">
+          <option :value="sub.id" :selected="subsegmentoId == sub.id" x-text="sub.nombre"></option>
+        </template>
+      </select>
+      <template x-if="!segmentoId">
+        <p class="mt-1 text-xs text-body-subtle">Seleccioná un segmento primero.</p>
+      </template>
+      {% for error in form.subsegmento.errors %}<p class="mt-1 text-xs text-fg-danger">{{ error }}</p>{% endfor %}
+    </div>
+
+    {# campos restantes #}
+    {% with field=form.fecha_inicio %}{% include "programas/becas/_field.html" %}{% endwith %}
+    {% with field=form.fecha_fin %}{% include "programas/becas/_field.html" %}{% endwith %}
+    {% with field=form.descripcion %}{% include "programas/becas/_field.html" %}{% endwith %}
+    {% with field=form.activo %}{% include "programas/becas/_field.html" %}{% endwith %}
+
     <div class="flex justify-end gap-3 mt-6 pt-4 border-t border-[#F3F4F6]">
       <a href="{% url 'becas:convocatorias' %}" class="btn-nodo btn-secondary btn-base">← Cancelar</a>
       <button type="submit" class="btn-nodo btn-brand btn-base">Guardar convocatoria</button>
     </div>
   </form>
 </div>
+
+<script>
+function convocatoriaForm(segmentoIdRaw, subsegmentoIdRaw) {
+  return {
+    segmentoId: segmentoIdRaw ? parseInt(segmentoIdRaw) : null,
+    subsegmentoId: subsegmentoIdRaw ? parseInt(subsegmentoIdRaw) : null,
+    subsegmentos: [],
+
+    async init() {
+      if (this.segmentoId) {
+        await this.fetchSubsegmentos(this.segmentoId);
+      }
+    },
+
+    async onSegmentoChange(value) {
+      this.segmentoId = value ? parseInt(value) : null;
+      this.subsegmentoId = null;
+      this.subsegmentos = [];
+      if (this.segmentoId) {
+        await this.fetchSubsegmentos(this.segmentoId);
+      }
+    },
+
+    async fetchSubsegmentos(segmentoId) {
+      try {
+        const resp = await fetch(`{% url 'becas:segmento_subsegmentos_json' pk=0 %}`.replace('/0/', `/${segmentoId}/`));
+        if (resp.ok) {
+          this.subsegmentos = await resp.json();
+        }
+      } catch (_) {
+        this.subsegmentos = [];
+      }
+    },
+  };
+}
+</script>
 {% endblock %}

--- a/programas/urls.py
+++ b/programas/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
 
     # --- Subsegmentos ---
     path("config/segmentos/<int:segmento_pk>/subsegmentos/nuevo/", cfg.subsegmento_crear, name="subsegmento_crear"),
+    path("config/segmentos/<int:pk>/subsegmentos-json/", cfg.segmento_subsegmentos_json, name="segmento_subsegmentos_json"),
     path("config/subsegmentos/<int:pk>/", cfg.SubsegmentoDetailView.as_view(), name="subsegmento_detalle"),
     path("config/subsegmentos/<int:pk>/editar/", cfg.subsegmento_editar, name="subsegmento_editar"),
     path("config/subsegmentos/<int:pk>/eliminar/", cfg.subsegmento_eliminar, name="subsegmento_eliminar"),

--- a/programas/views/configuracion.py
+++ b/programas/views/configuracion.py
@@ -8,6 +8,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Count, Sum
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, ListView, UpdateView
@@ -493,3 +494,19 @@ def pregunta_eliminar(request, pk):
         pregunta.delete()
         messages.success(request, "Pregunta eliminada.")
     return redirect("becas:preguntas")
+
+
+# ---------------------------------------------------------------------------
+# API JSON — uso interno del formulario de convocatoria
+# ---------------------------------------------------------------------------
+@login_required
+@requiere(CAP_CONFIG)
+def segmento_subsegmentos_json(request, pk):
+    """Devuelve los subsegmentos activos de un segmento para el filtrado dinámico."""
+    segmento = get_object_or_404(Segmento, pk=pk)
+    data = list(
+        segmento.subsegmentos.filter(activo=True)
+        .order_by("nombre")
+        .values("id", "nombre", "cupo_maximo")
+    )
+    return JsonResponse(data, safe=False)


### PR DESCRIPTION
## Resumen

Cierra #75. El select de `subsegmento` en el formulario de Convocatorias ahora filtra dinámicamente según el segmento elegido y queda deshabilitado cuando no hay segmento seleccionado.

## Cambios

- **`programas/views/configuracion.py`** — nueva vista `segmento_subsegmentos_json`: `GET /becas/config/segmentos/<pk>/subsegmentos-json/` que devuelve los subsegmentos activos como `[{id, nombre, cupo_maximo}]`. Protegida con `@requiere(becas.configurar)` (mismo mixin que el resto de las vistas de config).
- **`programas/urls.py`** — URL registrada con nombre `becas:segmento_subsegmentos_json`.
- **`programas/templates/programas/becas/relevamientos/convocatoria_form.html`** — template refactorizado: los campos `segmento` y `subsegmento` se renderizan manualmente con Alpine.js; el resto sigue usando el partial `_field.html` sin cambios.

## Comportamiento

| Caso | Resultado |
|---|---|
| Formulario nuevo | `subsegmento` deshabilitado, muestra hint. |
| Cambio de segmento | Fetch al endpoint, repuebla opciones, resetea subsegmento anterior. |
| Edición de convocatoria | `init()` fetchea los subsegmentos del segmento actual y preselecciona el guardado. |
| Error de validación (re-render) | Igual que edición — `form.segmento.value` y `form.subsegmento.value` retienen los valores enviados. |

## Validación

- `manage.py check` sin errores.
- El filtrado de backend existente en `Convocatoria.clean()` no fue tocado.