### PR TITLE
UI: quitar el breadcrumb "Inicio > X" redundante de los listados

### DIFF
--- a/configuracion/templates/configuracion/localidad_list.html
+++ b/configuracion/templates/configuracion/localidad_list.html
@@ -14,11 +14,6 @@
 {# Page Header #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div>
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Localidades</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Localidades</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Gestión de localidades del sistema</p>
     </div>

--- a/configuracion/templates/configuracion/municipio_list.html
+++ b/configuracion/templates/configuracion/municipio_list.html
@@ -16,11 +16,6 @@
 {# ------------------------------------------------------------------ #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div>
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Municipios</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Municipios</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Gestión de municipios del sistema</p>
     </div>

--- a/configuracion/templates/configuracion/provincia_list.html
+++ b/configuracion/templates/configuracion/provincia_list.html
@@ -16,11 +16,6 @@
 {# ------------------------------------------------------------------ #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div>
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Provincias</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Provincias</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Gestión de provincias del sistema</p>
     </div>

--- a/configuracion/templates/configuracion/secretaria_list.html
+++ b/configuracion/templates/configuracion/secretaria_list.html
@@ -14,11 +14,6 @@
 {# Page Header #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div>
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Secretarías</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Secretarías</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Gestión de secretarías del sistema</p>
     </div>

--- a/configuracion/templates/configuracion/subsecretaria_list.html
+++ b/configuracion/templates/configuracion/subsecretaria_list.html
@@ -14,11 +14,6 @@
 {# Page Header #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div>
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Subsecretarías</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Subsecretarías</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Gestión de subsecretarías del sistema</p>
     </div>

--- a/users/templates/rol/rol_list.html
+++ b/users/templates/rol/rol_list.html
@@ -82,11 +82,6 @@
 {# Page Header #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div style="min-width:220px; flex:1 1 280px;">
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Roles</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Roles</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Definí qué puede ver y hacer cada rol del sistema</p>
     </div>

--- a/users/templates/user/user_list.html
+++ b/users/templates/user/user_list.html
@@ -8,11 +8,6 @@
 {# Page Header #}
 <div style="display:flex; align-items:flex-end; justify-content:space-between; gap:16px; margin-bottom:24px; flex-wrap:wrap;">
     <div style="min-width:220px; flex:1 1 280px;">
-        <div style="display:flex; align-items:center; gap:6px; margin-bottom:6px;">
-            <a href="/" style="font-size:12.5px; color:var(--text-body-subtle); text-decoration:none;">Inicio</a>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-body-subtle); flex-shrink:0;" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg>
-            <span style="font-size:12.5px; color:var(--text-body); font-weight:600;">Usuarios</span>
-        </div>
         <h1 style="font-size:28px; font-weight:800; color:var(--text-heading); letter-spacing:-0.5px; margin:0 0 4px;">Usuarios</h1>
         <p style="font-size:14px; color:var(--text-body-subtle); margin:0;">Gestión de usuarios del sistema</p>
     </div>


### PR DESCRIPTION
## Qué

Elimina el breadcrumb de un solo nivel **"Inicio > \<sección\>"** de los listados del backoffice, porque repite el nombre que ya muestra el `<h1>` justo debajo.

## Pantallas afectadas (7)

- Usuarios (`user_list.html`), Roles (`rol_list.html`)
- Configuración: Provincias, Localidades, Municipios, Secretarías, Subsecretarías

## Qué NO se toca

- Los breadcrumbs jerárquicos reales de Becas (`Programa Becas > Relevamientos > …`) — aportan navegación, no empiezan con "Inicio".
- El ítem "Inicio" del menú lateral y la home.
- `templates/core/performance_dashboard.html` (breadcrumb legacy AdminLTE `<li>Inicio</li>`, pantalla interna) — queda pendiente de decisión.

## Validación

- `design_audit.py --changed` → 0 errores / 0 warnings
- `compile_templates.py` → 268 OK / 0 errores
- Sin cambios de backend ni migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)