### PR TITLE
Becas: correcciones de auditoría de diseño en Relevamientos

### DIFF
--- a/programas/templates/programas/becas/_ajax_js.html
+++ b/programas/templates/programas/becas/_ajax_js.html
@@ -10,10 +10,18 @@
   }
   function toast(msg, isErr) {
     var el = document.createElement('div');
-    el.className = 'fixed bottom-5 right-5 z-[200] rounded-xl px-4 py-3 text-sm font-medium shadow-lg ' +
+    el.className = 'fixed bottom-5 right-5 z-[200] flex items-center gap-2 rounded-xl px-4 py-3 text-sm font-medium shadow-lg ' +
       (isErr ? 'bg-danger-soft text-fg-danger border border-[color:var(--border-danger-subtle)]'
              : 'bg-success-soft text-fg-success border border-[color:var(--border-success-subtle)]');
-    el.textContent = msg;
+    el.setAttribute('role', 'alert');
+    el.setAttribute('aria-live', 'polite');
+    var icon = document.createElement('i');
+    icon.className = 'fas ' + (isErr ? 'fa-circle-xmark' : 'fa-circle-check');
+    icon.setAttribute('aria-hidden', 'true');
+    var text = document.createElement('span');
+    text.textContent = msg;
+    el.appendChild(icon);
+    el.appendChild(text);
     document.body.appendChild(el);
     setTimeout(function () {
       el.style.transition = 'opacity .3s'; el.style.opacity = '0';

--- a/programas/templates/programas/becas/relevamientos/_convocatorias_table.html
+++ b/programas/templates/programas/becas/relevamientos/_convocatorias_table.html
@@ -35,16 +35,15 @@
         </td>
         <td class="px-4 py-[13px] text-sm border-t border-light text-right">
           <div class="flex items-center justify-end gap-2">
-            <a href="{% url 'becas:convocatoria_detalle' c.pk %}" class="text-body-subtle hover:text-fg-brand p-1" title="Ver detalle"><i class="fas fa-eye"></i></a>
-            <a href="{% url 'becas:convocatoria_detalle' c.pk %}" class="text-body-subtle hover:text-heading p-1" title="Editar"><i class="fas fa-edit"></i></a>
+            <a href="{% url 'becas:convocatoria_detalle' c.pk %}" class="text-body-subtle hover:text-fg-brand p-1" title="Ver detalle" aria-label="Ver detalle"><i class="fas fa-eye"></i></a>
             {% if c.activo %}
-            <button type="button" class="text-fg-danger hover:opacity-70 p-1" title="Desactivar"
+            <button type="button" class="text-fg-danger hover:opacity-70 p-1" title="Desactivar" aria-label="Desactivar"
                     data-confirm-url="{% url 'becas:convocatoria_toggle' c.pk %}"
                     data-confirm-title="¿Desactivar convocatoria?" data-confirm-text="{{ c.nombre }}" data-confirm-icon="question" data-confirm-ok="Sí">
               <i class="fas fa-times-circle"></i>
             </button>
             {% else %}
-            <button type="button" class="text-fg-success hover:opacity-70 p-1" title="Activar"
+            <button type="button" class="text-fg-success hover:opacity-70 p-1" title="Activar" aria-label="Activar"
                     data-confirm-url="{% url 'becas:convocatoria_toggle' c.pk %}"
                     data-confirm-title="¿Activar convocatoria?" data-confirm-text="{{ c.nombre }}" data-confirm-icon="question" data-confirm-ok="Sí">
               <i class="fas fa-check-circle"></i>

--- a/programas/templates/programas/becas/relevamientos/_relevamientos_tab_table.html
+++ b/programas/templates/programas/becas/relevamientos/_relevamientos_tab_table.html
@@ -1,0 +1,38 @@
+{% if relevamientos %}
+<div class="bg-white rounded-xl border border-base shadow-sm overflow-hidden">
+  <table class="w-full border-collapse">
+    <thead>
+      <tr class="bg-secondary border-b border-base">
+        <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Nombre</th>
+        <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Territorial</th>
+        <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Zona</th>
+        <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Fecha</th>
+        <th class="px-4 py-[11px] text-center font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Estado</th>
+        <th class="px-4 py-[11px] text-right font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for rel in relevamientos %}
+      <tr class="hover:bg-secondary">
+        <td class="px-4 py-[13px] text-sm border-t border-light font-semibold text-heading">
+          <a href="{% url 'becas:relevamiento_detalle' rel.pk %}" class="text-fg-brand hover:underline">{{ rel.nombre }}</a>
+        </td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.territorial.get_full_name|default:rel.territorial.username }}</td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.zona|default:"—" }}</td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.fecha_asignada|date:"d/m/Y" }}</td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-center">{% with rel=rel %}{% include "programas/becas/relevamientos/_estado_badge.html" %}{% endwith %}</td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-right">
+          <a href="{% url 'becas:relevamiento_detalle' rel.pk %}" class="text-fg-brand hover:opacity-70 p-1" title="Ver detalle" aria-label="Ver detalle"><i class="fas fa-chevron-right"></i></a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<div class="py-14 px-6 text-center flex flex-col items-center gap-3 bg-white rounded-xl border border-base shadow-sm">
+  <div class="text-fg-brand"><i class="fas fa-clipboard-list text-5xl"></i></div>
+  <p class="text-[17px] font-bold text-heading">Sin relevamientos</p>
+  <p class="text-sm text-body max-w-xs">Esta convocatoria no tiene relevamientos asignados aún.</p>
+</div>
+{% endif %}

--- a/programas/templates/programas/becas/relevamientos/convocatoria_detail.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_detail.html
@@ -3,7 +3,7 @@
 
 {% block main-content %}
 <style>[x-cloak]{display:none!important}</style>
-<div class="space-y-5" x-data="{ tab: 'info', modalRel: false }">
+<div class="space-y-5" x-data="{ tab: 'info', modalRel: false }" @becas-saved.window="modalRel=false">
 
   <div>
     <a href="{% url 'becas:convocatorias' %}" class="btn-nodo btn-tertiary btn-sm" style="min-width:0;">
@@ -31,25 +31,25 @@
     {# Tabs #}
     <div class="border-b border-base flex gap-1 px-2 flex-wrap">
       <button @click="tab='info'" type="button"
-              class="px-4 py-3 text-sm font-semibold border-b-2 -mb-px transition flex items-center gap-1.5"
-              :class="tab==='info' ? 'text-fg-brand border-brand' : 'text-body-subtle border-transparent hover:text-body'">
+              class="px-4 py-3 text-sm border-b-2 -mb-px transition flex items-center gap-1.5"
+              :class="tab==='info' ? 'text-fg-brand border-brand font-bold' : 'text-body-subtle border-transparent hover:text-body font-medium'">
         <i class="fas fa-id-card"></i> Información general
       </button>
       <button @click="tab='rel'" type="button"
-              class="px-4 py-3 text-sm font-semibold border-b-2 -mb-px transition flex items-center gap-1.5"
-              :class="tab==='rel' ? 'text-fg-brand border-brand' : 'text-body-subtle border-transparent hover:text-body'">
+              class="px-4 py-3 text-sm border-b-2 -mb-px transition flex items-center gap-1.5"
+              :class="tab==='rel' ? 'text-fg-brand border-brand font-bold' : 'text-body-subtle border-transparent hover:text-body font-medium'">
         <i class="fas fa-folder-open"></i> Relevamientos
-        <span class="badge badge-gray ml-0.5">{{ n_relevamientos }}</span>
+        <span class="badge ml-0.5" :class="tab==='rel' ? 'bg-brand-soft text-fg-brand' : 'badge-gray'">{{ n_relevamientos }}</span>
       </button>
       <button @click="tab='ben'" type="button"
-              class="px-4 py-3 text-sm font-semibold border-b-2 -mb-px transition flex items-center gap-1.5"
-              :class="tab==='ben' ? 'text-fg-brand border-brand' : 'text-body-subtle border-transparent hover:text-body'">
+              class="px-4 py-3 text-sm border-b-2 -mb-px transition flex items-center gap-1.5"
+              :class="tab==='ben' ? 'text-fg-brand border-brand font-bold' : 'text-body-subtle border-transparent hover:text-body font-medium'">
         <i class="fas fa-users"></i> Beneficiarios
-        <span class="badge badge-gray ml-0.5">{{ n_beneficiarios }}</span>
+        <span class="badge ml-0.5" :class="tab==='ben' ? 'bg-brand-soft text-fg-brand' : 'badge-gray'">{{ n_beneficiarios }}</span>
       </button>
       <button @click="tab='rep'" type="button"
-              class="px-4 py-3 text-sm font-semibold border-b-2 -mb-px transition flex items-center gap-1.5"
-              :class="tab==='rep' ? 'text-fg-brand border-brand' : 'text-body-subtle border-transparent hover:text-body'">
+              class="px-4 py-3 text-sm border-b-2 -mb-px transition flex items-center gap-1.5"
+              :class="tab==='rep' ? 'text-fg-brand border-brand font-bold' : 'text-body-subtle border-transparent hover:text-body font-medium'">
         <i class="fas fa-chart-simple"></i> Reportes
       </button>
     </div>
@@ -154,44 +154,9 @@
         <p class="text-sm text-body-subtle">Relevamientos asignados a esta convocatoria.</p>
         <button type="button" @click="modalRel=true" class="btn-nodo btn-brand btn-sm"><i class="fas fa-plus"></i> Nuevo relevamiento</button>
       </div>
-      {% if relevamientos %}
-      <div class="bg-white rounded-xl border border-base shadow-sm overflow-hidden">
-        <table class="w-full border-collapse">
-          <thead>
-            <tr class="bg-secondary border-b border-base">
-              <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Nombre</th>
-              <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Territorial</th>
-              <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Zona</th>
-              <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Fecha</th>
-              <th class="px-4 py-[11px] text-center font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Estado</th>
-              <th class="px-4 py-[11px] text-right font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Acciones</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for rel in relevamientos %}
-            <tr class="hover:bg-secondary">
-              <td class="px-4 py-[13px] text-sm border-t border-light font-semibold text-heading">
-                <a href="{% url 'becas:relevamiento_detalle' rel.pk %}" class="text-fg-brand hover:underline">{{ rel.nombre }}</a>
-              </td>
-              <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.territorial.get_full_name|default:rel.territorial.username }}</td>
-              <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.zona|default:"—" }}</td>
-              <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.fecha_asignada|date:"d/m/Y" }}</td>
-              <td class="px-4 py-[13px] text-sm border-t border-light text-center">{% with rel=rel %}{% include "programas/becas/relevamientos/_estado_badge.html" %}{% endwith %}</td>
-              <td class="px-4 py-[13px] text-sm border-t border-light text-right">
-                <a href="{% url 'becas:relevamiento_detalle' rel.pk %}" class="text-fg-brand hover:opacity-70 p-1" title="Ver detalle"><i class="fas fa-chevron-right"></i></a>
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+      <div id="relevamientos-table">
+        {% include "programas/becas/relevamientos/_relevamientos_tab_table.html" %}
       </div>
-      {% else %}
-      <div class="py-10 px-6 text-center flex flex-col items-center gap-3 bg-white rounded-xl border border-base shadow-sm">
-        <div class="text-fg-brand"><i class="fas fa-clipboard-list text-4xl"></i></div>
-        <p class="text-base font-bold text-heading">Sin relevamientos</p>
-        <p class="text-sm text-body max-w-xs">Esta convocatoria no tiene relevamientos asignados aún.</p>
-      </div>
-      {% endif %}
     </div>
 
     {# ===== TAB: Beneficiarios ===== #}
@@ -230,9 +195,9 @@
         </table>
       </div>
       {% else %}
-      <div class="py-10 px-6 text-center flex flex-col items-center gap-3 bg-white rounded-xl border border-base shadow-sm">
-        <div class="text-fg-brand"><i class="fas fa-users text-4xl"></i></div>
-        <p class="text-base font-bold text-heading">Sin beneficiarios</p>
+      <div class="py-14 px-6 text-center flex flex-col items-center gap-3 bg-white rounded-xl border border-base shadow-sm">
+        <div class="text-fg-brand"><i class="fas fa-users text-5xl"></i></div>
+        <p class="text-[17px] font-bold text-heading">Sin beneficiarios</p>
         <p class="text-sm text-body max-w-xs">Todavía no se cargaron formularios en los relevamientos de esta convocatoria.</p>
       </div>
       {% endif %}
@@ -261,44 +226,61 @@
   {# ============ Modal: Nuevo relevamiento (convocatoria preseleccionada) ============ #}
   <div x-show="modalRel" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/40" @click="modalRel=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-xl p-6 max-h-[90vh] overflow-y-auto" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Nuevo relevamiento</h3>
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-xl max-h-[90vh] overflow-y-auto" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center text-lg"
+               style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <i class="fas fa-route"></i>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Nuevo relevamiento</h3>
+        </div>
+        <button type="button" @click="modalRel=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <i class="fas fa-xmark text-base"></i>
+        </button>
       </div>
 
-      <div class="rounded-xl bg-brand-soft p-3 text-sm text-fg-brand mb-5 flex items-start gap-2" style="border:1px solid var(--color-brand-200)">
-        <i class="fas fa-circle-info mt-0.5"></i>
-        <span>El relevamiento se nombra automáticamente: <strong>{{ siguiente_nombre }}</strong> y queda en estado Asignado.</span>
-      </div>
-
-      <form method="post" action="{% url 'becas:relevamiento_crear' %}" class="space-y-4">
+      <form method="post" action="{% url 'becas:relevamiento_crear' %}" data-ajax>
         {% csrf_token %}
         <input type="hidden" name="next" value="{% url 'becas:convocatoria_detalle' convocatoria.pk %}">
-        {% if form_crear.non_field_errors %}
-          <div class="rounded-lg bg-danger-soft p-3 text-sm text-fg-danger">{{ form_crear.non_field_errors }}</div>
-        {% endif %}
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Convocatoria <span class="text-fg-danger">*</span></label>
-          {{ form_crear.convocatoria }}
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Territorial asignado <span class="text-fg-danger">*</span></label>
-          {{ form_crear.territorial }}
-          <p class="text-xs text-body-subtle mt-1">Solo se listan los territoriales del segmento de la convocatoria elegida.</p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="p-6 space-y-4">
+          <div class="rounded-xl bg-brand-soft p-3 text-sm text-fg-brand flex items-start gap-2" style="border:1px solid var(--color-brand-200)">
+            <i class="fas fa-circle-info mt-0.5"></i>
+            <span>El relevamiento se nombra automáticamente: <strong>{{ siguiente_nombre }}</strong> y queda en estado Asignado.</span>
+          </div>
+          {% if form_crear.non_field_errors %}
+            <div class="rounded-lg bg-danger-soft p-3 text-sm text-fg-danger">{{ form_crear.non_field_errors }}</div>
+          {% endif %}
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Zona / Localidad <span class="text-fg-danger">*</span></label>
-            {{ form_crear.zona }}
+            <label class="block text-sm font-medium text-heading mb-1">Convocatoria <span class="text-fg-danger">*</span></label>
+            {{ form_crear.convocatoria }}
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="convocatoria"></p>
           </div>
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Fecha asignada <span class="text-fg-danger">*</span></label>
-            {{ form_crear.fecha_asignada }}
+            <label class="block text-sm font-medium text-heading mb-1">Territorial asignado <span class="text-fg-danger">*</span></label>
+            {{ form_crear.territorial }}
+            <p class="text-xs text-body-subtle mt-1">Solo se listan los territoriales del segmento de la convocatoria elegida.</p>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="territorial"></p>
           </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Zona / Localidad <span class="text-fg-danger">*</span></label>
+              {{ form_crear.zona }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="zona"></p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Fecha asignada <span class="text-fg-danger">*</span></label>
+              {{ form_crear.fecha_asignada }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="fecha_asignada"></p>
+            </div>
+          </div>
+          <p class="text-xs text-fg-danger hidden" data-error="__all__"></p>
         </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalRel=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalRel=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base">Guardar</button>
         </div>
       </form>
@@ -307,3 +289,5 @@
 </div>
 {% include "programas/becas/relevamientos/_filtro_territorial.html" %}
 {% endblock %}
+
+{% block customJS %}{% include "programas/becas/_ajax_js.html" %}{% endblock %}

--- a/programas/templates/programas/becas/relevamientos/convocatoria_form.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_form.html
@@ -64,10 +64,10 @@
     {% with field=form.fecha_inicio %}{% include "programas/becas/_field.html" %}{% endwith %}
     {% with field=form.fecha_fin %}{% include "programas/becas/_field.html" %}{% endwith %}
     {% with field=form.descripcion %}{% include "programas/becas/_field.html" %}{% endwith %}
-    {% with field=form.activo %}{% include "programas/becas/_field.html" %}{% endwith %}
+    <label class="flex items-center gap-2 text-sm text-body cursor-pointer">{{ form.activo }} Activa</label>
 
     <div class="flex justify-end gap-3 mt-6 pt-4 border-t border-light">
-      <a href="{% url 'becas:convocatorias' %}" class="btn-nodo btn-secondary btn-base">← Cancelar</a>
+      <a href="{% url 'becas:convocatorias' %}" class="btn-nodo btn-tertiary btn-base">← Cancelar</a>
       <button type="submit" class="btn-nodo btn-brand btn-base">Guardar convocatoria</button>
     </div>
   </form>

--- a/programas/templates/programas/becas/relevamientos/convocatoria_list.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_list.html
@@ -29,50 +29,64 @@
   {# Modal: Nueva convocatoria #}
   <div x-show="modalCrear" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/40" @click="modalCrear=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Nueva convocatoria</h3>
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center text-lg"
+               style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <i class="fas fa-bullhorn"></i>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Nueva convocatoria</h3>
+        </div>
+        <button type="button" @click="modalCrear=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <i class="fas fa-xmark text-base"></i>
+        </button>
       </div>
-      <form method="post" action="{% url 'becas:convocatoria_crear' %}" class="space-y-4" data-ajax>
+
+      <form method="post" action="{% url 'becas:convocatoria_crear' %}" data-ajax>
         {% csrf_token %}
         <input type="hidden" name="activo" value="on">
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Nombre <span class="text-fg-danger">*</span></label>
-          {{ form_convocatoria.nombre }}
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="nombre"></p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div class="p-6 space-y-4">
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Segmento <span class="text-fg-danger">*</span></label>
-            {{ form_convocatoria.segmento }}
-            <p class="mt-1 text-xs text-fg-danger hidden" data-error="segmento"></p>
+            <label class="block text-sm font-medium text-heading mb-1">Nombre <span class="text-fg-danger">*</span></label>
+            {{ form_convocatoria.nombre }}
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="nombre"></p>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Segmento <span class="text-fg-danger">*</span></label>
+              {{ form_convocatoria.segmento }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="segmento"></p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Subsegmento</label>
+              {{ form_convocatoria.subsegmento }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="subsegmento"></p>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Fecha de inicio <span class="text-fg-danger">*</span></label>
+              {{ form_convocatoria.fecha_inicio }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="fecha_inicio"></p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Fecha de fin <span class="text-fg-danger">*</span></label>
+              {{ form_convocatoria.fecha_fin }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="fecha_fin"></p>
+            </div>
           </div>
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Subsegmento</label>
-            {{ form_convocatoria.subsegmento }}
-            <p class="mt-1 text-xs text-fg-danger hidden" data-error="subsegmento"></p>
+            <label class="block text-sm font-medium text-heading mb-1">Descripción</label>
+            {{ form_convocatoria.descripcion }}
           </div>
+          <p class="text-xs text-fg-danger hidden" data-error="__all__"></p>
         </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Fecha de inicio <span class="text-fg-danger">*</span></label>
-            {{ form_convocatoria.fecha_inicio }}
-            <p class="mt-1 text-xs text-fg-danger hidden" data-error="fecha_inicio"></p>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Fecha de fin <span class="text-fg-danger">*</span></label>
-            {{ form_convocatoria.fecha_fin }}
-            <p class="mt-1 text-xs text-fg-danger hidden" data-error="fecha_fin"></p>
-          </div>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Descripción</label>
-          {{ form_convocatoria.descripcion }}
-        </div>
-        <p class="text-xs text-fg-danger hidden" data-error="__all__"></p>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalCrear=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalCrear=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base"><i class="fas fa-plus"></i> Crear convocatoria</button>
         </div>
       </form>

--- a/programas/templates/programas/becas/relevamientos/relevamiento_detail.html
+++ b/programas/templates/programas/becas/relevamientos/relevamiento_detail.html
@@ -23,15 +23,15 @@
   <div class="bg-white rounded-xl border border-base shadow-sm">
     <div class="border-b border-base flex gap-1 px-2">
       <button @click="tab='info'" type="button"
-              class="px-4 py-3 text-sm font-semibold border-b-2 -mb-px transition flex items-center gap-1.5"
-              :class="tab==='info' ? 'text-fg-brand border-brand' : 'text-body-subtle border-transparent hover:text-body'">
+              class="px-4 py-3 text-sm border-b-2 -mb-px transition flex items-center gap-1.5"
+              :class="tab==='info' ? 'text-fg-brand border-brand font-bold' : 'text-body-subtle border-transparent hover:text-body font-medium'">
         <i class="fas fa-id-card"></i> Información
       </button>
       <button @click="tab='formularios'" type="button"
-              class="px-4 py-3 text-sm font-semibold border-b-2 -mb-px transition flex items-center gap-1.5"
-              :class="tab==='formularios' ? 'text-fg-brand border-brand' : 'text-body-subtle border-transparent hover:text-body'">
+              class="px-4 py-3 text-sm border-b-2 -mb-px transition flex items-center gap-1.5"
+              :class="tab==='formularios' ? 'text-fg-brand border-brand font-bold' : 'text-body-subtle border-transparent hover:text-body font-medium'">
         <i class="fas fa-users"></i> Personas relevadas
-        <span class="badge badge-gray ml-0.5">{{ n_formularios }}</span>
+        <span class="badge ml-0.5" :class="tab==='formularios' ? 'bg-brand-soft text-fg-brand' : 'badge-gray'">{{ n_formularios }}</span>
       </button>
     </div>
 
@@ -86,7 +86,7 @@
             <h3 class="text-sm font-bold text-heading mb-3">
               <i class="fas fa-user-pen mr-1 text-fg-brand"></i> Reasignar territorial
             </h3>
-            {{ form_reasignar.territorial.label_tag }}{{ form_reasignar.territorial }}
+            {% with field=form_reasignar.territorial %}{% include "programas/becas/_field.html" %}{% endwith %}
             <button type="submit" class="btn-nodo btn-tertiary btn-sm mt-3 w-full">Reasignar</button>
           </form>
 
@@ -96,7 +96,7 @@
             <h3 class="text-sm font-bold text-heading mb-3">
               <i class="fas fa-calendar-day mr-1 text-fg-brand"></i> Reprogramar fecha
             </h3>
-            {{ form_reprogramar.fecha_asignada.label_tag }}{{ form_reprogramar.fecha_asignada }}
+            {% with field=form_reprogramar.fecha_asignada %}{% include "programas/becas/_field.html" %}{% endwith %}
             <button type="submit" class="btn-nodo btn-tertiary btn-sm mt-3 w-full">Reprogramar</button>
           </form>
         </div>
@@ -143,9 +143,9 @@
                 <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ f.celular }}</td>
                 <td class="px-4 py-[13px] text-sm border-t border-light text-center">
                   {% if f.validado_renaper %}
-                    <i class="fas fa-check text-fg-success"></i>
+                    <span class="badge badge-success">Validado</span>
                   {% else %}
-                    <i class="fas fa-clock text-body-subtle"></i>
+                    <span class="badge badge-gray">Pendiente</span>
                   {% endif %}
                 </td>
                 <td class="px-4 py-[13px] text-sm border-t border-light">

--- a/programas/templates/programas/becas/relevamientos/relevamiento_form.html
+++ b/programas/templates/programas/becas/relevamientos/relevamiento_form.html
@@ -19,7 +19,7 @@
     {% endif %}
     {% for field in form %}{% include "programas/becas/_field.html" %}{% endfor %}
     <div class="flex justify-end gap-3 mt-6 pt-4 border-t border-light">
-      <a href="{% url 'becas:relevamientos' %}" class="btn-nodo btn-secondary btn-base">← Cancelar</a>
+      <a href="{% url 'becas:relevamientos' %}" class="btn-nodo btn-tertiary btn-base">← Cancelar</a>
       <button type="submit" class="btn-nodo btn-brand btn-base">Crear y asignar</button>
     </div>
   </form>

--- a/programas/templates/programas/becas/relevamientos/relevamiento_list.html
+++ b/programas/templates/programas/becas/relevamientos/relevamiento_list.html
@@ -59,7 +59,7 @@
             <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ rel.fecha_asignada|date:"d/m/Y" }}</td>
             <td class="px-4 py-[13px] text-sm border-t border-light">{% include "programas/becas/relevamientos/_estado_badge.html" %}</td>
             <td class="px-4 py-[13px] text-sm border-t border-light text-right">
-              <a href="{% url 'becas:relevamiento_detalle' rel.pk %}" class="text-fg-brand hover:opacity-70 p-1" title="Ver">
+              <a href="{% url 'becas:relevamiento_detalle' rel.pk %}" class="text-fg-brand hover:opacity-70 p-1" title="Ver" aria-label="Ver">
                 <i class="fas fa-eye"></i>
               </a>
             </td>
@@ -83,43 +83,55 @@
   {# ============ Modal: Nuevo relevamiento ============ #}
   <div x-show="modalRel" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
     <div class="absolute inset-0 bg-black/40" @click="modalRel=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-xl p-6 max-h-[90vh] overflow-y-auto" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Nuevo relevamiento</h3>
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-xl max-h-[90vh] overflow-y-auto" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center text-lg"
+               style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <i class="fas fa-route"></i>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Nuevo relevamiento</h3>
+        </div>
+        <button type="button" @click="modalRel=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <i class="fas fa-xmark text-base"></i>
+        </button>
       </div>
 
-      <div class="rounded-xl bg-brand-soft p-3 text-sm text-fg-brand mb-5 flex items-start gap-2" style="border:1px solid var(--color-brand-200)">
-        <i class="fas fa-circle-info mt-0.5"></i>
-        <span>El relevamiento se nombra automáticamente: <strong>{{ siguiente_nombre }}</strong> y queda en estado Asignado.</span>
-      </div>
-
-      <form method="post" action="{% url 'becas:relevamiento_crear' %}" class="space-y-4">
+      <form method="post" action="{% url 'becas:relevamiento_crear' %}">
         {% csrf_token %}
-        {% if form_crear.non_field_errors %}
-          <div class="rounded-lg bg-danger-soft p-3 text-sm text-fg-danger">{{ form_crear.non_field_errors }}</div>
-        {% endif %}
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Convocatoria <span class="text-fg-danger">*</span></label>
-          {{ form_crear.convocatoria }}
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Territorial asignado <span class="text-fg-danger">*</span></label>
-          {{ form_crear.territorial }}
-          <p class="text-xs text-body-subtle mt-1">Solo se listan los territoriales del segmento de la convocatoria elegida.</p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="p-6 space-y-4">
+          <div class="rounded-xl bg-brand-soft p-3 text-sm text-fg-brand flex items-start gap-2" style="border:1px solid var(--color-brand-200)">
+            <i class="fas fa-circle-info mt-0.5"></i>
+            <span>El relevamiento se nombra automáticamente: <strong>{{ siguiente_nombre }}</strong> y queda en estado Asignado.</span>
+          </div>
+          {% if form_crear.non_field_errors %}
+            <div class="rounded-lg bg-danger-soft p-3 text-sm text-fg-danger">{{ form_crear.non_field_errors }}</div>
+          {% endif %}
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Zona / Localidad <span class="text-fg-danger">*</span></label>
-            {{ form_crear.zona }}
+            <label class="block text-sm font-medium text-heading mb-1">Convocatoria <span class="text-fg-danger">*</span></label>
+            {{ form_crear.convocatoria }}
           </div>
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Fecha asignada <span class="text-fg-danger">*</span></label>
-            {{ form_crear.fecha_asignada }}
+            <label class="block text-sm font-medium text-heading mb-1">Territorial asignado <span class="text-fg-danger">*</span></label>
+            {{ form_crear.territorial }}
+            <p class="text-xs text-body-subtle mt-1">Solo se listan los territoriales del segmento de la convocatoria elegida.</p>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Zona / Localidad <span class="text-fg-danger">*</span></label>
+              {{ form_crear.zona }}
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Fecha asignada <span class="text-fg-danger">*</span></label>
+              {{ form_crear.fecha_asignada }}
+            </div>
           </div>
         </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalRel=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalRel=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base">Guardar</button>
         </div>
       </form>

--- a/programas/templates/programas/becas/revision/formulario_list.html
+++ b/programas/templates/programas/becas/revision/formulario_list.html
@@ -81,9 +81,9 @@
             <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ f.celular }}</td>
             <td class="px-4 py-[13px] text-sm border-t border-light text-center">
               {% if f.validado_renaper %}
-                <i class="fas fa-check text-fg-success"></i>
+                <span class="badge badge-success">Validado</span>
               {% else %}
-                <i class="fas fa-clock text-body-subtle"></i>
+                <span class="badge badge-gray">Pendiente</span>
               {% endif %}
             </td>
             <td class="px-4 py-[13px] text-sm border-t border-light">

--- a/programas/views/relevamientos.py
+++ b/programas/views/relevamientos.py
@@ -51,6 +51,19 @@ def _convocatorias_ajax(request, message="Convocatoria guardada."):
     )
 
 
+def _relevamientos_ajax(request, convocatoria, message="Relevamiento creado y asignado."):
+    """Re-renderiza la tabla de relevamientos de una convocatoria (pestaña
+    "Relevamientos" de su detalle) tras crear uno desde el modal embebido."""
+    relevamientos = list(convocatoria.relevamientos.select_related("territorial").order_by("-fecha_asignada"))
+    return ajax_ok(
+        request,
+        target="#relevamientos-table",
+        partial="programas/becas/relevamientos/_relevamientos_tab_table.html",
+        context={"relevamientos": relevamientos},
+        message=message,
+    )
+
+
 def _assert_scope(request, relevamiento):
     """403 si el usuario no puede gestionar el segmento del relevamiento."""
     if not puede_gestionar_segmento(request.user, relevamiento.segmento):
@@ -271,8 +284,16 @@ class RelevamientoCreateView(CapacidadRequeridaMixin, LoginRequiredMixin, Create
         return kwargs
 
     def form_valid(self, form):
+        self.object = form.save()
+        if is_ajax(self.request):
+            return _relevamientos_ajax(self.request, self.object.convocatoria)
         messages.success(self.request, "Relevamiento creado y asignado.")
-        return super().form_valid(form)
+        return redirect(self.get_success_url())
+
+    def form_invalid(self, form):
+        if is_ajax(self.request):
+            return ajax_errors(form)
+        return super().form_invalid(form)
 
     def get_success_url(self):
         # "next" permite volver a la pantalla de origen (p. ej. el detalle de la


### PR DESCRIPTION
## Qué

Aplica las correcciones de una auditoría de diseño (agente `chaco-design-reviewer`) sobre la sección Relevamientos de Becas, que estaba en ~80-85% de adherencia al design system NODO.

## Correcciones

**Prioritarias**
1. `aria-label` en todas las acciones solo-ícono (antes solo `title`).
2. Estado RENAPER con texto (`badge` Validado/Pendiente) en vez de solo ícono — regla dura del canon (§22), en `relevamiento_detail.html` y `revision/formulario_list.html`.
3. Modales de alta completos (relevamiento y convocatoria): icon-tile en header, botón `×` con `aria-label`, `Cancelar` en `btn-tertiary` — calcados del modal de subsegmento.
4. **Fix funcional**: crear un relevamiento desde la pestaña "Relevamientos" del detalle de convocatoria ya no recarga la página ni te devuelve a "Información". Nuevo partial `_relevamientos_tab_table.html` + `_relevamientos_ajax()`; `RelevamientoCreateView` soporta `is_ajax` (mismo patrón que `ConvocatoriaCreateView`). El flujo no-AJAX queda idéntico.
5. Pestañas con estado dinámico completo: peso 700 activo / 500 inactivo y chip de conteo en brand cuando la pestaña está activa (§13).

**Secundarias**
6. Mini-forms reasignar/reprogramar con `_field.html` (labels del sistema + render de errores, antes ausente).
7. Checkbox `activo` de convocatoria con el patrón flex del canon.
8. Eliminado enlace "Editar" redundante en `_convocatorias_table.html` (apuntaba a la misma URL que "Ver").
9. Empty states de `convocatoria_detail.html` unificados al tamaño canónico.
10. `← Cancelar` de forms standalone a `btn-tertiary`.
11. Toast de `_ajax_js.html` con ícono + `role="alert"`/`aria-live="polite"` (API intacta).

**Fuera de alcance (deuda sistémica documentada):** select "pill" de filtros, hover `bg-secondary` de tablas, tallas de stat-cards, `bg-white` vs dark mode.

## Validación

- `scripts/design_audit.py --changed` → 0 errores / 3 warnings preexistentes (selects pill, fuera de alcance)
- `scripts/compile_templates.py` → 267 OK / 0 errores
- `manage.py check` → sin issues
- Sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)