### PR TITLE
pm: /pm:programas + imputacion de junio 2026 a Becas

### DIFF
--- a/.claude/agents/pm-assistant.md
+++ b/.claude/agents/pm-assistant.md
@@ -38,10 +38,12 @@ Resumen de lo que vas a encontrar ahí (no es sustituto de leerlo):
   issues ni items del Project. **Solo el PM humano mueve las tareas.**
 - **Fuentes de datos:** Project #1 de `Mkdir-arg` e issues de `Mkdir-arg/Chaco`
   vía **GitHub MCP** (preferido) con fallback `gh`; horas reales en
-  `docs/client/sprints/sprint-NNN-consumo-horas.md`.
-- **Cuatro informes canónicos:** Estado (foto del sprint) · Salud (auditoría de
+  `docs/client/versiones/version-NNN-consumo-horas.md` (desde jul-2026 con
+  columna `Programa`); estimaciones en
+  `docs/client/funcionalidades/estimacion-programa-*.md`.
+- **Cinco informes canónicos:** Estado (foto del sprint) · Salud (auditoría de
   trazabilidad y cobertura QA) · Minuta (reunión → `docs/client/`) · Reporte
-  (avance en lenguaje cliente).
+  (avance en lenguaje cliente) · Programas (estimado vs consumido por programa).
 - Disciplina: recolectar datos antes de opinar, citar siempre `#NN`, no
   inventar datos faltantes, confirmar antes de publicar a Pages.
 

--- a/.claude/commands/infoagente.md
+++ b/.claude/commands/infoagente.md
@@ -93,11 +93,12 @@ Presentá, en este orden y de forma legible:
    | QA | `/qa:casos` | Casos de prueba de una task |
    | QA | `/qa:plan` | `[PLAN DE PRUEBAS]` consolidado de una épica |
    | QA | `/qa:revision` | Detectar y cubrir tasks sin casos |
-   | PM | `/pm` | Flujo guiado (estado / salud / minuta / reporte) |
+   | PM | `/pm` | Flujo guiado (estado / salud / minuta / reporte / programas) |
    | PM | `/pm:estado` | Foto del sprint: tablero, esfuerzo, horas reales |
    | PM | `/pm:salud` | Auditoría de trazabilidad y cobertura (7 chequeos + score + plan de remediación con el comando para arreglar cada error) |
    | PM | `/pm:minuta` | Minuta de reunión → docs/client |
    | PM | `/pm:reporte` | Avance del período en lenguaje cliente |
+   | PM | `/pm:programas` | Panorama por programa: estimado vs consumido |
    | — | `/infoagente` | Este manual |
    | — | `/inicio-de-trabajo` · `/fin-de-trabajo` | Registrar sesión de trabajo y horas del sprint |
 
@@ -119,6 +120,7 @@ Presentá, en este orden y de forma legible:
    | "¿Estamos respetando el método? ¿Algo colgado?" | `/pm:salud` |
    | "Tuvimos reunión con el Ministerio, registrala" | `/pm:minuta` |
    | "Armá el avance para mandarle al cliente" | `/pm:reporte` |
+   | "¿Cuántas horas estimamos y consumimos por programa?" | `/pm:programas` |
    | "Empiezo/termino de trabajar" | `/inicio-de-trabajo` / `/fin-de-trabajo` |
    | "No sé con qué comando arrancar esto" | `/infoagente <describí el tema>` |
 

--- a/.claude/commands/pm.md
+++ b/.claude/commands/pm.md
@@ -1,5 +1,5 @@
 ---
-description: Sesión guiada de gestión del proyecto (estado, salud, minuta, reporte) sobre el Project #1
+description: Sesión guiada de gestión del proyecto (estado, salud, minuta, reporte, programas) sobre el Project #1
 argument-hint: "[qué necesitás, opcional]"
 ---
 
@@ -23,12 +23,13 @@ Saludá corto y presentá las opciones (preguntas numeradas en texto):
 > 2. **Salud** — auditoría de trazabilidad (cadena, campos, cobertura QA, estancados).
 > 3. **Minuta** — registrar una reunión y publicarla en docs/client.
 > 4. **Reporte** — avance del período en lenguaje cliente.
+> 5. **Programas** — panorama estimado vs consumido por programa (Becas / Dispositivos).
 
 ## Paso 1 — Ejecutar el informe elegido
 
-Cada opción tiene su estructura canónica en `PM.md` (sección "Los cuatro
+Cada opción tiene su estructura canónica en `PM.md` (sección "Los cinco
 informes"). Aplicá el flujo del comando dedicado correspondiente
-(`/pm:estado`, `/pm:salud`, `/pm:minuta`, `/pm:reporte`).
+(`/pm:estado`, `/pm:salud`, `/pm:minuta`, `/pm:reporte`, `/pm:programas`).
 
 Acceso a datos: **GitHub MCP** (server `github`) como vía preferida para leer
 issues y el Project #1 de `Mkdir-arg`; fallback `gh` si el MCP no está
@@ -46,4 +47,4 @@ autenticado en la sesión (avisá al usuario que puede autenticarlo con `/mcp`).
 
 ## Cierre
 
-Después de cada informe, preguntá si necesita otro de los cuatro o si cerramos.
+Después de cada informe, preguntá si necesita otro de los cinco o si cerramos.

--- a/.claude/commands/pm/estado.md
+++ b/.claude/commands/pm/estado.md
@@ -14,8 +14,8 @@ Contexto del usuario: `$ARGUMENTS`
 1. **Levantá el Project #1** de `Mkdir-arg` (GitHub MCP preferido; fallback
    `gh project item-list 1 --owner Mkdir-arg --format json`): items con Status,
    Tipo, Prioridad, Modulo y EstimacionHoras.
-2. **Levantá las horas reales** del sprint actual:
-   `docs/client/sprints/sprint-NNN-consumo-horas.md` (el de número más alto).
+2. **Levantá las horas reales** de la versión actual:
+   `docs/client/versiones/version-NNN-consumo-horas.md` (el de número más alto).
 3. **Armá el informe canónico** de `PM.md` → "1. Estado":
    resumen ejecutivo · tablero (Status × Tipo) · esfuerzo (EstimacionHoras por
    Status) · horas reales (total y por persona) · alertas rápidas (sin

--- a/.claude/commands/pm/programas.md
+++ b/.claude/commands/pm/programas.md
@@ -1,0 +1,34 @@
+---
+description: "Panorama por programa: horas estimadas vs horas registradas (Becas / Dispositivos)"
+argument-hint: "[programa o foco, opcional]"
+---
+
+# Panorama por programa
+
+Actuá como el **PM Assistant de Chaco** (metodología y estructura canónica del
+informe en `PM.md` (raíz, fuente de verdad) — leelo y seguilo, sección
+"5. Programas"). **Solo lectura.**
+
+Contexto del usuario: `$ARGUMENTS`
+
+## Pasos
+1. **Levantá las estimaciones**: todos los
+   `docs/client/funcionalidades/estimacion-programa-*.md`. De cada uno tomá el
+   total y el desglose por concepto del "Resumen ejecutivo", más fecha, versión
+   y estado de aprobación.
+2. **Levantá el consumo por programa**: tablas mensuales con columna `Programa`
+   de `docs/client/versiones/version-NNN-consumo-horas.md` (el de número más
+   alto). Sumá por programa desde julio 2026. Los meses sin columna `Programa`
+   (junio 2026) y las horas `Transversal` van aparte, no contra los programas.
+3. **Cruzá con el Project #1** de `Mkdir-arg` (GitHub MCP preferido; fallback
+   `gh project item-list 1 --owner Mkdir-arg --format json`): suma de
+   `EstimacionHoras` de las tasks de la épica de cada programa vs. el total del
+   documento. Si el MCP/`gh` no está disponible, marcá la sección como
+   "sin verificar" y seguí.
+4. **Armá el informe canónico** de `PM.md` → "5. Programas": resumen ejecutivo ·
+   panorama (Estimado | Consumido | % avance | Restante | Estado) · detalle del
+   estimado · horas fuera de programas · cruce con el Project · alertas.
+5. Datos faltantes se marcan, no se rellenan. Todo número cita su fuente
+   (documento de estimación o registro de consumo).
+6. Cerrá con las 2-3 lecturas más útiles para el PM (dónde hay riesgo de
+   desvío, qué conviene mirar primero).

--- a/.claude/commands/pm/programas.md
+++ b/.claude/commands/pm/programas.md
@@ -16,10 +16,11 @@ Contexto del usuario: `$ARGUMENTS`
    `docs/client/funcionalidades/estimacion-programa-*.md`. De cada uno tomá el
    total y el desglose por concepto del "Resumen ejecutivo", más fecha, versión
    y estado de aprobación.
-2. **Levantá el consumo por programa**: tablas mensuales con columna `Programa`
-   de `docs/client/versiones/version-NNN-consumo-horas.md` (el de número más
-   alto). Sumá por programa desde julio 2026. Los meses sin columna `Programa`
-   (junio 2026) y las horas `Transversal` van aparte, no contra los programas.
+2. **Levantá el consumo por programa**: `docs/client/versiones/version-NNN-consumo-horas.md`
+   (el de número más alto). **Junio 2026 se imputa íntegramente a Becas**
+   (decisión del PM, 08/07/2026, anotada en el registro); desde julio sumá por
+   programa con la columna `Programa` de las tablas mensuales. Las horas
+   `Transversal` van aparte, no contra los programas.
 3. **Cruzá con el Project #1** de `Mkdir-arg` (GitHub MCP preferido; fallback
    `gh project item-list 1 --owner Mkdir-arg --format json`): suma de
    `EstimacionHoras` de las tasks de la épica de cada programa vs. el total del

--- a/PM.md
+++ b/PM.md
@@ -22,7 +22,8 @@ tareas entre estados (**solo el PM humano mueve las tareas**) y no define alcanc
 |--------|--------|----------------|
 | **Project #1** (`Mkdir-arg`, "Proyect Chaco") | Items, Status, Prioridad, Modulo, EstimacionHoras | GitHub MCP (lectura) o `gh project item-list 1 --owner Mkdir-arg --format json` |
 | **Issues del repo** (`Mkdir-arg/Chaco`) | Épicas, análisis, tasks, `[REQUERIMIENTO]`, `[PLAN DE PRUEBAS]`, cuerpos y vínculos | GitHub MCP (lectura) o `gh issue list/view` |
-| **Consumo de horas** | Horas reales por persona/día del sprint | `docs/client/sprints/sprint-NNN-consumo-horas.md` (lo alimentan `/inicio-de-trabajo` y `/fin-de-trabajo`) |
+| **Consumo de horas** | Horas reales por persona/día (desde jul-2026 con columna `Programa`) | `docs/client/versiones/version-NNN-consumo-horas.md` (lo alimentan `/inicio-de-trabajo` y `/fin-de-trabajo`) |
+| **Estimaciones por programa** | Horas estimadas por programa (resumen ejecutivo, desglose por concepto, estado de aprobación) | `docs/client/funcionalidades/estimacion-programa-*.md` |
 
 ### GitHub MCP y fallback `gh`
 
@@ -35,7 +36,7 @@ EstimacionHoras) la receta canónica sigue siendo `gh project item-edit` de
 `AGENTS.md` — pero el PM Assistant no escribe al Project, así que esto le aplica
 al Analista y a QA.
 
-## Los cuatro informes (estructuras canónicas)
+## Los cinco informes (estructuras canónicas)
 
 ### 1. Estado (`/pm:estado`) — la foto del sprint
 
@@ -107,6 +108,32 @@ Para enviar o publicar. **Sin jerga técnica ni interna** (regla de
 4. **Próximos pasos** — qué sigue, en lenguaje cliente.
 5. **Temas que necesitamos de ustedes** — definiciones pendientes del cliente
    (de las "Asunciones a confirmar" de los análisis, reformuladas en claro).
+
+### 5. Programas (`/pm:programas`) — panorama estimado vs consumido por programa
+
+Cruza las **horas estimadas** de cada programa contra las **horas registradas**
+para ver el panorama de avance. Fuentes: los documentos de estimación
+(`docs/client/funcionalidades/estimacion-programa-*.md` — total del resumen
+ejecutivo, desglose por concepto, fecha/versión/estado de aprobación) y el
+registro de consumo (`docs/client/versiones/version-NNN-consumo-horas.md`,
+tablas mensuales con columna `Programa`, disponibles desde julio 2026).
+Secciones, en este orden:
+1. **Resumen ejecutivo** — 2-3 líneas por programa: cuánto se estimó, cuánto se
+   consumió, qué % de avance implica y qué preocupa.
+2. **Panorama** — tabla por programa: Estimado (doc) | Consumido | % avance |
+   Restante | Estado de la estimación (aprobada / pendiente de aprobación).
+3. **Detalle del estimado** — por programa, el desglose por concepto del resumen
+   ejecutivo (Backend, Frontend, App, UX, QA, despliegue, capacitación).
+4. **Horas fuera de programas** — Transversal del período (gestión, reuniones,
+   soporte) y meses previos sin imputación (junio 2026: 499 h), para que el
+   total cierre contra el registro. Las estimaciones son esfuerzo técnico neto:
+   lo Transversal **no** descuenta avance de ningún programa.
+5. **Cruce con el Project** — suma de `EstimacionHoras` de las tasks de la épica
+   de cada programa vs. el total del documento de estimación; discrepancias se
+   marcan (no se corrigen).
+6. **Alertas** — programa consumiendo sin estimación aprobada; consumo del mes
+   sin columna `Programa`; % de avance de consumo muy por encima del % de
+   alcance entregado; estimaciones desactualizadas respecto del alcance.
 
 ## Forma de trabajar (siempre igual)
 

--- a/PM.md
+++ b/PM.md
@@ -115,19 +115,24 @@ Cruza las **horas estimadas** de cada programa contra las **horas registradas**
 para ver el panorama de avance. Fuentes: los documentos de estimación
 (`docs/client/funcionalidades/estimacion-programa-*.md` — total del resumen
 ejecutivo, desglose por concepto, fecha/versión/estado de aprobación) y el
-registro de consumo (`docs/client/versiones/version-NNN-consumo-horas.md`,
-tablas mensuales con columna `Programa`, disponibles desde julio 2026).
+registro de consumo (`docs/client/versiones/version-NNN-consumo-horas.md`).
+Imputación del consumo: **junio 2026 se imputa íntegramente a Becas**
+(decisión del PM, 08/07/2026, anotada en el registro); **desde julio 2026**
+cada fila lleva columna `Programa` en las tablas mensuales.
 Secciones, en este orden:
 1. **Resumen ejecutivo** — 2-3 líneas por programa: cuánto se estimó, cuánto se
    consumió, qué % de avance implica y qué preocupa.
 2. **Panorama** — tabla por programa: Estimado (doc) | Consumido | % avance |
    Restante | Estado de la estimación (aprobada / pendiente de aprobación).
+   Si parte del consumo es previo a la fecha de la estimación (p. ej. junio
+   para Becas), el informe lo separa en una línea aparte: consumo total vs
+   consumo desde la estimación — el PM decide contra cuál medir el avance.
 3. **Detalle del estimado** — por programa, el desglose por concepto del resumen
    ejecutivo (Backend, Frontend, App, UX, QA, despliegue, capacitación).
 4. **Horas fuera de programas** — Transversal del período (gestión, reuniones,
-   soporte) y meses previos sin imputación (junio 2026: 499 h), para que el
-   total cierre contra el registro. Las estimaciones son esfuerzo técnico neto:
-   lo Transversal **no** descuenta avance de ningún programa.
+   soporte), para que el total cierre contra el registro. Las estimaciones son
+   esfuerzo técnico neto: lo Transversal **no** descuenta avance de ningún
+   programa.
 5. **Cruce con el Project** — suma de `EstimacionHoras` de las tasks de la épica
    de cada programa vs. el total del documento de estimación; discrepancias se
    marcan (no se corrigen).

--- a/docs/client/versiones/version-001-consumo-horas.md
+++ b/docs/client/versiones/version-001-consumo-horas.md
@@ -2,6 +2,9 @@
 
 ## :material-account-clock: Consumo de junio 2026 — detalle día por día
 
+!!! note "Imputación de junio"
+    Por decisión del PM (08/07/2026), el consumo de junio 2026 se imputa **íntegramente al Programa Becas**, incluyendo el trabajo de base del mes (motor de roles, design system, legajo ciudadano, análisis inicial del Programa Dispositivos y reuniones). La imputación por programa fila por fila rige desde julio 2026.
+
 | Día | Persona | Motivo | Qué hice | Consumo |
 |---|---|---|---|---:|
 | 2026-06-03 | Agostina Coppola | Reunión inicial y alineación funcional del sprint | Definición funcional inicial y coordinación del alcance | 50 min |
@@ -149,6 +152,13 @@
 | Pablo Cao | App de campo (diseño, desarrollo front e integración) | 95 h 59 min |
 | Equipo UX | Mockups del programa | 65 h 00 min |
 | **Total junio 2026** | | **499 h 12 min** |
+
+### :material-briefcase-outline: Consumo de junio por programa
+
+| Programa | Horas junio |
+|---|---:|
+| Becas | 499 h 12 min (100%) |
+| **Total junio 2026** | **499 h 12 min** |
 
 ---
 


### PR DESCRIPTION
## Resumen
Dos cambios de gestion de horas:

**1. Nuevo informe del PM Assistant: `/pm:programas`** (quinto informe canonico en `PM.md`)
Cruza horas estimadas por programa (docs de estimacion en `funcionalidades/`) contra horas registradas (registro de consumo), con cruce opcional contra `EstimacionHoras` del Project #1 y alertas. Tambien se corrige en `PM.md`, `/pm:estado` y el agente `pm-assistant` la ruta del registro de consumo (`docs/client/versiones/`, la carpeta `sprints/` ya no existe).

**2. Imputacion de junio 2026 al Programa Becas** (decision del PM, 08/07/2026)
Las 499 h 12 min de junio se imputan integramente a Becas. Queda anotado en el registro de consumo (`versiones/version-001-consumo-horas.md`) con su tabla de junio por programa, y el metodo de `/pm:programas` cuenta junio como consumo de Becas. El informe separa consumo total vs consumo desde la fecha de la estimacion.

Build estricto de mkdocs validado localmente (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
