### PR TITLE
docs(client): corregir presupuesto de junio 2026 a 500 horas

### DIFF
--- a/docs/client/financiero/index.md
+++ b/docs/client/financiero/index.md
@@ -13,9 +13,9 @@
 
     ---
 
-    :material-wallet-outline: Presupuesto: **714 horas**  
-    :material-clock-check-outline: Consumido: **499 horas** (70%)  
-    :material-check-circle-outline: Saldo: **215 horas** sin consumir
+    :material-wallet-outline: Presupuesto: **500 horas**  
+    :material-clock-check-outline: Consumido: **499 horas** (100%)  
+    :material-check-circle-outline: Saldo: **1 hora** sin consumir
 
     **Estado:** :material-circle:{ style="color: #10b981" } Cerrado dentro del presupuesto
 

--- a/docs/client/financiero/mes-2026-06.md
+++ b/docs/client/financiero/mes-2026-06.md
@@ -1,7 +1,7 @@
 # :material-cash-multiple: Junio 2026 — Resumen de cierre
 
 !!! abstract "Mes cerrado"
-    Junio 2026 cerró con **499 horas consumidas** sobre un presupuesto de **714 horas** (70%), dentro del presupuesto acordado y sin requerir horas extras.
+    Junio 2026 cerró con **499 horas consumidas** sobre un presupuesto de **500 horas** (100%), dentro del presupuesto acordado y sin requerir horas extras.
 
 ---
 
@@ -13,7 +13,7 @@
 
     ---
 
-    **714 horas**
+    **500 horas**
 
     Presupuesto acordado para junio 2026
 
@@ -21,7 +21,7 @@
 
     ---
 
-    **499 horas** (70%)
+    **499 horas** (100%)
 
     Horas consumidas al cierre del mes
 
@@ -29,7 +29,7 @@
 
     ---
 
-    **215 horas**
+    **1 hora**
 
     El mes cerró dentro del presupuesto
 

--- a/docs/client/funcionalidades/estimacion-programa-becas.md
+++ b/docs/client/funcionalidades/estimacion-programa-becas.md
@@ -5,7 +5,7 @@
 **Versión:** 1.2
 **Alcance cubierto:** Análisis A — funcionalidades sin dependencia de integración SIS
 
-> **Nota de consumo (cierre de junio 2026):** en junio se consumieron 499 horas del sprint en análisis funcional (Becas, legajos, programa Dispositivos), desarrollo del motor RBAC y del backend de Becas, Design System, app de campo y mockups del equipo UX, cerrando el mes dentro del presupuesto de 714 horas (70%). Las 654 horas estimadas en este documento corresponden a trabajo comprometido que se ejecuta en los meses siguientes.
+> **Nota de consumo (cierre de junio 2026):** en junio se consumieron 499 horas del sprint en análisis funcional (Becas, legajos, programa Dispositivos), desarrollo del motor RBAC y del backend de Becas, Design System, app de campo y mockups del equipo UX, cerrando el mes dentro del presupuesto de 500 horas (100%). Las 654 horas estimadas en este documento corresponden a trabajo comprometido que se ejecuta en los meses siguientes.
 
 ---
 

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -34,7 +34,7 @@ hide:
 
     ---
 
-    **Junio 2026 (cerrado):** 499h consumidas de 714h (70%) — dentro del presupuesto
+    **Junio 2026 (cerrado):** 499h consumidas de 500h (100%) — dentro del presupuesto
 
     [:octicons-arrow-right-16: Ver dashboard](financiero/mes-2026-06.md)
 


### PR DESCRIPTION
## Resumen
La pagina publicada [financiero/mes-2026-06](https://mkdir-arg.github.io/Chaco/financiero/mes-2026-06/) mostraba **714 horas** de presupuesto mensual; el presupuesto acordado de junio 2026 es **500 horas**.

Se corrigen las cuatro paginas que repiten el dato:
- `docs/client/financiero/mes-2026-06.md` — presupuesto 500 h, consumo 499 h (100%), saldo 1 h
- `docs/client/financiero/index.md` — card de junio
- `docs/client/index.md` — card de estado financiero del home
- `docs/client/funcionalidades/estimacion-programa-becas.md` — nota de consumo

Cambio docs-only cherry-picked desde `development` (ya incluido alli en 466f88a). Al mergear se dispara `docs-auto-deploy` y se republica el sitio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)