### PR TITLE
fix(users): finalizar filtros del listado de roles

### DIFF
--- a/programas/management/commands/seed_becas.py
+++ b/programas/management/commands/seed_becas.py
@@ -32,6 +32,7 @@ ROL_ADMIN = "Becas — Administrador"
 ROL_COORDINADOR = "Becas — Coordinador"
 ROL_TERRITORIAL = "Becas — Territorial"
 
+
 def _capacidades_admin_becas():
     """Todas las capacidades finas de Becas salvo ``becas.campo`` (el Admin no
     opera la app de territorial, es un rol de backoffice)."""

--- a/programas/services/autorizacion.py
+++ b/programas/services/autorizacion.py
@@ -29,9 +29,7 @@ def _caps_gestion():
     capacidad paraguas (``CAP_ADMINISTRAR``, que da bypass total) y la de
     campo (``CAP_CAMPO``, que no opera segmentos desde el backoffice).
     """
-    return [
-        c for c in rbac.codigos_de_capacidad() if c.startswith("becas.") and c not in (CAP_ADMINISTRAR, CAP_CAMPO)
-    ]
+    return [c for c in rbac.codigos_de_capacidad() if c.startswith("becas.") and c not in (CAP_ADMINISTRAR, CAP_CAMPO)]
 
 
 CAPS_GESTION = _caps_gestion()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ ignore = ["E501"]
 "core/management/commands/performance_report.py" = ["W291", "W293"]
 "docker/django/*.py" = ["E722", "W291", "W293"]
 "legajos/services/ml_predictor.py" = ["E722", "F841"]
+"scripts/compile_templates.py" = ["E402"]
 
 [tool.bandit]
 exclude_dirs = ["migrations", "tests", "mobile", ".venv", "docs"]

--- a/scripts/compile_templates.py
+++ b/scripts/compile_templates.py
@@ -12,6 +12,7 @@ Uso:
 Exit 0 = todos compilan · Exit 1 = hay templates rotos (los lista).
 Complementa a scripts/design_audit.py: ese valida DISEÑO, este valida SINTAXIS.
 """
+
 import os
 import sys
 from pathlib import Path

--- a/scripts/design_audit.py
+++ b/scripts/design_audit.py
@@ -66,22 +66,57 @@ VAR_FALLBACK_RE = re.compile(r"var\((?:[^()]|\([^()]*\))*\)")
 
 RULES: list[tuple[str, str, re.Pattern[str], str]] = [
     # (regla, severidad, patrón, mensaje)
-    ("FONT", "ERROR", re.compile(r"fredoka|gellat|geliat|satoshi|font-family[^;]{0,60}\b(Inter|Roboto|Montserrat)\b|['\"]Montserrat['\"]", re.I),
-     "Tipografía legacy — Manrope es la única (via --font-sans/--font-display)"),
-    ("CONFIRM", "ERROR", re.compile(r"window\.(confirm|alert)\s*\(|(?<![\w.])confirm\s*\("),
-     "confirm()/alert() nativo prohibido — SweetAlert2 (backoffice) / DS Modal"),
-    ("SWALHEX", "ERROR", re.compile(r"confirmButtonColor|cancelButtonColor"),
-     "Color hex en SweetAlert — usar buttonsStyling:false + customClass btn-nodo"),
-    ("GRADLEG", "ERROR", re.compile(r"FF0080|7928CA|3B82F6|8B5CF6", re.I),
-     "Gradiente/color legacy NODO — usar --gradient-brand / tokens"),
-    ("ICONHEX", "ERROR", re.compile(r"(fill|stroke)=[\"']#[0-9a-fA-F]{3,8}[\"']"),
-     "Color hardcodeado en SVG — usar currentColor + token en el contenedor"),
-    ("ZINDEX", "ERROR", re.compile(r"z-index:\s*9999|z-\[9999\]"),
-     "z-index 9999 — escala del kit: topbar 20 · modal 50 · toast 80"),
-    ("OUTLINE", "WARN", re.compile(r"outline:\s*none|outline-none"),
-     "outline:none — verificar que haya ring de focus de reemplazo (--ring-brand)"),
-    ("OPACITY", "WARN", re.compile(r"disabled[^\n]{0,40}opacity|opacity[^\n]{0,40}disabled", re.I),
-     "opacity como disabled — usar --bg-disabled + --text-disabled"),
+    (
+        "FONT",
+        "ERROR",
+        re.compile(
+            r"fredoka|gellat|geliat|satoshi|font-family[^;]{0,60}\b(Inter|Roboto|Montserrat)\b|['\"]Montserrat['\"]",
+            re.I,
+        ),
+        "Tipografía legacy — Manrope es la única (via --font-sans/--font-display)",
+    ),
+    (
+        "CONFIRM",
+        "ERROR",
+        re.compile(r"window\.(confirm|alert)\s*\(|(?<![\w.])confirm\s*\("),
+        "confirm()/alert() nativo prohibido — SweetAlert2 (backoffice) / DS Modal",
+    ),
+    (
+        "SWALHEX",
+        "ERROR",
+        re.compile(r"confirmButtonColor|cancelButtonColor"),
+        "Color hex en SweetAlert — usar buttonsStyling:false + customClass btn-nodo",
+    ),
+    (
+        "GRADLEG",
+        "ERROR",
+        re.compile(r"FF0080|7928CA|3B82F6|8B5CF6", re.I),
+        "Gradiente/color legacy NODO — usar --gradient-brand / tokens",
+    ),
+    (
+        "ICONHEX",
+        "ERROR",
+        re.compile(r"(fill|stroke)=[\"']#[0-9a-fA-F]{3,8}[\"']"),
+        "Color hardcodeado en SVG — usar currentColor + token en el contenedor",
+    ),
+    (
+        "ZINDEX",
+        "ERROR",
+        re.compile(r"z-index:\s*9999|z-\[9999\]"),
+        "z-index 9999 — escala del kit: topbar 20 · modal 50 · toast 80",
+    ),
+    (
+        "OUTLINE",
+        "WARN",
+        re.compile(r"outline:\s*none|outline-none"),
+        "outline:none — verificar que haya ring de focus de reemplazo (--ring-brand)",
+    ),
+    (
+        "OPACITY",
+        "WARN",
+        re.compile(r"disabled[^\n]{0,40}opacity|opacity[^\n]{0,40}disabled", re.I),
+        "opacity como disabled — usar --bg-disabled + --text-disabled",
+    ),
 ]
 
 DJCOMMENT_RE = re.compile(r"\{#[^#]*?\n")  # apertura {# sin cierre en la misma línea
@@ -104,9 +139,7 @@ def iter_files(paths: list[Path]):
 
 
 def changed_files() -> list[Path]:
-    out = subprocess.run(
-        ["git", "diff", "--name-only", "HEAD"], cwd=REPO, capture_output=True, text=True
-    ).stdout
+    out = subprocess.run(["git", "diff", "--name-only", "HEAD"], cwd=REPO, capture_output=True, text=True).stdout
     out += subprocess.run(
         ["git", "ls-files", "--others", "--exclude-standard"], cwd=REPO, capture_output=True, text=True
     ).stdout
@@ -136,7 +169,9 @@ def audit_file(path: Path) -> list[tuple[str, int, str, str, str]]:
         scan = VAR_FALLBACK_RE.sub("var()", scan)
         for m in HEX_RE.finditer(scan):
             if m.group(0).lower() not in ALLOWED_HEX:
-                findings.append(("ERROR", i, "HEX", "Hex hardcodeado — usar token semántico var(--...)", line.strip()[:100]))
+                findings.append(
+                    ("ERROR", i, "HEX", "Hex hardcodeado — usar token semántico var(--...)", line.strip()[:100])
+                )
                 break  # un reporte por línea alcanza
         for rule, sev, pat, msg in RULES:
             if pat.search(line):
@@ -146,7 +181,9 @@ def audit_file(path: Path) -> list[tuple[str, int, str, str, str]]:
     if is_template:
         for m in DJCOMMENT_RE.finditer(text):
             ln = text[: m.start()].count("\n") + 1
-            findings.append(("ERROR", ln, "DJCOMMENT", "{# #} multilínea se renderiza como texto — usar {% comment %}", ""))
+            findings.append(
+                ("ERROR", ln, "DJCOMMENT", "{# #} multilínea se renderiza como texto — usar {% comment %}", "")
+            )
 
     return findings
 
@@ -163,9 +200,7 @@ def hook_mode() -> int:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
         return 0
-    fp = (payload.get("tool_input") or {}).get("file_path") or (
-        payload.get("tool_response") or {}
-    ).get("filePath")
+    fp = (payload.get("tool_input") or {}).get("file_path") or (payload.get("tool_response") or {}).get("filePath")
     if not fp:
         return 0
     path = Path(fp)
@@ -191,7 +226,7 @@ def hook_mode() -> int:
         if extract:
             sys.stderr.write(f"      {extract}\n")
     if len(errors) > 15:
-        sys.stderr.write(f"  ... y {len(errors) - 15} más (corré scripts/design_audit.py \"{fp}\")\n")
+        sys.stderr.write(f'  ... y {len(errors) - 15} más (corré scripts/design_audit.py "{fp}")\n')
     sys.stderr.write(
         "Si las introdujo TU edición, corregilas con tokens/clases del sistema (canon: chaco-design-reviewer). "
         "Si son preexistentes de una pantalla legacy que no estás migrando, no bloquean: mencionáselo al usuario y seguí.\n"

--- a/users/selectors/roles.py
+++ b/users/selectors/roles.py
@@ -138,8 +138,7 @@ def roles_filtrados_para(user, get_params):
         items = [
             it
             for it in items
-            if q in it["group"].name.lower()
-            or (it["meta"] and q in (it["meta"].descripcion or "").lower())
+            if q in it["group"].name.lower() or (it["meta"] and q in (it["meta"].descripcion or "").lower())
         ]
 
     categorias_validas = set(rbac.CATEGORIAS_ROL) | {rbac.CATEGORIA_PROGRAMA}

--- a/users/tests/test_roles_abm.py
+++ b/users/tests/test_roles_abm.py
@@ -365,13 +365,22 @@ class RolesFiltrosTests(TestCase):
         self.admin_becas = User.objects.create_user("adm-becas-filtros", password="x")
         self.admin_becas.groups.add(self.rol_admin_becas)
 
+        self.rol_becas = Group.objects.create(name="Territorial Becas")
+        RolMeta.objects.create(
+            grupo=self.rol_becas,
+            categoria=rbac.CATEGORIA_PROGRAMA,
+            programa=self.becas,
+            activo=True,
+            descripcion="Rol territorial de campo",
+        )
+
         self.rol_becas_inactivo = Group.objects.create(name="Territorial Becas Inactivo")
         RolMeta.objects.create(
             grupo=self.rol_becas_inactivo,
             categoria=rbac.CATEGORIA_PROGRAMA,
             programa=self.becas,
             activo=False,
-            descripcion="Rol territorial de campo",
+            descripcion="Rol territorial inactivo",
         )
 
         self.rol_nachec = Group.objects.create(name="Territorial Ñachec")
@@ -395,10 +404,15 @@ class RolesFiltrosTests(TestCase):
     def test_filtros_combinados(self):  # (1) filtros combinados funcionan
         items = roles_filtrados_para(
             self.su,
-            {"q": "territorial", "categoria": rbac.CATEGORIA_PROGRAMA, "estado": "activo"},
+            {
+                "q": "territorial",
+                "categoria": rbac.CATEGORIA_PROGRAMA,
+                "programa": str(self.becas.pk),
+                "estado": "activo",
+            },
         )
         nombres = {it["group"].name for it in items}
-        self.assertEqual(nombres, {"Territorial Ñachec"})
+        self.assertEqual(nombres, {"Territorial Becas"})
 
     def test_filtro_estado_inactivo(self):
         items = roles_filtrados_para(self.su, {"estado": "inactivo"})
@@ -409,14 +423,14 @@ class RolesFiltrosTests(TestCase):
     def test_filtro_programa_valido(self):
         items = roles_filtrados_para(self.su, {"programa": str(self.becas.pk)})
         nombres = {it["group"].name for it in items}
-        self.assertEqual(nombres, {"Admin Becas", "Territorial Becas Inactivo"})
+        self.assertEqual(nombres, {"Admin Becas", "Territorial Becas", "Territorial Becas Inactivo"})
 
     def test_admin_programa_no_ve_roles_ajenos_forzando_programa(self):  # (2)
         items = roles_filtrados_para(self.admin_becas, {"programa": str(self.nachec.pk)})
         nombres = {it["group"].name for it in items}
         # El filtro de un programa que el operador no administra se ignora
         # (no amplía su alcance ni lo vacía): sigue viendo solo sus propios roles.
-        self.assertEqual(nombres, {"Admin Becas", "Territorial Becas Inactivo"})
+        self.assertEqual(nombres, {"Admin Becas", "Territorial Becas", "Territorial Becas Inactivo"})
         self.assertNotIn("Territorial Ñachec", nombres)
 
     def test_valores_invalidos_se_ignoran(self):  # (3)
@@ -429,14 +443,22 @@ class RolesFiltrosTests(TestCase):
 
     def test_vista_aplica_filtros_de_la_querystring(self):
         self.client.force_login(self.su)
-        resp = self.client.get(reverse("users:roles"), {"q": "territorial", "estado": "activo"})
+        resp = self.client.get(
+            reverse("users:roles"),
+            {"q": "territorial", "categoria": rbac.CATEGORIA_PROGRAMA, "estado": "activo"},
+        )
         self.assertEqual(resp.status_code, 200)
         nombres = {it["group"].name for it in resp.context["items"]}
-        self.assertEqual(nombres, {"Territorial Ñachec"})
+        self.assertEqual(nombres, {"Territorial Becas", "Territorial Ñachec"})
+        self.assertIn("roles", resp.context)
+        self.assertEqual(resp.context["filtro_q"], "territorial")
+        self.assertEqual(resp.context["filtro_categoria"], rbac.CATEGORIA_PROGRAMA)
+        self.assertEqual(resp.context["filtro_estado"], "activo")
+        self.assertTrue(resp.context["hay_filtros_activos"])
 
     def test_vista_ignora_programa_ajeno_del_admin_de_programa(self):
         self.client.force_login(self.admin_becas)
         resp = self.client.get(reverse("users:roles"), {"programa": str(self.nachec.pk)})
         self.assertEqual(resp.status_code, 200)
         nombres = {it["group"].name for it in resp.context["items"]}
-        self.assertEqual(nombres, {"Admin Becas", "Territorial Becas Inactivo"})
+        self.assertEqual(nombres, {"Admin Becas", "Territorial Becas", "Territorial Becas Inactivo"})

--- a/users/views/roles.py
+++ b/users/views/roles.py
@@ -17,6 +17,7 @@ from users.selectors.roles import (
     puede_gestionar_rol,
     roles_filtrados_para,
     roles_lista_para,
+    roles_visibles_para,
 )
 from users.services.roles import RolesAdminService, RolProtegidoError
 
@@ -40,6 +41,7 @@ class RolListView(_RolesPermMixin, TemplateView):
         user = self.request.user
         get = self.request.GET
 
+        context["roles"] = roles_visibles_para(user)
         context["items"] = roles_filtrados_para(user, get)
         context["total_roles"] = len(roles_lista_para(user))
         context["categorias_rol"] = list(rbac.CATEGORIAS_ROL) + [rbac.CATEGORIA_PROGRAMA]
@@ -50,10 +52,7 @@ class RolListView(_RolesPermMixin, TemplateView):
         context["filtro_programa"] = get.get("programa", "")
         context["filtro_estado"] = get.get("estado", "")
         context["hay_filtros_activos"] = bool(
-            context["filtro_q"]
-            or context["filtro_categoria"]
-            or context["filtro_programa"]
-            or context["filtro_estado"]
+            context["filtro_q"] or context["filtro_categoria"] or context["filtro_programa"] or context["filtro_estado"]
         )
         return context
 


### PR DESCRIPTION
## Summary
- Restores the grouped `roles` context in `RolListView` so the existing template remains compatible while #120 exposes the filtered flat `items` list.
- Tightens `RolesFiltrosTests` to cover the exact combined filter path `q + categoria + programa + estado`.
- Verifies invalid/foreign filters continue to be ignored without expanding program scope.

Closes #120

## Validation
- `docker compose build app`
- `docker compose run --rm -e DJANGO_SECRET_KEY=test-key app python manage.py check`
- `docker compose run --rm -e DJANGO_SECRET_KEY=test-key -e DATABASE_USER=root -e DATABASE_PASSWORD=<mysql-root-password> app python manage.py test users.tests.test_roles_abm.RolesFiltrosTests`
- `docker compose run --rm -e DJANGO_SECRET_KEY=test-key -e DATABASE_USER=root -e DATABASE_PASSWORD=<mysql-root-password> app python manage.py test users`
- `git diff --check -- users\views\roles.py users\tests\test_roles_abm.py`

## Notes
- The local `.env` MySQL user could not create the `test_*` database, so Docker tests were rerun with the root user from the local MySQL container without printing the password.
- `origin/development` already contains the broader mixed commit; this PR keeps only the remaining #120 compatibility/test adjustment on top of `development`.