### PR TITLE
UI: estandarizar todos los modales del sistema al design system

### DIFF
--- a/programas/templates/programas/becas/config/pregunta_list.html
+++ b/programas/templates/programas/becas/config/pregunta_list.html
@@ -32,52 +32,68 @@
   </div>
 
   {# Modal: Nueva pregunta #}
-  <div x-show="modalCrear" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalCrear=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Nueva pregunta</h3>
+  <div x-show="modalCrear" x-cloak @click="modalCrear=false" class="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" style="background:rgba(0,0,0,.5)">
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0" style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Nueva pregunta</h3>
+        </div>
+        <button type="button" @click="modalCrear=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
-      <form method="post" action="{% url 'becas:pregunta_crear' %}" class="space-y-4" data-ajax>
+
+      {% comment %}FORM envuelve body + footer{% endcomment %}
+      <form method="post" action="{% url 'becas:pregunta_crear' %}" data-ajax>
         {% csrf_token %}
         <input type="hidden" name="activo" value="on">
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Texto <span class="text-fg-danger">*</span></label>
-          <input type="text" name="texto" required
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+
+        {% comment %}BODY{% endcomment %}
+        <div class="p-6 space-y-5">
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-            <select name="tipo" x-model="createTipo"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
-            </select>
+            <label class="block text-sm font-medium text-heading mb-1">Texto <span class="text-fg-danger">*</span></label>
+            <input type="text" name="texto" required class="nodo-field">
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-            <select name="obligatorio"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              <option value="True">Obligatorio</option>
-              <option value="False">Opcional</option>
-            </select>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
+              <select name="tipo" x-model="createTipo" class="nodo-field">
+                {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
+              <select name="obligatorio" class="nodo-field">
+                <option value="True">Obligatorio</option>
+                <option value="False">Opcional</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Orden</label>
+              <input type="number" name="orden" min="0" value="0" class="nodo-field">
+            </div>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Orden</label>
-            <input type="number" name="orden" min="0" value="0"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
+          <div x-show="createTipo === 'SELECTOR' || createTipo === 'SELECTOR_MULTIPLE'">
+            <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
+            <textarea name="opciones_texto" rows="4" class="nodo-field"></textarea>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="opciones_texto"></p>
           </div>
         </div>
-        <div x-show="createTipo === 'SELECTOR' || createTipo === 'SELECTOR_MULTIPLE'">
-          <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
-          <textarea name="opciones_texto" rows="4"
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"></textarea>
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="opciones_texto"></p>
-        </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalCrear=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+
+        {% comment %}FOOTER{% endcomment %}
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalCrear=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base"><i class="fas fa-plus"></i> Crear pregunta</button>
         </div>
       </form>
@@ -85,58 +101,73 @@
   </div>
 
   {# Modal: Editar pregunta #}
-  <div x-show="modalEdit" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalEdit=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Editar pregunta</h3>
+  <div x-show="modalEdit" x-cloak @click="modalEdit=false" class="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" style="background:rgba(0,0,0,.5)">
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0" style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Editar pregunta</h3>
+        </div>
+        <button type="button" @click="modalEdit=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
-      <form method="post" :action="editUrl" class="space-y-4" data-ajax data-reset="false">
+
+      {% comment %}FORM envuelve body + footer{% endcomment %}
+      <form method="post" :action="editUrl" data-ajax data-reset="false">
         {% csrf_token %}
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Texto <span class="text-fg-danger">*</span></label>
-          <input type="text" name="texto" x-model="editTexto" required
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
+
+        {% comment %}BODY{% endcomment %}
+        <div class="p-6 space-y-5">
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Texto <span class="text-fg-danger">*</span></label>
+            <input type="text" name="texto" x-model="editTexto" required class="nodo-field">
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
+              <select name="tipo" x-model="editTipo" class="nodo-field">
+                {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
+              <select name="obligatorio" x-model="editObl" class="nodo-field">
+                <option value="True">Obligatorio</option>
+                <option value="False">Opcional</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Estado</label>
+              <select name="activo" x-model="editActivo" class="nodo-field">
+                <option value="True">Activa</option>
+                <option value="False">Inactiva</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Orden</label>
+              <input type="number" name="orden" x-model="editOrden" min="0" class="nodo-field">
+            </div>
+          </div>
+          <div x-show="editTipo === 'SELECTOR' || editTipo === 'SELECTOR_MULTIPLE'">
+            <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
+            <textarea name="opciones_texto" x-model="editOpciones" rows="4" class="nodo-field"></textarea>
+          </div>
         </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-            <select name="tipo" x-model="editTipo"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-            <select name="obligatorio" x-model="editObl"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              <option value="True">Obligatorio</option>
-              <option value="False">Opcional</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Estado</label>
-            <select name="activo" x-model="editActivo"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              <option value="True">Activa</option>
-              <option value="False">Inactiva</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Orden</label>
-            <input type="number" name="orden" x-model="editOrden" min="0"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-          </div>
-        </div>
-        <div x-show="editTipo === 'SELECTOR' || editTipo === 'SELECTOR_MULTIPLE'">
-          <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
-          <textarea name="opciones_texto" x-model="editOpciones" rows="4"
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"></textarea>
-        </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalEdit=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+
+        {% comment %}FOOTER{% endcomment %}
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalEdit=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base"><i class="fas fa-check"></i> Guardar cambios</button>
         </div>
       </form>

--- a/programas/templates/programas/becas/config/requisitos_segmento.html
+++ b/programas/templates/programas/becas/config/requisitos_segmento.html
@@ -59,64 +59,79 @@
   </div>
 
   {# Modal: Nuevo requisito #}
-  <div x-show="modalCrear" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalCrear=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Nuevo requisito</h3>
+  <div x-show="modalCrear" x-cloak @click="modalCrear=false" class="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" style="background:rgba(0,0,0,.5)">
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0" style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Nuevo requisito</h3>
+        </div>
+        <button type="button" @click="modalCrear=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
-      <form method="post" :action="segUrls[createSeg] || ''" class="space-y-4" data-ajax>
+
+      {% comment %}FORM envuelve body + footer{% endcomment %}
+      <form method="post" :action="segUrls[createSeg] || ''" data-ajax>
         {% csrf_token %}
         <input type="hidden" name="scope" value="reqseg">
         <input type="hidden" name="f_segmento" value="{{ seg_actual }}">
         <input type="hidden" name="f_subsegmento" value="{{ sub_actual }}">
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Segmento <span class="text-fg-danger">*</span></label>
-          <select x-model="createSeg" required
-                  class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-            <option value="">Elegí un segmento…</option>
-            {% for seg in segmentos %}
-            <option value="{{ seg.pk }}">{{ seg.nombre }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
-          <input type="text" name="texto" required
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+
+        {% comment %}BODY{% endcomment %}
+        <div class="p-6 space-y-5">
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-            <select name="tipo" x-model="createTipo"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+            <label class="block text-sm font-medium text-heading mb-1">Segmento <span class="text-fg-danger">*</span></label>
+            <select x-model="createSeg" required class="nodo-field">
+              <option value="">Elegí un segmento…</option>
+              {% for seg in segmentos %}
+              <option value="{{ seg.pk }}">{{ seg.nombre }}</option>
+              {% endfor %}
             </select>
           </div>
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-            <select name="obligatorio"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              <option value="True">Obligatorio</option>
-              <option value="False">Opcional</option>
-            </select>
+            <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
+            <input type="text" name="texto" required class="nodo-field">
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Orden</label>
-            <input type="number" name="orden" min="0"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
+              <select name="tipo" x-model="createTipo" class="nodo-field">
+                {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
+              <select name="obligatorio" class="nodo-field">
+                <option value="True">Obligatorio</option>
+                <option value="False">Opcional</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Orden</label>
+              <input type="number" name="orden" min="0" class="nodo-field">
+            </div>
+          </div>
+          <div x-show="createTipo === 'SELECTOR' || createTipo === 'SELECTOR_MULTIPLE'">
+            <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
+            <textarea name="opciones_texto" rows="4" class="nodo-field"></textarea>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="opciones_texto"></p>
           </div>
         </div>
-        <div x-show="createTipo === 'SELECTOR' || createTipo === 'SELECTOR_MULTIPLE'">
-          <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
-          <textarea name="opciones_texto" rows="4"
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"></textarea>
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="opciones_texto"></p>
-        </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalCrear=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+
+        {% comment %}FOOTER{% endcomment %}
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalCrear=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base" :disabled="!createSeg">Crear requisito</button>
         </div>
       </form>
@@ -124,53 +139,69 @@
   </div>
 
   {# Modal: Editar requisito #}
-  <div x-show="modalEdit" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalEdit=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Editar requisito</h3>
+  <div x-show="modalEdit" x-cloak @click="modalEdit=false" class="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" style="background:rgba(0,0,0,.5)">
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0" style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Editar requisito</h3>
+        </div>
+        <button type="button" @click="modalEdit=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
-      <form method="post" :action="editUrl" class="space-y-4" data-ajax data-reset="false">
+
+      {% comment %}FORM envuelve body + footer{% endcomment %}
+      <form method="post" :action="editUrl" data-ajax data-reset="false">
         {% csrf_token %}
         <input type="hidden" name="scope" value="reqseg">
         <input type="hidden" name="f_segmento" value="{{ seg_actual }}">
         <input type="hidden" name="f_subsegmento" value="{{ sub_actual }}">
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
-          <input type="text" name="texto" x-model="editTexto" required
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+
+        {% comment %}BODY{% endcomment %}
+        <div class="p-6 space-y-5">
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-            <select name="tipo" x-model="editTipo"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
-            </select>
+            <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
+            <input type="text" name="texto" x-model="editTexto" required class="nodo-field">
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-            <select name="obligatorio" x-model="editObl"
-                    class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              <option value="True">Obligatorio</option>
-              <option value="False">Opcional</option>
-            </select>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
+              <select name="tipo" x-model="editTipo" class="nodo-field">
+                {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
+              <select name="obligatorio" x-model="editObl" class="nodo-field">
+                <option value="True">Obligatorio</option>
+                <option value="False">Opcional</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Orden</label>
+              <input type="number" name="orden" x-model="editOrden" min="0" class="nodo-field">
+            </div>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Orden</label>
-            <input type="number" name="orden" x-model="editOrden" min="0"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
+          <div x-show="editTipo === 'SELECTOR' || editTipo === 'SELECTOR_MULTIPLE'">
+            <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
+            <textarea name="opciones_texto" x-model="editOpciones" rows="4" class="nodo-field"></textarea>
           </div>
         </div>
-        <div x-show="editTipo === 'SELECTOR' || editTipo === 'SELECTOR_MULTIPLE'">
-          <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
-          <textarea name="opciones_texto" x-model="editOpciones" rows="4"
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"></textarea>
-        </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalEdit=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+
+        {% comment %}FOOTER{% endcomment %}
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalEdit=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base"><i class="fas fa-check"></i> Guardar cambios</button>
         </div>
       </form>

--- a/programas/templates/programas/becas/config/segmento_detail.html
+++ b/programas/templates/programas/becas/config/segmento_detail.html
@@ -449,44 +449,65 @@
   </div>
 
   {# ============ Modal: Nuevo requisito ============ #}
-  <div x-show="modalReq" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalReq=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Nuevo requisito</h3>
+  <div x-show="modalReq" x-cloak @click="modalReq=false" class="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" style="background:rgba(0,0,0,.5)">
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0" style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Nuevo requisito</h3>
+        </div>
+        <button type="button" @click="modalReq=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
-      <form method="post" action="{% url 'becas:requisito_crear' segmento.pk %}" class="space-y-4" id="form-req-crear" data-ajax>
+
+      {% comment %}FORM envuelve body + footer{% endcomment %}
+      <form method="post" action="{% url 'becas:requisito_crear' segmento.pk %}" id="form-req-crear" data-ajax>
         {% csrf_token %}
         <input type="hidden" name="scope" value="segmento">
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
-          {{ form_requisito.texto }}
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+
+        {% comment %}BODY{% endcomment %}
+        <div class="p-6 space-y-5">
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-            {{ form_requisito.tipo }}
-            <p class="mt-1 text-xs text-fg-danger hidden" data-error="tipo"></p>
+            <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
+            {{ form_requisito.texto }}
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-            {{ form_requisito.obligatorio }}
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
+              {{ form_requisito.tipo }}
+              <p class="mt-1 text-xs text-fg-danger hidden" data-error="tipo"></p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
+              {{ form_requisito.obligatorio }}
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Orden</label>
+              {{ form_requisito.orden }}
+            </div>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Orden</label>
-            {{ form_requisito.orden }}
+          <div data-opciones-wrapper>
+            <label class="block text-sm font-medium text-heading mb-1">{{ form_requisito.opciones_texto.label }}</label>
+            {{ form_requisito.opciones_texto }}
+            <p class="text-xs text-body-subtle mt-1">{{ form_requisito.opciones_texto.help_text }}</p>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="opciones_texto"></p>
           </div>
         </div>
-        <div data-opciones-wrapper>
-          <label class="block text-sm font-medium text-heading mb-1">{{ form_requisito.opciones_texto.label }}</label>
-          {{ form_requisito.opciones_texto }}
-          <p class="text-xs text-body-subtle mt-1">{{ form_requisito.opciones_texto.help_text }}</p>
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="opciones_texto"></p>
-        </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalReq=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+
+        {% comment %}FOOTER{% endcomment %}
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalReq=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base">Crear requisito</button>
         </div>
       </form>
@@ -494,54 +515,70 @@
   </div>
 
   {# ============ Modal: Editar requisito ============ #}
-  <div x-show="modalReqEdit" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalReqEdit=false"></div>
-    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg p-6" @click.stop>
-      <div class="flex items-center gap-3 mb-5">
-        <div class="w-9 h-9 rounded-lg" style="background: var(--gradient-brand)"></div>
-        <h3 class="text-lg font-bold text-heading">Editar requisito</h3>
+  <div x-show="modalReqEdit" x-cloak @click="modalReqEdit=false" class="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm" style="background:rgba(0,0,0,.5)">
+    <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden" @click.stop>
+
+      {% comment %}HEADER{% endcomment %}
+      <div class="flex items-center justify-between px-6 py-5 border-b" style="border-color:var(--border-light)">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0" style="background:var(--bg-brand-soft);color:var(--text-fg-brand)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+            </svg>
+          </div>
+          <h3 class="text-lg font-bold text-heading">Editar requisito</h3>
+        </div>
+        <button type="button" @click="modalReqEdit=false" aria-label="Cerrar"
+                class="p-1.5 rounded-lg text-body-subtle hover:text-heading hover:bg-secondary transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
       </div>
-      <form method="post" :action="editReqUrl" class="space-y-4" id="form-req-editar" data-ajax data-reset="false">
+
+      {% comment %}FORM envuelve body + footer{% endcomment %}
+      <form method="post" :action="editReqUrl" id="form-req-editar" data-ajax data-reset="false">
         {% csrf_token %}
         <input type="hidden" name="scope" value="segmento">
-        <div>
-          <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
-          <input type="text" name="texto" x-model="editReqTexto" required
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-          <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+
+        {% comment %}BODY{% endcomment %}
+        <div class="p-6 space-y-5">
           <div>
-            <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-            <select name="tipo" x-model="editReqTipo"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              {% for val, label in form_requisito.tipo.field.choices %}
-              <option value="{{ val }}">{{ label }}</option>
-              {% endfor %}
-            </select>
+            <label class="block text-sm font-medium text-heading mb-1">Pregunta <span class="text-fg-danger">*</span></label>
+            <input type="text" name="texto" x-model="editReqTexto" required class="nodo-field">
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="texto"></p>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-            <select name="obligatorio" x-model="editReqObligatorio"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
-              <option value="True">Obligatorio</option>
-              <option value="False">Opcional</option>
-            </select>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
+              <select name="tipo" x-model="editReqTipo" class="nodo-field">
+                {% for val, label in form_requisito.tipo.field.choices %}
+                <option value="{{ val }}">{{ label }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
+              <select name="obligatorio" x-model="editReqObligatorio" class="nodo-field">
+                <option value="True">Obligatorio</option>
+                <option value="False">Opcional</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-heading mb-1">Orden</label>
+              <input type="number" name="orden" x-model="editReqOrden" min="0" class="nodo-field">
+            </div>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-heading mb-1">Orden</label>
-            <input type="number" name="orden" x-model="editReqOrden" min="0"
-              class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand">
+          <div x-show="editReqTipo === 'SELECTOR' || editReqTipo === 'SELECTOR_MULTIPLE'">
+            <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
+            <textarea name="opciones_texto" x-model="editReqOpciones" rows="4" class="nodo-field"></textarea>
+            <p class="text-xs text-body-subtle mt-1">Solo para Selector / Selector múltiple.</p>
           </div>
         </div>
-        <div x-show="editReqTipo === 'SELECTOR' || editReqTipo === 'SELECTOR_MULTIPLE'">
-          <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
-          <textarea name="opciones_texto" x-model="editReqOpciones" rows="4"
-            class="w-full rounded-lg border border-base bg-secondary-soft px-3 py-2 text-sm text-body focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"></textarea>
-          <p class="text-xs text-body-subtle mt-1">Solo para Selector / Selector múltiple.</p>
-        </div>
-        <div class="flex justify-end gap-3 pt-2">
-          <button type="button" @click="modalReqEdit=false" class="btn-nodo btn-secondary btn-base">Cancelar</button>
+
+        {% comment %}FOOTER{% endcomment %}
+        <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
+          <button type="button" @click="modalReqEdit=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
           <button type="submit" class="btn-nodo btn-brand btn-base"><i class="fas fa-check"></i> Guardar cambios</button>
         </div>
       </form>

--- a/programas/templates/programas/becas/relevamientos/convocatoria_detail.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_detail.html
@@ -227,7 +227,7 @@
 
   {# ============ Modal: Nuevo relevamiento (convocatoria preseleccionada) ============ #}
   <div x-show="modalRel" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalRel=false"></div>
+    <div class="absolute inset-0" style="background:rgba(0,0,0,.5);backdrop-filter:blur(4px)" @click="modalRel=false"></div>
     <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-xl max-h-[90vh] overflow-y-auto" @click.stop>
 
       {% comment %}HEADER{% endcomment %}

--- a/programas/templates/programas/becas/relevamientos/convocatoria_list.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_list.html
@@ -23,7 +23,7 @@
 
   {# Modal: Nueva convocatoria #}
   <div x-show="modalCrear" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalCrear=false"></div>
+    <div class="absolute inset-0" style="background:rgba(0,0,0,.5);backdrop-filter:blur(4px)" @click="modalCrear=false"></div>
     <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto" @click.stop>
 
       {% comment %}HEADER{% endcomment %}

--- a/programas/templates/programas/becas/relevamientos/relevamiento_list.html
+++ b/programas/templates/programas/becas/relevamientos/relevamiento_list.html
@@ -77,7 +77,7 @@
 
   {# ============ Modal: Nuevo relevamiento ============ #}
   <div x-show="modalRel" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-black/40" @click="modalRel=false"></div>
+    <div class="absolute inset-0" style="background:rgba(0,0,0,.5);backdrop-filter:blur(4px)" @click="modalRel=false"></div>
     <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-xl max-h-[90vh] overflow-y-auto" @click.stop>
 
       {% comment %}HEADER{% endcomment %}

--- a/static/custom/css/nodo-swal.css
+++ b/static/custom/css/nodo-swal.css
@@ -1,0 +1,179 @@
+/* ============================================================================
+   NODO Design System — theming global de SweetAlert2
+   ============================================================================
+   Fuente única de estilos para TODOS los `Swal.fire(...)` del sistema (29 usos
+   en 13 templates). El objetivo es que el "chrome" de SweetAlert2 (popup,
+   título, texto, acciones, ícono) matchee el DS Modal (canon §11) sin tener
+   que tocar cada call site.
+
+   Complementa a `includes/_swal_theme.html` (mixin JS con buttonsStyling:false
+   + customClass por defecto + recolor de ícono vía didRender). Un solo punto
+   de cambio: este CSS se carga siempre desde `includes/base.html`.
+
+   NOTA: `scripts/design_audit.py` no valida el CSS de una librería externa
+   (clases `.swal2-*`); los valores de aquí SÍ deben (y están) tokenizados. */
+
+.swal2-popup.swal2-popup {
+  display: grid !important;
+  grid-template-columns: 40px 1fr auto;
+  grid-template-areas:
+    "icon title close"
+    "content content content"
+    "actions actions actions";
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 0;
+  width: auto !important;
+  max-width: 480px !important;
+  padding: 0 !important;
+  border-radius: var(--radius-2xl, 16px) !important;
+  box-shadow: var(--shadow-xl) !important;
+  font-family: 'Manrope', var(--font-sans, sans-serif) !important;
+  overflow: hidden;
+}
+
+/* Backdrop: negro/50 + blur (canon §11), por encima de z-index 50 propio de swal2 */
+.swal2-container.swal2-backdrop-show,
+.swal2-container.swal2-backdrop-hide {
+  background: rgba(0, 0, 0, 0.5) !important;
+  -webkit-backdrop-filter: blur(4px) !important;
+  backdrop-filter: blur(4px) !important;
+}
+
+/* ── Header: ícono-tile + título + cerrar (grid en una sola fila) ── */
+.swal2-icon.swal2-icon {
+  grid-area: icon;
+  margin: 20px 0 20px 24px !important;
+  width: 40px !important;
+  height: 40px !important;
+  min-width: 40px;
+  box-sizing: border-box;
+  border-radius: var(--radius-lg, 8px) !important;
+  border: none !important;
+  align-items: center;
+  justify-content: center;
+}
+
+/* El ring/círculo animado default de swal2 no aplica al icon-tile plano del DS */
+.swal2-icon:before,
+.swal2-icon:after,
+.swal2-icon .swal2-success-ring,
+.swal2-icon .swal2-success-fix,
+.swal2-icon .swal2-success-circular-line-left,
+.swal2-icon .swal2-success-circular-line-right {
+  display: none !important;
+  content: none !important;
+}
+
+.swal2-icon .swal2-icon-content {
+  font-size: 20px !important;
+  color: inherit !important;
+}
+
+.swal2-title {
+  grid-area: title;
+  margin: 0 !important;
+  padding: 20px 24px 20px 0 !important;
+  text-align: left !important;
+  font-size: 18px !important;
+  font-weight: 700 !important;
+  line-height: 1.3 !important;
+  color: var(--text-heading) !important;
+}
+
+.swal2-close {
+  grid-area: close;
+  margin: 16px 16px 0 0 !important;
+  align-self: flex-start;
+  font-size: 20px !important;
+  color: var(--text-body-subtle) !important;
+  border-radius: var(--radius-lg, 8px);
+  transition: color 150ms, background 150ms;
+}
+
+.swal2-close:hover,
+.swal2-close:focus {
+  color: var(--text-heading) !important;
+  background: var(--bg-secondary, #F9FAFB) !important;
+  box-shadow: none !important;
+}
+
+/* ── Body ── */
+.swal2-html-container {
+  grid-area: content;
+  margin: 0 !important;
+  padding: 24px !important;
+  border-top: 1px solid var(--border-light, #F3F4F6);
+  text-align: left !important;
+  font-size: 14px !important;
+  line-height: 1.6 !important;
+  color: var(--text-body) !important;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+/* Inputs embebidos en el body (preConfirm de programa_detail, etc.) alineados a .nodo-field */
+.swal2-textarea,
+.swal2-input,
+.swal2-select,
+.swal2-file {
+  font-family: 'Manrope', var(--font-sans, sans-serif) !important;
+  font-size: 14px !important;
+  color: var(--text-heading) !important;
+  background: var(--bg-white, #fff) !important;
+  border: 1px solid var(--border-base, #E5E7EB) !important;
+  border-radius: var(--radius-lg, 8px) !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.swal2-textarea:focus,
+.swal2-input:focus,
+.swal2-select:focus {
+  border-color: var(--border-brand, #5059BC) !important;
+  box-shadow: var(--ring-brand) !important;
+}
+
+.swal2-validation-message {
+  grid-column: 1 / -1 !important;
+  margin: 0 !important;
+  padding: 10px 24px !important;
+  background: var(--bg-danger-soft, #FEF0F2) !important;
+  color: var(--text-fg-danger, #C70036) !important;
+  font-size: 12.5px !important;
+  border-top: 1px solid var(--border-danger-subtle, #FFCCD3) !important;
+}
+
+.swal2-validation-message::before {
+  background-color: var(--text-fg-danger, #C70036) !important;
+}
+
+/* ── Footer / acciones ── */
+.swal2-actions.swal2-actions {
+  grid-area: actions;
+  margin: 0 !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  justify-content: flex-end !important;
+  gap: 12px !important;
+  padding: 16px 24px !important;
+  border-top: 1px solid var(--border-light, #F3F4F6) !important;
+  background: var(--bg-secondary, #F9FAFB) !important;
+}
+
+.swal2-actions .swal2-styled:focus {
+  box-shadow: none !important;
+}
+
+.swal2-footer {
+  margin: 0 !important;
+  padding: 12px 24px 16px !important;
+  border-top: none !important;
+  font-size: 12.5px !important;
+  color: var(--text-body-subtle) !important;
+}
+
+/* Timer bar (si algún call site futuro usa `timer`) */
+.swal2-timer-progress-bar {
+  background: var(--bg-brand, #5059BC) !important;
+}

--- a/static/custom/js/nodo-swal-theme.js
+++ b/static/custom/js/nodo-swal-theme.js
@@ -1,0 +1,66 @@
+/**
+ * NODO Design System — theming global de SweetAlert2 (fuente única).
+ *
+ * Se carga siempre desde includes/base.html, DESPUÉS de {% block customJS %}.
+ * Como cada Swal.fire(...) existente referencia la variable global `Swal` recién
+ * en el momento del click (no al parsear el script), reasignar `window.Swal` acá
+ * -aunque este archivo se ejecute después del script de la página- alcanza para
+ * que los 29 usos del repo (13 templates) hereden el theme sin tocar cada uno.
+ *
+ * Complementa a static/custom/css/nodo-swal.css (chrome del popup: radius,
+ * shadow, tipografía, grid header/body/footer). Acá van los defaults de
+ * comportamiento/clases que sólo se pueden fijar por JS:
+ *   - buttonsStyling:false + customClass .btn-nodo (fallback para los
+ *     Swal.fire('Error', msg, 'error') abreviados que hoy no pasan customClass).
+ *   - showCloseButton (× en el header, requisito del canon §11) con aria-label
+ *     "Cerrar" en es-AR.
+ *   - recolor del ícono default de swal2 al tono del DS (bg/color por token)
+ *     vía didRender — no depende de selectores CSS internos de swal2.
+ */
+(function () {
+  function initNodoSwalTheme() {
+    if (typeof Swal === 'undefined') return;
+
+    var TONE_ICON = {
+      success: { bg: 'var(--bg-success-soft)', fg: 'var(--text-fg-success)' },
+      error: { bg: 'var(--bg-danger-soft)', fg: 'var(--text-fg-danger)' },
+      warning: { bg: 'var(--bg-warning-soft)', fg: 'var(--text-fg-warning)' },
+      info: { bg: 'var(--bg-info-soft)', fg: 'var(--text-fg-info)' },
+      question: { bg: 'var(--bg-brand-soft)', fg: 'var(--text-fg-brand)' }
+    };
+
+    window.Swal = Swal.mixin({
+      buttonsStyling: false,
+      showCloseButton: true,
+      showCloseButtonAriaLabel: 'Cerrar',
+      customClass: {
+        confirmButton: 'btn-nodo btn-brand btn-base',
+        cancelButton: 'btn-nodo btn-tertiary btn-base',
+        denyButton: 'btn-nodo btn-danger btn-base'
+      },
+      didRender: function (popup) {
+        var icon = popup.querySelector('.swal2-icon');
+        if (!icon) return;
+        var tone = null;
+        ['success', 'error', 'warning', 'info', 'question'].some(function (t) {
+          if (icon.classList.contains('swal2-' + t)) {
+            tone = TONE_ICON[t];
+            return true;
+          }
+          return false;
+        });
+        if (tone) {
+          icon.style.setProperty('background', tone.bg, 'important');
+          icon.style.setProperty('color', tone.fg, 'important');
+          icon.style.setProperty('border-color', 'transparent', 'important');
+        }
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNodoSwalTheme);
+  } else {
+    initNodoSwalTheme();
+  }
+})();

--- a/templates/includes/base.html
+++ b/templates/includes/base.html
@@ -176,7 +176,10 @@
 
         <!-- NODO Forms Design System -->
         <link rel="stylesheet" href="{% static 'custom/css/nodo-forms.css' %}" />
-        
+
+        <!-- NODO SweetAlert2 theming (fuente única — cascada a los 29 Swal.fire del sistema) -->
+        <link rel="stylesheet" href="{% static 'custom/css/nodo-swal.css' %}" />
+
         <!-- Custom CSS Files -->
         <link rel="stylesheet" href="{% static 'custom/css/main.css' %}" />
         <link rel="stylesheet" href="{% static 'custom/css/custom.css' %}" />
@@ -286,29 +289,29 @@
         {% include 'components/alertas_eventos.html' %}
         
         <!-- Sistema de Modales Modernos -->
-        <div id="modal-overlay" class="modal-responsive fixed inset-0 z-[1001] hidden bg-black/50 backdrop-blur-sm transition-opacity duration-300">
+        <div id="modal-overlay" class="modal-responsive fixed inset-0 z-50 hidden bg-black/50 backdrop-blur-sm transition-opacity duration-300">
             <div class="flex min-h-[100dvh] items-end justify-center p-0 sm:min-h-screen sm:items-center sm:p-4">
                 <div id="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-message" class="modal-responsive-content w-full transform bg-white shadow-lg transition-all duration-300 scale-95 opacity-0 sm:max-w-md sm:rounded-2xl">
                     <!-- Modal Header -->
-                    <div id="modal-header" class="modal-header border-b border-gray-200 p-4 sm:p-6">
+                    <div id="modal-header" class="modal-header border-b border-[color:var(--border-light)] p-4 sm:p-6">
                         <div class="flex items-center justify-between">
                             <div class="flex items-center space-x-3">
                                 <div id="modal-icon" class="w-10 h-10 rounded-lg flex items-center justify-center">
-                                    <i class="fas fa-info-circle text-xl" aria-hidden="true"></i>
+                                    <i class="fas fa-info-circle text-[18px]" aria-hidden="true"></i>
                                 </div>
-                                <h3 id="modal-title" class="text-lg font-semibold text-gray-900">Información</h3>
+                                <h3 id="modal-title" class="text-lg font-bold text-[color:var(--text-heading)]">Información</h3>
                             </div>
-                            <button id="modal-close" aria-label="Cerrar" class="touch-target text-gray-400 transition-colors hover:text-gray-600">
-                                <i class="fas fa-times text-xl" aria-hidden="true"></i>
+                            <button id="modal-close" aria-label="Cerrar" class="touch-target text-[color:var(--text-body-subtle)] transition-colors hover:text-[color:var(--text-heading)]">
+                                <i class="fas fa-times text-[18px]" aria-hidden="true"></i>
                             </button>
                         </div>
                     </div>
                     <!-- Modal Body -->
                     <div id="modal-body" class="modal-body p-4 sm:p-6">
-                        <p id="modal-message" class="text-gray-600 leading-relaxed"></p>
+                        <p id="modal-message" class="text-[color:var(--text-body)] leading-relaxed"></p>
                     </div>
                     <!-- Modal Footer -->
-                    <div id="modal-footer" class="modal-footer flex flex-col-reverse gap-3 border-t border-gray-200 p-4 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-3 sm:p-6">
+                    <div id="modal-footer" class="modal-footer flex flex-col-reverse gap-3 border-t border-[color:var(--border-light)] bg-[color:var(--bg-secondary)] p-4 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-3 sm:p-6">
                         <button id="modal-cancel" class="btn-nodo btn-secondary btn-sm hidden w-full sm:w-auto">
                             Cancelar
                         </button>
@@ -355,7 +358,7 @@
 
                         // Configurar contenido
                         icon.className = `w-10 h-10 rounded-lg flex items-center justify-center ${type.iconColor}`;
-                        icon.querySelector('i').className = `fas ${type.icon} text-xl`;
+                        icon.querySelector('i').className = `fas ${type.icon} text-[18px]`;
                         title.textContent = options.title || 'Información';
                         message.textContent = options.message || '';
 
@@ -513,5 +516,10 @@
         {% endif %}
         
         {% block customJS %}{% endblock %}
+
+        <!-- NODO SweetAlert2 theming (fuente única): se ejecuta después de customJS
+             a propósito — reasigna window.Swal = Swal.mixin(...) y cada Swal.fire()
+             existente lee esa variable global recién al momento del click. -->
+        <script src="{% static 'custom/js/nodo-swal-theme.js' %}"></script>
     </body>
 </html>


### PR DESCRIPTION
## Qué

Unifica **todos los pop-ups/modales** del sistema a un mismo look (el del design system NODO), a partir de una auditoría del `chaco-design-reviewer`. Resuelve el caso reportado (el modal "Activar usuario" se veía distinto y con los botones mal) y los demás.

## Diagnóstico

Coexistían **4 motores de modal** con estilos distintos: SweetAlert2 (29 usos), ModernModal (Becas), modales Alpine inline (Becas config) y un Bootstrap legacy.

## Cambios

1. **Theming global de SweetAlert2** (mayor leverage): `static/custom/css/nodo-swal.css` + `static/custom/js/nodo-swal-theme.js` (nuevos), cargados desde `base.html`. Arregla el chrome (ícono-tile, título 18/700, footer bandeado, radius 16, backdrop con blur, botones `btn-nodo`) de los 29 usos sin tocar cada call site.
2. **ModernModal**: tokens corregidos en `base.html` (título negrita/navy, footer gris, z-50, ícono 18px).
3. **6 modales Alpine "rotos"** alineados al patrón canónico (icon-tile con glifo real, botón ×, Cancelar `btn-tertiary`, backdrop con blur, `.nodo-field`): `segmento_detail`, `requisitos_segmento`, `pregunta_list`.
4. **Backdrops** normalizados en `convocatoria_detail/list` y `relevamiento_list`.

**No incluido:** el modal Bootstrap legacy de `legajos/historial_contactos.html` (queda para una pasada aparte).

## Validación

- `design_audit.py --changed` → 0 errores / 5 warnings preexistentes
- `compile_templates.py` → 268 OK / 0 errores
- `manage.py check` → sin issues
- Sin migraciones ni backend.
- ⚠️ **Requiere revisión visual**: el `design_audit` no valida CSS de librería externa (`.swal2-*`). Revisar: Users→toggle usuario, Becas→aprobar/rechazar, Becas→nuevo requisito/subsegmento, y el modal con textarea de `legajos/programas/programa_detail` ("dar de baja").

🤖 Generated with [Claude Code](https://claude.com/claude-code)