### PR TITLE
UI: corregir solapado ícono/título en modales

### DIFF
--- a/static/custom/css/nodo-swal.css
+++ b/static/custom/css/nodo-swal.css
@@ -15,7 +15,7 @@
 
 .swal2-popup.swal2-popup {
   display: grid !important;
-  grid-template-columns: 40px 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   grid-template-areas:
     "icon title close"
     "content content content"


### PR DESCRIPTION
Ajuste visual sobre el theming de modales (PR #154): la columna del ícono en el header de SweetAlert2 se desbordaba y pisaba el título. Se corrige la grilla a `auto minmax(0,1fr) auto`. Solo CSS, sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)