### PR TITLE
docs(client): imputacion de horas por programa desde julio 2026

### DIFF
--- a/.claude/commands/fin-de-trabajo.md
+++ b/.claude/commands/fin-de-trabajo.md
@@ -14,6 +14,7 @@ Reglas:
 Pasos:
 1. Leé `.github/worklog/sesion-activa.json` y tomá:
    - persona
+   - programa (si falta, preguntá: **Becas**, **Dispositivos** o **Transversal**)
    - motivo
    - que_hare
    - inicio_iso
@@ -26,18 +27,21 @@ Pasos:
    - `minutos_pausa = suma de pausas cerradas`.
    - Si `pausada_desde_iso` está informado al cerrar, sumá además la pausa abierta `fin - pausada_desde_iso`.
    - `minutos_consumidos = max(0, minutos_brutos - minutos_pausa)`.
-4. Asegurá que exista `consumo_file`.
-   - Si no existe, crealo con estas secciones:
-     - Título del sprint de consumo
-     - Tabla `Persona | Motivo | Qué hice | Consumo`
-     - Sección "Total consumido"
-5. Insertá una fila nueva en la tabla con:
+4. Asegurá que en `consumo_file` exista la sección del mes en curso
+   (`## ... Consumo de <mes> <año> — detalle día por día`).
+   - Si no existe, creala con una tabla `Día | Persona | Programa | Motivo | Qué hice | Consumo`
+     y una subsección `### Consumo de <mes> por programa` con filas Becas / Dispositivos / Transversal.
+   - Desde julio 2026 todo registro lleva programa; no toques las tablas de meses anteriores.
+5. Insertá una fila nueva en la tabla del mes en curso con:
+   - Día (`YYYY-MM-DD`)
    - Persona
+   - Programa (Becas / Dispositivos / Transversal)
    - Motivo
    - Qué hice
    - Consumo en formato `NN min`
-6. Recalculá el total sumando todos los valores `NN min` de la tabla y actualizá la caja de "Contador total" mostrando:
-   - Minutos totales
-   - Equivalente en horas y minutos
+6. Recalculá y actualizá:
+   - La tabla `Consumo de <mes> por programa` (suma de `NN min` por programa, en formato `N h MM min`).
+   - La caja de "Contador total": minutos totales, equivalente en horas y minutos, y el desglose por mes.
 7. Eliminá `.github/worklog/sesion-activa.json` para dejar la sesión cerrada.
-8. Respondé un resumen con inicio, fin, minutos y archivo actualizado.
+8. Avisá que la página financiera del mes (`docs/client/financiero/mes-<año>-<mes>.md`) queda desactualizada y ofrecé actualizar sus números (consumo, saldo, por programa y por persona).
+9. Respondé un resumen con inicio, fin, minutos, programa y archivo actualizado.

--- a/.claude/commands/inicio-de-trabajo.md
+++ b/.claude/commands/inicio-de-trabajo.md
@@ -12,10 +12,11 @@ Reglas:
 - Guardá el estado de sesión en `.github/worklog/sesion-activa.json`.
 
 Pasos:
-1. Detectá el sprint actual en `docs/client/sprints/` tomando el archivo `sprint-XXX.md` de mayor número, excluyendo `index.md` y cualquier `*-consumo-horas.md`.
-2. Calculá el archivo de detalle asociado: `docs/client/sprints/sprint-XXX-consumo-horas.md`.
+1. Detectá la versión actual en `docs/client/versiones/` tomando el archivo `version-XXX.md` de mayor número, excluyendo `index.md` y cualquier `*-consumo-horas.md`.
+2. Calculá el archivo de detalle asociado: `docs/client/versiones/version-XXX-consumo-horas.md`.
 3. Pedí y confirmá estos datos mínimos:
    - Persona
+   - Programa: **Becas**, **Dispositivos** o **Transversal** (gestión, reuniones, soporte — todo lo que no se imputa a un programa puntual)
    - Motivo
    - Qué vas a hacer
 4. Registrá la hora de inicio en formato ISO local (`YYYY-MM-DDTHH:mm:ss`).
@@ -24,14 +25,15 @@ Pasos:
 ```json
 {
   "persona": "...",
+  "programa": "Becas | Dispositivos | Transversal",
   "motivo": "...",
   "que_hare": "...",
   "inicio_iso": "YYYY-MM-DDTHH:mm:ss",
   "pausada_desde_iso": null,
   "pausas": [],
-  "sprint_file": "docs/client/sprints/sprint-XXX.md",
-  "consumo_file": "docs/client/sprints/sprint-XXX-consumo-horas.md"
+  "version_file": "docs/client/versiones/version-XXX.md",
+  "consumo_file": "docs/client/versiones/version-XXX-consumo-horas.md"
 }
 ```
 
-6. Respondé un resumen corto con persona, sprint detectado y hora de inicio.
+6. Respondé un resumen corto con persona, programa, versión detectada y hora de inicio.

--- a/docs/client/financiero/index.md
+++ b/docs/client/financiero/index.md
@@ -15,7 +15,8 @@
 
     :material-wallet-outline: Presupuesto: **500 horas**  
     :material-clock-check-outline: Consumido: **7 horas** (1%) — al 03/07  
-    :material-check-circle-outline: Saldo: **493 horas** disponibles
+    :material-check-circle-outline: Saldo: **493 horas** disponibles  
+    :material-briefcase-outline: Becas: **7 h** · Dispositivos: **0 h**
 
     **Estado:** :material-circle:{ style="color: #3b82f6" } En curso
 

--- a/docs/client/financiero/mes-2026-07.md
+++ b/docs/client/financiero/mes-2026-07.md
@@ -37,6 +37,19 @@
 
 ---
 
+## :material-briefcase-outline: Consumo por programa
+
+Desde julio 2026 el consumo se imputa por programa.
+
+| Programa | Horas | % del consumo |
+|---|---:|---:|
+| [Programa Becas](../funcionalidades/programa-becas.md) | 7.1 | 100% |
+| [Programa Dispositivos](../funcionalidades/programa-dispositivos.md) | 0.0 | 0% |
+| Transversal (gestión, reuniones, soporte) | 0.0 | 0% |
+| **Total julio 2026 (al 03/07)** | **7.1** | **100%** |
+
+---
+
 ## :material-account-group: Consumo por persona
 
 | Persona | Foco principal | Horas | % del consumo |

--- a/docs/client/versiones/version-001-consumo-horas.md
+++ b/docs/client/versiones/version-001-consumo-horas.md
@@ -1,6 +1,6 @@
 # :material-table-clock: Versión 001 - Detalle de consumo de horas
 
-## :material-account-clock: Consumo por persona
+## :material-account-clock: Consumo de junio 2026 — detalle día por día
 
 | Día | Persona | Motivo | Qué hice | Consumo |
 |---|---|---|---|---:|
@@ -115,8 +115,27 @@
 | 2026-06-30 | Matías Fariña | Programa Dispositivos — análisis | Consolidación y documentación del análisis | 520 min |
 | 2026-06-30 | Agostina Coppola | Programa Dispositivos — análisis y testing | Cierre de documentación y testing del período | 500 min |
 | 2026-06-30 | Equipo UX | Mockups del programa | Entrega final de mockups y handoff | 480 min |
-| 2026-07-01 | Pablo Cao | App mobile Becas | Trabajo sobre Issue #83: flujo de identidad por escaneo DNI/RENAPER/manual, preguntas globales/segmento/subsegmento, imagenes desde camara/galeria, mejoras visuales del formulario, correccion RENAPER, captura GPS oculta, validaciones Expo/Django y auditoria funcional contra issues/documentacion. | 308 min |
-| 2026-07-03 | Juani Portilla | Becas | Refinamiento backend y frontend de Becas | 120 min |
+
+---
+
+## :material-calendar-month: Consumo de julio 2026 — detalle día por día
+
+!!! info "Imputación por programa"
+    Desde julio 2026 cada registro se imputa a un **programa** (Becas o Dispositivos). Las horas que no corresponden a un programa puntual (gestión, reuniones, soporte) se imputan como **Transversal**.
+
+| Día | Persona | Programa | Motivo | Qué hice | Consumo |
+|---|---|---|---|---|---:|
+| 2026-07-01 | Pablo Cao | Becas | App mobile Becas | Trabajo sobre Issue #83: flujo de identidad por escaneo DNI/RENAPER/manual, preguntas globales/segmento/subsegmento, imagenes desde camara/galeria, mejoras visuales del formulario, correccion RENAPER, captura GPS oculta, validaciones Expo/Django y auditoria funcional contra issues/documentacion. | 308 min |
+| 2026-07-03 | Juani Portilla | Becas | Becas | Refinamiento backend y frontend de Becas | 120 min |
+
+### :material-briefcase-outline: Consumo de julio por programa
+
+| Programa | Horas julio |
+|---|---:|
+| Becas | 7 h 8 min |
+| Dispositivos | 0 h 0 min |
+| Transversal | 0 h 0 min |
+| **Total julio 2026 (al 03/07)** | **7 h 8 min** |
 
 ---
 


### PR DESCRIPTION
## Resumen
Desde julio 2026 el consumo de horas se imputa por programa: **Becas**, **Dispositivos** o **Transversal** (gestion, reuniones, soporte).

- **Registro dia por dia** (`versiones/version-001-consumo-horas.md`): julio pasa a su propia tabla con columna `Programa` + subtotal mensual por programa. Junio queda como estaba.
- **Pagina de julio** (`financiero/mes-2026-07.md`): nueva seccion *Consumo por programa* (Becas 7.1 h / Dispositivos 0 h al 03/07).
- **Indice financiero**: desglose Becas/Dispositivos en el card de julio.
- **Comandos `/inicio-de-trabajo` y `/fin-de-trabajo`**: piden y registran el programa en cada sesion, y se corrige la ruta del registro (`docs/client/versiones/` en lugar de `docs/client/sprints/`, que ya no existe).

Build estricto de mkdocs validado localmente (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
