### PR TITLE
docs(client): pagina financiera de julio 2026 (mes en curso)

### DIFF
--- a/docs/client/financiero/index.md
+++ b/docs/client/financiero/index.md
@@ -5,6 +5,26 @@
 
 ---
 
+## :material-progress-clock: Mes en curso
+
+<div class="grid cards" markdown>
+
+-   :material-calendar-clock: **Julio 2026**
+
+    ---
+
+    :material-wallet-outline: Presupuesto: **500 horas**  
+    :material-clock-check-outline: Consumido: **7 horas** (1%) — al 03/07  
+    :material-check-circle-outline: Saldo: **493 horas** disponibles
+
+    **Estado:** :material-circle:{ style="color: #3b82f6" } En curso
+
+    [:octicons-arrow-right-16: Ver detalle del mes](mes-2026-07.md)
+
+</div>
+
+---
+
 ## :material-archive-check-outline: Meses cerrados
 
 <div class="grid cards" markdown>

--- a/docs/client/financiero/mes-2026-07.md
+++ b/docs/client/financiero/mes-2026-07.md
@@ -1,0 +1,63 @@
+# :material-cash-multiple: Julio 2026 — Mes en curso
+
+!!! info "Mes en curso"
+    Julio 2026 está en ejecución. Al **03/07** se llevan **7 horas consumidas** sobre un presupuesto de **500 horas** (1%). Esta página se actualiza a medida que se registran horas.
+
+---
+
+## :material-chart-box-outline: Números del mes
+
+<div class="grid cards" markdown>
+
+-   :material-wallet-outline: **Presupuesto mensual**
+
+    ---
+
+    **500 horas**
+
+    Presupuesto acordado para julio 2026
+
+-   :material-clock-check-outline: **Consumo real**
+
+    ---
+
+    **7 horas** (1%)
+
+    Horas consumidas al 03/07
+
+-   :material-check-circle-outline: **Saldo**
+
+    ---
+
+    **493 horas**
+
+    Disponibles para el resto del mes
+
+</div>
+
+---
+
+## :material-account-group: Consumo por persona
+
+| Persona | Foco principal | Horas | % del consumo |
+|---|---|---:|---:|
+| Pablo Cao | App de campo (flujo de identidad, formulario y validaciones) | 5.1 | 72% |
+| Juani Portilla | Refinamiento backend y frontend de Becas | 2.0 | 28% |
+| **Total julio 2026 (al 03/07)** | | **7.1** | **100%** |
+
+[:material-table-arrow-right: Ver detalle de consumo día por día](../versiones/version-001-consumo-horas.md){ .md-button }
+
+---
+
+## :material-format-list-bulleted: Qué se está trabajando en el mes
+
+- **App de campo:** flujo de identidad por escaneo de DNI / RENAPER / carga manual, preguntas por segmento y subsegmento, carga de imágenes desde cámara o galería, captura de GPS y validaciones (issue #83).
+- **Programa Becas:** refinamiento del backend y del frontend del módulo.
+
+!!! note "Estimación comprometida"
+    Las **654 horas** estimadas del [Programa Becas](../funcionalidades/estimacion-programa-becas.md) corresponden a trabajo comprometido que se ejecuta durante estos meses; el consumo se refleja en esta página a medida que se registra.
+
+---
+
+[:material-arrow-left: Volver al índice financiero](index.md){ .md-button }
+[:material-home: Volver al inicio](../index.md){ .md-button }

--- a/docs/client/index.md
+++ b/docs/client/index.md
@@ -34,15 +34,17 @@ hide:
 
     ---
 
-    **Junio 2026 (cerrado):** 499h consumidas de 500h (100%) — dentro del presupuesto
+    **Julio 2026 (en curso):** 7h consumidas de 500h al 03/07
 
-    [:octicons-arrow-right-16: Ver dashboard](financiero/mes-2026-06.md)
+    **Junio 2026 (cerrado):** 499h de 500h (100%) — dentro del presupuesto
+
+    [:octicons-arrow-right-16: Ver dashboard](financiero/mes-2026-07.md)
 
 -   :material-calendar-clock: **Última actualización**
 
     ---
 
-    **2 de julio 2026**
+    **8 de julio 2026**
 
     Documentación viva — se actualiza al cierre de cada versión.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Version 001 - Detalle de consumo de horas: versiones/version-001-consumo-horas.md
   - Financiero:
     - financiero/index.md
+    - Julio 2026: financiero/mes-2026-07.md
     - Junio 2026: financiero/mes-2026-06.md
   - Funcionalidades:
     - funcionalidades/index.md


### PR DESCRIPTION
## Resumen
Crea la pagina publica [financiero/mes-2026-07](https://mkdir-arg.github.io/Chaco/financiero/mes-2026-07/) con el detalle del mes en curso:

- **Presupuesto:** 500 horas (mismo acuerdo que junio)
- **Consumo al 03/07:** 7 h — Pablo Cao 5.1 h (app de campo, issue #83) y Juani Portilla 2 h (refinamiento Becas), segun el registro de consumo dia por dia
- **Saldo:** 493 horas

Ademas:
- `mkdocs.yml` — Julio 2026 en la nav de Financiero
- `docs/client/financiero/index.md` — nueva seccion Mes en curso
- `docs/client/index.md` — card de estado financiero apunta a julio + fecha de ultima actualizacion

Build estricto de mkdocs validado localmente (exit 0). Al mergear se dispara `docs-auto-deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)