### PR TITLE
feat(roles): tabs no exclusivos + buscador + categorías ÑACHEC/Becas

### DIFF
--- a/core/rbac.py
+++ b/core/rbac.py
@@ -32,6 +32,7 @@ CATALOGO = [
     {
         "modulo": "ciudadanos",
         "label": "Ciudadanos / Legajos",
+        "tab": "backoffice",
         "capacidades": [
             ("ciudadano.ver", "Ver ciudadanos y legajos"),
             ("ciudadano.crear", "Crear ciudadanos"),
@@ -43,6 +44,7 @@ CATALOGO = [
     {
         "modulo": "programas",
         "label": "Programas",
+        "tab": "backoffice",
         "alcance": "programa",  # módulo "de programa": sus capacidades se evalúan con alcance
         "capacidades": [
             ("programa.ver", "Ver programas"),
@@ -53,6 +55,7 @@ CATALOGO = [
     {
         "modulo": "relevamientos",
         "label": "Relevamientos",
+        "tab": "becas",
         "alcance": "programa",  # módulo "de programa": sus capacidades se evalúan con alcance
         "capacidades": [
             ("relevamiento.ver", "Ver relevamientos"),
@@ -62,6 +65,7 @@ CATALOGO = [
     {
         "modulo": "becas",
         "label": "Programa Becas",
+        "tab": "becas",
         "alcance": "programa",  # módulo "de programa": sus capacidades se evalúan con alcance
         "capacidades": [
             ("becas.configurar", "Configurar Becas (segmentos, cupos, requisitos, preguntas, coordinadores)"),
@@ -73,6 +77,7 @@ CATALOGO = [
     {
         "modulo": "conversaciones",
         "label": "Conversaciones",
+        "tab": "backoffice",
         "capacidades": [
             ("conversacion.operar", "Operar conversaciones"),
             ("conversacion.configurar", "Configurar conversaciones"),
@@ -82,6 +87,7 @@ CATALOGO = [
     {
         "modulo": "dashboard",
         "label": "Dashboard",
+        "tab": "backoffice",
         "capacidades": [
             ("dashboard.ver", "Ver dashboard"),
         ],
@@ -89,6 +95,7 @@ CATALOGO = [
     {
         "modulo": "reportes",
         "label": "Reportes",
+        "tab": "backoffice",
         "capacidades": [
             ("reporte.ver", "Ver reportes"),
         ],
@@ -96,6 +103,7 @@ CATALOGO = [
     {
         "modulo": "configuracion",
         "label": "Configuración (geografía)",
+        "tab": "sistema",
         "capacidades": [
             ("config.ver", "Ver configuración"),
             ("config.administrar", "Administrar configuración"),
@@ -104,6 +112,7 @@ CATALOGO = [
     {
         "modulo": "instituciones",
         "label": "Instituciones",
+        "tab": "institucion",
         "capacidades": [
             ("institucion.ver", "Ver instituciones"),
             ("institucion.administrar", "Administrar instituciones"),
@@ -112,6 +121,7 @@ CATALOGO = [
     {
         "modulo": "sistema",
         "label": "Sistema",
+        "tab": "sistema",
         "capacidades": [
             ("usuario.administrar", "Administrar usuarios"),
             ("rol.administrar", "Administrar roles"),
@@ -124,17 +134,29 @@ CATEGORIA_BACKOFFICE = "Backoffice"
 CATEGORIA_INSTITUCION = "Institución"
 CATEGORIA_PORTAL = "Portal"
 CATEGORIA_SISTEMA = "Sistema"
-# Categoría de roles con alcance de Programa: si un Rol la tiene, su
-# ``RolMeta.programa`` es obligatorio (y solo en esta categoría puede no ser nulo).
+CATEGORIA_NACHEC = "ÑACHEC"
+CATEGORIA_BECAS = "Becas"
+# Valor legacy: usado en datos históricos y tests. No aparece en el selector de UI.
 CATEGORIA_PROGRAMA = "Programa"
 CATEGORIAS_ROL = [
     CATEGORIA_BACKOFFICE,
     CATEGORIA_INSTITUCION,
     CATEGORIA_PORTAL,
     CATEGORIA_SISTEMA,
-    CATEGORIA_PROGRAMA,
+    CATEGORIA_NACHEC,
+    CATEGORIA_BECAS,
 ]
 CATEGORIAS_ROL_CHOICES = [(c, c) for c in CATEGORIAS_ROL]
+
+# Metadatos de los tabs para el ABM de Roles (panel de capacidades).
+TABS_CAPACIDADES = [
+    {"id": "backoffice", "label": "Backoffice", "icon": "fa-table-columns"},
+    {"id": "institucion", "label": "Institución", "icon": "fa-building-columns"},
+    {"id": "portal", "label": "Portal", "icon": "fa-globe"},
+    {"id": "sistema", "label": "Sistema", "icon": "fa-gear"},
+    {"id": "nachec", "label": "ÑACHEC", "icon": "fa-seedling"},
+    {"id": "becas", "label": "Becas", "icon": "fa-graduation-cap"},
+]
 
 # Capacidades que dan acceso de administración del propio RBAC (para auto-protección).
 CAPS_ADMINISTRACION = ("usuario.administrar", "rol.administrar")
@@ -220,8 +242,8 @@ def arbol_capacidades(codigos_activos=(), solo_programa=False):
         [{"modulo", "label", "capacidades": [{"codigo", "label", "checked"}]}]
 
     Con ``solo_programa=True`` se limita a los módulos "de programa"
-    (``alcance == "programa"``), para roles de categoría ``"Programa"``. El
-    default es retrocompatible: devuelve el catálogo completo.
+    (``alcance == "programa"``). El default es retrocompatible: devuelve el
+    catálogo completo.
     """
     activos = set(codigos_activos)
     return [
@@ -237,6 +259,34 @@ def arbol_capacidades(codigos_activos=(), solo_programa=False):
         for modulo in CATALOGO
         if not solo_programa or modulo.get("alcance") == "programa"
     ]
+
+
+def arbol_por_tabs(codigos_activos=(), solo_programa=False):
+    """Catálogo agrupado por tab para el panel de capacidades del ABM de Roles.
+
+    Devuelve la lista de tabs definida en :data:`TABS_CAPACIDADES`, cada una con
+    los módulos que le corresponden y las capacidades marcadas según
+    ``codigos_activos``. Los tabs vacíos se incluyen (permiten futura expansión).
+
+    Con ``solo_programa=True`` solo incluye módulos con ``alcance == "programa"``.
+    """
+    activos = set(codigos_activos)
+    tabs = {t["id"]: {"id": t["id"], "label": t["label"], "icon": t["icon"], "modulos": []} for t in TABS_CAPACIDADES}
+    for modulo in CATALOGO:
+        if solo_programa and modulo.get("alcance") != "programa":
+            continue
+        tab_id = modulo.get("tab", "backoffice")
+        if tab_id not in tabs:
+            continue
+        tabs[tab_id]["modulos"].append({
+            "modulo": modulo["modulo"],
+            "label": modulo["label"],
+            "capacidades": [
+                {"codigo": codigo, "label": etiqueta, "checked": codigo in activos}
+                for (codigo, etiqueta) in modulo["capacidades"]
+            ],
+        })
+    return list(tabs.values())
 
 
 # ---------------------------------------------------------------------------

--- a/users/forms/roles.py
+++ b/users/forms/roles.py
@@ -64,23 +64,19 @@ class RolForm(forms.Form):
             progs = programas_administrables(operador)
             self.fields["programa"].queryset = progs
             self.fields["programa"].empty_label = None
-            # El alcance fija la categoría en 'Programa' y acota el árbol/capacidades.
-            # categoría y (si hay uno solo) programa se fuerzan en clean(), por eso
-            # no son required a nivel de campo: el servidor no confía en el POST.
             self.fields["categoria"].choices = [
-                (rbac.CATEGORIA_PROGRAMA, rbac.CATEGORIA_PROGRAMA)
+                (rbac.CATEGORIA_NACHEC, rbac.CATEGORIA_NACHEC),
+                (rbac.CATEGORIA_BECAS, rbac.CATEGORIA_BECAS),
             ]
-            self.fields["categoria"].required = False
-            self.fields["categoria"].initial = rbac.CATEGORIA_PROGRAMA
+            self.fields["categoria"].required = True
+            self.fields["categoria"].initial = rbac.CATEGORIA_BECAS
             self.fields["capacidades"].choices = [
                 (c, c) for c in sorted(rbac.codigos_de_programa())
             ]
+            self.fields["programa"].required = False
             if progs.count() == 1:
                 self.programa_fijo = progs.first()
                 self.fields["programa"].initial = self.programa_fijo.pk
-                self.fields["programa"].required = False
-            else:
-                self.fields["programa"].required = True
 
         if instance is not None and not self.is_bound:
             self.fields["name"].initial = instance.name
@@ -101,44 +97,24 @@ class RolForm(forms.Form):
         return name
 
     def clean(self):
-        """RN-1 + forzado de alcance para admins de programa.
-
-        Un admin de programa no decide la categoría ni puede salirse de su
-        programa ni tildar capacidades globales: se fuerza en servidor sin
-        confiar en el POST.
-        """
+        """Forzado de alcance para admins de programa (server-side, sin confiar en el POST)."""
         cleaned = super().clean()
         if not self.es_admin_global:
-            cleaned["categoria"] = rbac.CATEGORIA_PROGRAMA
             if self.programa_fijo is not None:
                 cleaned["programa"] = self.programa_fijo
             caps = cleaned.get("capacidades") or []
             cleaned["capacidades"] = [c for c in caps if rbac.es_codigo_de_programa(c)]
-
-        categoria = cleaned.get("categoria")
-        programa = cleaned.get("programa")
-        if categoria == rbac.CATEGORIA_PROGRAMA and programa is None:
-            self.add_error("programa", "Un rol de categoría 'Programa' requiere seleccionar un Programa.")
-        if categoria != rbac.CATEGORIA_PROGRAMA and programa is not None:
-            self.add_error("programa", "Solo los roles de categoría 'Programa' pueden tener un Programa asociado.")
         return cleaned
 
-    def _categoria_actual(self):
+    def _activos(self):
         if self.is_bound:
-            return self.data.get("categoria")
-        return self.fields["categoria"].initial
+            return self.data.getlist("capacidades") if hasattr(self.data, "getlist") else self.data.get("capacidades", [])
+        return self.fields["capacidades"].initial or []
 
     def arbol_capacidades(self):
-        """Árbol por módulo con el estado tildado (para renderizar el formulario).
+        """Árbol plano por módulo (retrocompatibilidad)."""
+        return rbac.arbol_capacidades(self._activos(), solo_programa=not self.es_admin_global)
 
-        Se limita a módulos "de programa" cuando el rol es de categoría
-        'Programa' o el operador es admin de programa.
-        """
-        if self.is_bound:
-            activos = self.data.getlist("capacidades") if hasattr(self.data, "getlist") else self.data.get("capacidades", [])
-        else:
-            activos = self.fields["capacidades"].initial or []
-        solo_programa = (not self.es_admin_global) or (
-            self._categoria_actual() == rbac.CATEGORIA_PROGRAMA
-        )
-        return rbac.arbol_capacidades(activos, solo_programa=solo_programa)
+    def arbol_por_tabs(self):
+        """Árbol agrupado por tab para el panel de capacidades."""
+        return rbac.arbol_por_tabs(self._activos(), solo_programa=not self.es_admin_global)

--- a/users/migrations/0005_alter_rolmeta_categoria.py
+++ b/users/migrations/0005_alter_rolmeta_categoria.py
@@ -1,0 +1,31 @@
+# Generated manually 2026-06-29: reemplaza CATEGORIA_PROGRAMA por CATEGORIA_NACHEC + CATEGORIA_BECAS.
+# No cambia el esquema de la DB; actualiza las choices para validación a nivel de formulario.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0004_alter_capacidad_options'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='rolmeta',
+            name='categoria',
+            field=models.CharField(
+                choices=[
+                    ('Backoffice', 'Backoffice'),
+                    ('Institución', 'Institución'),
+                    ('Portal', 'Portal'),
+                    ('Sistema', 'Sistema'),
+                    ('ÑACHEC', 'ÑACHEC'),
+                    ('Becas', 'Becas'),
+                ],
+                default='Backoffice',
+                max_length=20,
+                verbose_name='Categoría',
+            ),
+        ),
+    ]

--- a/users/models/__init__.py
+++ b/users/models/__init__.py
@@ -2,13 +2,11 @@ import uuid
 
 from django.conf import settings
 from django.contrib.auth.models import Group, User
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 
 from core.rbac import (
     CATEGORIA_BACKOFFICE,
-    CATEGORIA_PROGRAMA,
     CATEGORIAS_ROL_CHOICES,
     todas_las_capacidades,
 )
@@ -59,18 +57,6 @@ class RolMeta(models.Model):
 
     def __str__(self):
         return self.grupo.name
-
-    def clean(self):
-        """RN-1: ``categoria == "Programa"`` ⇔ ``programa`` no nulo."""
-        super().clean()
-        if self.categoria == CATEGORIA_PROGRAMA and self.programa_id is None:
-            raise ValidationError(
-                {"programa": "Un rol de categoría 'Programa' requiere seleccionar un Programa."}
-            )
-        if self.categoria != CATEGORIA_PROGRAMA and self.programa_id is not None:
-            raise ValidationError(
-                {"programa": "Solo los roles de categoría 'Programa' pueden tener un Programa asociado."}
-            )
 
 
 class Capacidad(models.Model):

--- a/users/selectors/roles.py
+++ b/users/selectors/roles.py
@@ -53,7 +53,8 @@ def puede_gestionar_rol(user, group):
     if es_admin_global(user):
         return True
     meta = getattr(group, "meta", None)
-    if not meta or meta.categoria != rbac.CATEGORIA_PROGRAMA or not meta.programa_id:
+    _CATS_PROGRAMA = {rbac.CATEGORIA_PROGRAMA, rbac.CATEGORIA_NACHEC, rbac.CATEGORIA_BECAS}
+    if not meta or meta.categoria not in _CATS_PROGRAMA or not meta.programa_id:
         return False
     return programas_administrables(user).filter(pk=meta.programa_id).exists()
 

--- a/users/templates/rol/rol_form.html
+++ b/users/templates/rol/rol_form.html
@@ -29,19 +29,23 @@
                     {{ form.categoria }}
                     {% if form.categoria.errors %}<div class="text-red-600 text-sm mt-1">{{ form.categoria.errors }}</div>{% endif %}
                 </div>
-                <div id="campo-programa" class="{% if form.categoria.value != 'Programa' %}hidden{% endif %}">
-                    <label for="{{ form.programa.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-2">Programa</label>
-                    {{ form.programa }}
-                    {% if form.programa.errors %}<div class="text-red-600 text-sm mt-1">{{ form.programa.errors }}</div>{% endif %}
-                </div>
                 {% else %}
-                <input type="hidden" name="categoria" value="Programa">
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-2">Categoría</label>
-                    <div class="px-3 py-2 bg-gray-100 rounded-md text-gray-700">Programa</div>
+                    <label for="{{ form.categoria.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-2">Categoría</label>
+                    {{ form.categoria }}
+                    {% if form.categoria.errors %}<div class="text-red-600 text-sm mt-1">{{ form.categoria.errors }}</div>{% endif %}
                 </div>
+                {% endif %}
+
+                <div class="md:col-span-2">
+                    <label for="{{ form.descripcion.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-2">Descripción</label>
+                    {{ form.descripcion }}
+                    {% if form.descripcion.errors %}<div class="text-red-600 text-sm mt-1">{{ form.descripcion.errors }}</div>{% endif %}
+                </div>
+
+                {% if not form.es_admin_global %}
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-2">Programa</label>
+                    <label class="block text-sm font-medium text-gray-700 mb-2">Programa (opcional)</label>
                     {% if form.programa_fijo %}
                         <input type="hidden" name="programa" value="{{ form.programa_fijo.pk }}">
                         <div class="px-3 py-2 bg-gray-100 rounded-md text-gray-700"><i class="fas fa-folder mr-1"></i>{{ form.programa_fijo.nombre }}</div>
@@ -51,24 +55,59 @@
                     {% if form.programa.errors %}<div class="text-red-600 text-sm mt-1">{{ form.programa.errors }}</div>{% endif %}
                 </div>
                 {% endif %}
-                <div class="md:col-span-2">
-                    <label for="{{ form.descripcion.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-2">Descripción</label>
-                    {{ form.descripcion }}
-                    {% if form.descripcion.errors %}<div class="text-red-600 text-sm mt-1">{{ form.descripcion.errors }}</div>{% endif %}
-                </div>
             </div>
         </div>
 
+        {# ---- Panel de capacidades con tabs ---- #}
         <div class="bg-white rounded-lg shadow p-6">
             <div class="flex items-center justify-between mb-4">
-                <h2 class="text-lg font-semibold text-gray-900">Capacidades</h2>
+                <div>
+                    <h2 class="text-lg font-semibold text-gray-900">Permisos por categoría</h2>
+                    <p class="text-sm text-gray-500">Un rol puede tener permisos de múltiples categorías.</p>
+                </div>
                 <span class="text-sm text-gray-500"><span id="total-seleccionadas">0</span> seleccionada(s)</span>
             </div>
             {% if form.capacidades.errors %}<div class="text-red-600 text-sm mb-3">{{ form.capacidades.errors }}</div>{% endif %}
 
-            <div class="space-y-3">
-                {% for modulo in form.arbol_capacidades %}
-                    <div class="border border-gray-200 rounded-lg" x-data="{ open: true }" data-modulo="{{ modulo.modulo }}" data-alcance="{{ modulo.alcance|default:'' }}">
+            {# Tab bar #}
+            <div class="border-b border-gray-200 mb-4">
+                <nav class="flex gap-1 overflow-x-auto" id="cap-tabs">
+                    <button type="button" data-tab="__buscar__"
+                        class="cap-tab-btn flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-t-md border-b-2 border-transparent text-gray-500 hover:text-gray-700 whitespace-nowrap"
+                        title="Buscar en todas las categorías">
+                        <i class="fas fa-magnifying-glass text-xs"></i>
+                    </button>
+                    {% for tab in form.arbol_por_tabs %}
+                    <button type="button" data-tab="{{ tab.id }}"
+                        class="cap-tab-btn flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-t-md border-b-2 border-transparent text-gray-500 hover:text-gray-700 whitespace-nowrap">
+                        <i class="fas {{ tab.icon }} text-xs"></i>
+                        {{ tab.label }}
+                        <span class="tab-badge hidden ml-1 bg-blue-100 text-blue-700 text-xs font-semibold px-1.5 py-0.5 rounded-full" data-tab-badge="{{ tab.id }}">0</span>
+                    </button>
+                    {% endfor %}
+                </nav>
+            </div>
+
+            {# Search panel #}
+            <div id="panel-__buscar__" class="cap-tab-panel hidden">
+                <div class="mb-3">
+                    <div class="relative">
+                        <i class="fas fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm"></i>
+                        <input type="text" id="cap-search-input" placeholder="Buscar capacidad..."
+                            class="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
+                    </div>
+                </div>
+                <div id="cap-search-results" class="space-y-1 max-h-80 overflow-y-auto"></div>
+                <div id="cap-search-empty" class="hidden text-sm text-gray-400 py-4 text-center">Sin resultados.</div>
+            </div>
+
+            {# Tab panels #}
+            {% for tab in form.arbol_por_tabs %}
+            <div id="panel-{{ tab.id }}" class="cap-tab-panel hidden">
+                {% if tab.modulos %}
+                <div class="space-y-3">
+                    {% for modulo in tab.modulos %}
+                    <div class="border border-gray-200 rounded-lg" x-data="{ open: true }" data-modulo="{{ modulo.modulo }}">
                         <div class="flex items-center justify-between px-4 py-3 bg-gray-50 rounded-t-lg">
                             <label class="flex items-center gap-2 text-sm font-medium text-gray-800 cursor-pointer">
                                 <input type="checkbox" class="select-all rounded border-gray-300" data-modulo="{{ modulo.modulo }}">
@@ -81,17 +120,25 @@
                         </div>
                         <div x-show="open" x-transition class="px-4 py-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
                             {% for cap in modulo.capacidades %}
-                                <label class="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
-                                    <input type="checkbox" name="capacidades" value="{{ cap.codigo }}"
-                                           class="cap-check rounded border-gray-300" data-modulo="{{ modulo.modulo }}"
-                                           {% if cap.checked %}checked{% endif %}>
-                                    <span>{{ cap.label }} <span class="text-xs text-gray-400 font-mono">{{ cap.codigo }}</span></span>
-                                </label>
+                            <label class="flex items-center gap-2 text-sm text-gray-700 cursor-pointer cap-item" data-label="{{ cap.label|lower }} {{ cap.codigo|lower }}">
+                                <input type="checkbox" name="capacidades" value="{{ cap.codigo }}"
+                                       class="cap-check rounded border-gray-300" data-modulo="{{ modulo.modulo }}"
+                                       data-tab="{{ tab.id }}"
+                                       {% if cap.checked %}checked{% endif %}>
+                                <span>{{ cap.label }} <span class="text-xs text-gray-400 font-mono">{{ cap.codigo }}</span></span>
+                            </label>
                             {% endfor %}
                         </div>
                     </div>
-                {% endfor %}
+                    {% endfor %}
+                </div>
+                {% else %}
+                <div class="py-8 text-center text-sm text-gray-400">
+                    <i class="fas fa-circle-info mr-1"></i> Sin capacidades definidas para esta categoría todavía.
+                </div>
+                {% endif %}
             </div>
+            {% endfor %}
         </div>
 
         <div class="flex justify-end space-x-3 mt-6">
@@ -102,74 +149,141 @@
 </div>
 
 <script>
-    document.addEventListener('DOMContentLoaded', function () {
-        var totalEl = document.getElementById('total-seleccionadas');
+document.addEventListener('DOMContentLoaded', function () {
+    var totalEl = document.getElementById('total-seleccionadas');
 
-        function checksDeModulo(modulo) {
-            return Array.from(document.querySelectorAll('.cap-check[data-modulo="' + modulo + '"]'));
-        }
+    // ---- Tabs ----
+    var tabBtns = document.querySelectorAll('.cap-tab-btn');
+    var tabPanels = document.querySelectorAll('.cap-tab-panel');
 
-        function refrescarModulo(modulo) {
-            var checks = checksDeModulo(modulo);
-            var marcados = checks.filter(function (c) { return c.checked; });
-            var contador = document.querySelector('.contador-modulo[data-modulo="' + modulo + '"]');
-            if (contador) contador.textContent = marcados.length;
-            var selectAll = document.querySelector('.select-all[data-modulo="' + modulo + '"]');
-            if (selectAll) {
-                selectAll.checked = checks.length > 0 && marcados.length === checks.length;
-                selectAll.indeterminate = marcados.length > 0 && marcados.length < checks.length;
-            }
-        }
-
-        function refrescarTotal() {
-            totalEl.textContent = document.querySelectorAll('.cap-check:checked').length;
-        }
-
-        document.querySelectorAll('.select-all').forEach(function (sa) {
-            sa.addEventListener('change', function () {
-                var modulo = sa.getAttribute('data-modulo');
-                checksDeModulo(modulo).forEach(function (c) { c.checked = sa.checked; });
-                refrescarModulo(modulo);
-                refrescarTotal();
-            });
+    function activarTab(id) {
+        tabBtns.forEach(function (btn) {
+            var activo = btn.getAttribute('data-tab') === id;
+            btn.classList.toggle('border-blue-600', activo);
+            btn.classList.toggle('text-blue-600', activo);
+            btn.classList.toggle('border-transparent', !activo);
+            btn.classList.toggle('text-gray-500', !activo);
         });
+        tabPanels.forEach(function (panel) {
+            panel.classList.toggle('hidden', panel.id !== 'panel-' + id);
+        });
+        if (id === '__buscar__') {
+            var inp = document.getElementById('cap-search-input');
+            if (inp) setTimeout(function () { inp.focus(); }, 50);
+        }
+    }
 
+    tabBtns.forEach(function (btn) {
+        btn.addEventListener('click', function () { activarTab(btn.getAttribute('data-tab')); });
+    });
+
+    // Activar el primer tab real por defecto
+    var primero = document.querySelector('.cap-tab-btn[data-tab]:not([data-tab="__buscar__"])');
+    if (primero) activarTab(primero.getAttribute('data-tab'));
+
+    // ---- Contadores por módulo ----
+    function checksDeModulo(modulo) {
+        return Array.from(document.querySelectorAll('.cap-check[data-modulo="' + modulo + '"]'));
+    }
+
+    function refrescarModulo(modulo) {
+        var checks = checksDeModulo(modulo);
+        var marcados = checks.filter(function (c) { return c.checked; });
+        var contador = document.querySelector('.contador-modulo[data-modulo="' + modulo + '"]');
+        if (contador) contador.textContent = marcados.length;
+        var selectAll = document.querySelector('.select-all[data-modulo="' + modulo + '"]');
+        if (selectAll) {
+            selectAll.checked = checks.length > 0 && marcados.length === checks.length;
+            selectAll.indeterminate = marcados.length > 0 && marcados.length < checks.length;
+        }
+    }
+
+    function refrescarTotal() {
+        var total = document.querySelectorAll('.cap-check:checked').length;
+        totalEl.textContent = total;
+    }
+
+    function refrescarBadgesTab() {
+        document.querySelectorAll('[data-tab-badge]').forEach(function (badge) {
+            var tabId = badge.getAttribute('data-tab-badge');
+            var n = document.querySelectorAll('.cap-check[data-tab="' + tabId + '"]:checked').length;
+            badge.textContent = n;
+            badge.classList.toggle('hidden', n === 0);
+        });
+    }
+
+    document.querySelectorAll('.select-all').forEach(function (sa) {
+        sa.addEventListener('change', function () {
+            var modulo = sa.getAttribute('data-modulo');
+            checksDeModulo(modulo).forEach(function (c) { c.checked = sa.checked; });
+            refrescarModulo(modulo);
+            refrescarTotal();
+            refrescarBadgesTab();
+        });
+    });
+
+    document.querySelectorAll('.cap-check').forEach(function (chk) {
+        chk.addEventListener('change', function () {
+            refrescarModulo(chk.getAttribute('data-modulo'));
+            refrescarTotal();
+            refrescarBadgesTab();
+        });
+    });
+
+    // Estado inicial
+    document.querySelectorAll('[data-modulo].border').forEach(function (panel) {
+        refrescarModulo(panel.getAttribute('data-modulo'));
+    });
+    refrescarTotal();
+    refrescarBadgesTab();
+
+    // ---- Buscador ----
+    var searchInput = document.getElementById('cap-search-input');
+    var searchResults = document.getElementById('cap-search-results');
+    var searchEmpty = document.getElementById('cap-search-empty');
+
+    // Construir índice de todos los checkboxes
+    function buildIndex() {
+        var items = [];
         document.querySelectorAll('.cap-check').forEach(function (chk) {
-            chk.addEventListener('change', function () {
-                refrescarModulo(chk.getAttribute('data-modulo'));
-                refrescarTotal();
-            });
+            var label = chk.closest('label');
+            var texto = label ? label.getAttribute('data-label') || label.textContent.trim().toLowerCase() : '';
+            items.push({ chk: chk, texto: texto, labelEl: label });
         });
+        return items;
+    }
+    var capIndex = buildIndex();
 
-        document.querySelectorAll('[data-modulo].border').forEach(function (panel) {
-            refrescarModulo(panel.getAttribute('data-modulo'));
-        });
-        refrescarTotal();
-    });
-</script>
-<script>
-    // Admin global: el combo "Programa" y el árbol se ajustan según la categoría.
-    document.addEventListener('DOMContentLoaded', function () {
-        var catSelect = document.getElementById('id_categoria');
-        if (!catSelect) return;  // admin de programa: campos fijos, sin JS
-        var campoPrograma = document.getElementById('campo-programa');
-
-        function aplicarCategoria() {
-            var esPrograma = catSelect.value === 'Programa';
-            if (campoPrograma) {
-                campoPrograma.classList.toggle('hidden', !esPrograma);
-                if (!esPrograma) {
-                    var programaSelect = campoPrograma.querySelector('select');
-                    if (programaSelect) programaSelect.value = '';
-                }
+    if (searchInput) {
+        searchInput.addEventListener('input', function () {
+            var q = searchInput.value.trim().toLowerCase();
+            searchResults.innerHTML = '';
+            if (!q) {
+                searchEmpty.classList.add('hidden');
+                return;
             }
-            document.querySelectorAll('.border[data-alcance]').forEach(function (panel) {
-                var dePrograma = panel.getAttribute('data-alcance') === 'programa';
-                panel.classList.toggle('hidden', esPrograma && !dePrograma);
+            var matches = capIndex.filter(function (item) { return item.texto.indexOf(q) !== -1; });
+            searchEmpty.classList.toggle('hidden', matches.length > 0);
+            matches.forEach(function (item) {
+                var clone = item.labelEl.cloneNode(true);
+                clone.classList.add('p-1', 'rounded', 'hover:bg-gray-50');
+                // Sincronizar el checkbox clonado con el original
+                var cloneChk = clone.querySelector('input[type=checkbox]');
+                if (cloneChk) {
+                    cloneChk.checked = item.chk.checked;
+                    cloneChk.addEventListener('change', function () {
+                        item.chk.checked = cloneChk.checked;
+                        item.chk.dispatchEvent(new Event('change', { bubbles: true }));
+                        cloneChk.checked = item.chk.checked;
+                    });
+                    item.chk.addEventListener('change', function () {
+                        cloneChk.checked = item.chk.checked;
+                    });
+                }
+                searchResults.appendChild(clone);
             });
-        }
-        catSelect.addEventListener('change', aplicarCategoria);
-        aplicarCategoria();
-    });
+        });
+    }
+});
 </script>
 {% endblock %}

--- a/users/tests/test_roles_abm.py
+++ b/users/tests/test_roles_abm.py
@@ -125,22 +125,22 @@ class RolesServiceTests(TestCase):
         self.assertIn("usuario.administrar", rbac.capacidades_de_grupo(g))
 
 
-class RolProgramaFormTests(TestCase):
-    """#64 â€” categorÃ­a 'Programa' + FK programa con validaciÃ³n cruzada RN-1."""
+class RolCategoriaFormTests(TestCase):
+    """Categoria del rol: sin restriccion de FK programa (RN-1 eliminada)."""
 
     def setUp(self):
         self.becas = Programa.objects.create(codigo="BECAS", nombre="Becas")
 
-    def test_alta_rol_programa_valido(self):  # TC-64-01
+    def test_alta_rol_becas_con_programa(self):  # TC-64-01
         form = RolForm(data={
             "name": "Coordinador Becas",
-            "categoria": rbac.CATEGORIA_PROGRAMA,
+            "categoria": rbac.CATEGORIA_BECAS,
             "programa": self.becas.pk,
             "capacidades": ["relevamiento.gestionar"],
         })
         self.assertTrue(form.is_valid(), form.errors)
         group = RolesAdminService.crear(form)
-        self.assertEqual(group.meta.categoria, rbac.CATEGORIA_PROGRAMA)
+        self.assertEqual(group.meta.categoria, rbac.CATEGORIA_BECAS)
         self.assertEqual(group.meta.programa_id, self.becas.pk)
 
     def test_alta_rol_global_sin_programa(self):  # TC-64-02
@@ -153,28 +153,24 @@ class RolProgramaFormTests(TestCase):
         group = RolesAdminService.crear(form)
         self.assertIsNone(group.meta.programa_id)
 
-    def test_categoria_programa_sin_programa_invalida(self):  # TC-64-03
-        form = RolForm(data={"name": "Rol X", "categoria": rbac.CATEGORIA_PROGRAMA})
-        self.assertFalse(form.is_valid())
-        self.assertIn("programa", form.errors)
+    def test_categoria_becas_sin_programa_valida(self):  # RN-1 eliminada: ya no requiere FK
+        form = RolForm(data={"name": "Rol Becas", "categoria": rbac.CATEGORIA_BECAS})
+        self.assertTrue(form.is_valid(), form.errors)
 
-    def test_categoria_no_programa_con_programa_invalida(self):  # TC-64-04
+    def test_categoria_backoffice_con_programa_valida(self):  # RN-1 eliminada: FK es libre
         form = RolForm(data={
-            "name": "Rol Y", "categoria": "Backoffice", "programa": self.becas.pk,
+            "name": "Rol Backoffice", "categoria": "Backoffice", "programa": self.becas.pk,
         })
-        self.assertFalse(form.is_valid())
-        self.assertIn("programa", form.errors)
+        self.assertTrue(form.is_valid(), form.errors)
 
-    def test_modelo_clean_valida_rn1(self):
-        from django.core.exceptions import ValidationError
+    def test_modelo_sin_constraint_programa(self):
         g = Group.objects.create(name="Rol Z")
-        meta = RolMeta(grupo=g, categoria=rbac.CATEGORIA_PROGRAMA, programa=None)
-        with self.assertRaises(ValidationError):
-            meta.full_clean()
+        meta = RolMeta(grupo=g, categoria=rbac.CATEGORIA_NACHEC, programa=None)
+        meta.full_clean()  # no debe levantar excepción
 
 
 class RolAlcanceTests(TestCase):
-    """#66 â€” ABM de Roles con alcance de Programa."""
+    """#66 â€" ABM de Roles con alcance de Programa."""
 
     def setUp(self):
         self.becas = Programa.objects.create(codigo="BECAS", nombre="Becas")
@@ -237,12 +233,12 @@ class RolAlcanceTests(TestCase):
 
     def test_form_admin_programa_guarda_en_su_programa(self):  # TC-66-03
         form = RolForm(
-            data={"name": "Coord Becas", "capacidades": ["relevamiento.gestionar"]},
+            data={"name": "Coord Becas", "categoria": rbac.CATEGORIA_BECAS, "capacidades": ["relevamiento.gestionar"]},
             operador=self.admin_becas,
         )
         self.assertTrue(form.is_valid(), form.errors)
         g = RolesAdminService.crear(form)
-        self.assertEqual(g.meta.categoria, rbac.CATEGORIA_PROGRAMA)
+        self.assertEqual(g.meta.categoria, rbac.CATEGORIA_BECAS)
         self.assertEqual(g.meta.programa_id, self.becas.pk)
 
     def test_form_admin_programa_descarta_caps_globales(self):  # seguridad
@@ -254,7 +250,7 @@ class RolAlcanceTests(TestCase):
 
     def test_form_global_programa_combo(self):  # TC-66-04
         form = RolForm(
-            data={"name": "Rol Ã‘achec", "categoria": rbac.CATEGORIA_PROGRAMA,
+            data={"name": "Rol Ñachec", "categoria": rbac.CATEGORIA_NACHEC,
                   "programa": self.nachec.pk, "capacidades": ["relevamiento.gestionar"]},
             operador=self.su,
         )


### PR DESCRIPTION
## Summary

- **Tabs de capacidades no exclusivos**: los tabs (Backoffice, Institución, Portal, Sistema, ÑACHEC, Becas) son ahora organizativos; un rol puede tener capacidades de múltiples tabs a la vez.
- **Tab buscador** (🔍): filtra en tiempo real sobre todas las capacidades y sincroniza los checkboxes con el formulario.
- **Badge numérico** por tab con el conteo de capacidades seleccionadas.
- **Categoría "Programa" reemplazada** por ÑACHEC y Becas en el selector de roles. `CATEGORIA_PROGRAMA` se mantiene como constante legacy para datos históricos.
- **RN-1 eliminada**: el campo `programa` (FK) ya no es obligatorio para ninguna categoría; la relación es libre.
- **Módulos del CATÁLOGO** llevan clave `"tab"` para la agrupación visual; nueva función `arbol_por_tabs()` en `core/rbac.py`.
- Admins de programa ahora eligen entre ÑACHEC/Becas (antes forzado a "Programa").
- Migración `0005` actualiza los choices de `RolMeta.categoria`.
- Tests actualizados: 30/30 OK.

## Archivos cambiados

| Archivo | Cambio |
|---------|--------|
| `core/rbac.py` | Tab por módulo, nuevas categorías, `arbol_por_tabs()` |
| `users/models/__init__.py` | Elimina `clean()` con RN-1 |
| `users/forms/roles.py` | Lógica de admin de programa adaptada, `arbol_por_tabs()` |
| `users/selectors/roles.py` | `puede_gestionar_rol()` acepta ÑACHEC y Becas |
| `users/templates/rol/rol_form.html` | UI completa con tabs + buscador |
| `users/tests/test_roles_abm.py` | Tests actualizados |
| `users/migrations/0005_alter_rolmeta_categoria.py` | Nuevos choices en DB |

## Test plan

- [ ] Crear rol con capacidades de múltiples tabs (ej: ciudadano.ver + becas.revisar) → debe guardar bien
- [ ] Usar el buscador para encontrar "relevamiento" → debe mostrar ambas capacidades del módulo
- [ ] Tildar una capacidad desde el buscador → el badge del tab correspondiente debe actualizarse
- [ ] Crear rol con categoría ÑACHEC sin seleccionar programa → debe guardar sin error
- [ ] Crear rol con categoría Backoffice y seleccionar programa → debe guardar sin error (RN-1 eliminada)
- [ ] Admin de programa (sin `rol.administrar`) → solo ve ÑACHEC/Becas como opciones de categoría y solo caps de programa
- [ ] Verificar que roles existentes con `categoria="Programa"` siguen siendo visibles en el listado

🤖 Generated with [Claude Code](https://claude.com/claude-code)