### PR TITLE
UI: estandarizar cápsulas de estado Activo/Inactivo

### DIFF
--- a/configuracion/templates/configuracion/secretaria_list.html
+++ b/configuracion/templates/configuracion/secretaria_list.html
@@ -76,9 +76,9 @@
                     <td style="padding:13px 16px; font-size:13.5px; color:var(--text-body-subtle); border-top:1px solid var(--border-light);">{{ s.cant_subsecretarias }}</td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">
                         {% if s.activo %}
-                        <span class="badge badge-success">Activa</span>
+                        <span class="badge badge-success badge-dot">Activa</span>
                         {% else %}
-                        <span class="badge badge-gray">Inactiva</span>
+                        <span class="badge badge-danger badge-dot">Inactiva</span>
                         {% endif %}
                     </td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">

--- a/configuracion/templates/configuracion/subsecretaria_list.html
+++ b/configuracion/templates/configuracion/subsecretaria_list.html
@@ -82,9 +82,9 @@
                     <td style="padding:13px 16px; font-size:13.5px; color:var(--text-body-subtle); border-top:1px solid var(--border-light);">{{ ss.cant_programas }}</td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">
                         {% if ss.activo %}
-                        <span class="badge badge-success">Activa</span>
+                        <span class="badge badge-success badge-dot">Activa</span>
                         {% else %}
-                        <span class="badge badge-gray">Inactiva</span>
+                        <span class="badge badge-danger badge-dot">Inactiva</span>
                         {% endif %}
                     </td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">

--- a/conversaciones/templates/conversaciones/configurar_cola.html
+++ b/conversaciones/templates/conversaciones/configurar_cola.html
@@ -80,9 +80,9 @@
                         </td>
                         <td class="px-4 py-4 whitespace-nowrap">
                             {% if cola.activo %}
-                                <span class="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs font-medium">Activo</span>
+                                <span class="badge badge-success badge-dot">Activo</span>
                             {% else %}
-                                <span class="bg-red-100 text-red-800 px-2 py-1 rounded-full text-xs font-medium">Inactivo</span>
+                                <span class="badge badge-danger badge-dot">Inactivo</span>
                             {% endif %}
                         </td>
                         <td class="px-4 py-4 whitespace-nowrap">

--- a/conversaciones/templates/conversaciones/metricas.html
+++ b/conversaciones/templates/conversaciones/metricas.html
@@ -83,9 +83,9 @@
                     </div>
                     <div class="flex items-center">
                         {% if cola.activo %}
-                            <span class="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs font-medium">Activo</span>
+                            <span class="badge badge-success badge-dot">Activo</span>
                         {% else %}
-                            <span class="bg-red-100 text-red-800 px-2 py-1 rounded-full text-xs font-medium">Inactivo</span>
+                            <span class="badge badge-danger badge-dot">Inactivo</span>
                         {% endif %}
                     </div>
                 </div>

--- a/programas/templates/programas/becas/config/_preguntas_table.html
+++ b/programas/templates/programas/becas/config/_preguntas_table.html
@@ -30,7 +30,7 @@
           {% if p.activo %}
             <span class="badge badge-success badge-dot">Activa</span>
           {% else %}
-            <span class="badge badge-gray">Inactiva</span>
+            <span class="badge badge-danger badge-dot">Inactiva</span>
           {% endif %}
         </td>
         <td class="px-4 py-[13px] text-sm border-t border-light text-right">

--- a/programas/templates/programas/becas/config/_segmentos_table.html
+++ b/programas/templates/programas/becas/config/_segmentos_table.html
@@ -40,7 +40,7 @@
           {% if s.activo %}
             <span class="badge badge-success badge-dot">Activo</span>
           {% else %}
-            <span class="badge badge-gray">Inactivo</span>
+            <span class="badge badge-danger badge-dot">Inactivo</span>
           {% endif %}
         </td>
         <td class="px-4 py-[13px] border-t border-light text-right" style="font-size:13.5px">

--- a/programas/templates/programas/becas/config/segmento_detail.html
+++ b/programas/templates/programas/becas/config/segmento_detail.html
@@ -56,7 +56,7 @@
       </div>
       <div class="flex items-center gap-2 flex-wrap">
         {% if segmento.activo %}<span class="badge badge-success badge-dot">Activo</span>
-        {% else %}<span class="badge badge-gray">Inactivo</span>{% endif %}
+        {% else %}<span class="badge badge-danger badge-dot">Inactivo</span>{% endif %}
         <a href="{% url 'becas:cupo_segmento' segmento.pk %}" class="btn-nodo btn-secondary btn-sm flex items-center gap-1.5">
           <i class="fas fa-users"></i> Cupo y beneficiarios
         </a>
@@ -235,7 +235,7 @@
             <dl class="space-y-2.5 text-sm">
               <div class="flex justify-between items-center">
                 <dt class="text-body-subtle">Estado</dt>
-                <dd>{% if segmento.activo %}<span class="badge badge-success badge-dot">Activo</span>{% else %}<span class="badge badge-gray">Inactivo</span>{% endif %}</dd>
+                <dd>{% if segmento.activo %}<span class="badge badge-success badge-dot">Activo</span>{% else %}<span class="badge badge-danger badge-dot">Inactivo</span>{% endif %}</dd>
               </div>
               <div class="flex justify-between">
                 <dt class="text-body-subtle">Coordinador</dt>

--- a/programas/templates/programas/becas/relevamientos/_convocatorias_table.html
+++ b/programas/templates/programas/becas/relevamientos/_convocatorias_table.html
@@ -30,7 +30,7 @@
           {% if c.activo %}
             <span class="badge badge-success badge-dot">Activa</span>
           {% else %}
-            <span class="badge badge-gray">Inactiva</span>
+            <span class="badge badge-danger badge-dot">Inactiva</span>
           {% endif %}
         </td>
         <td class="px-4 py-[13px] text-sm border-t border-light text-right">

--- a/programas/templates/programas/becas/relevamientos/convocatoria_detail.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_detail.html
@@ -18,7 +18,7 @@
         <p class="text-sm text-body-subtle mt-1">{{ convocatoria.segmento.nombre }}{% if convocatoria.subsegmento %} · {{ convocatoria.subsegmento.nombre }}{% endif %}</p>
       </div>
       {% if convocatoria.activo %}<span class="badge badge-success badge-dot">Activa</span>
-      {% else %}<span class="badge badge-gray">Inactiva</span>{% endif %}
+      {% else %}<span class="badge badge-danger badge-dot">Inactiva</span>{% endif %}
     </div>
   </div>
 
@@ -134,7 +134,7 @@
           <div class="bg-white rounded-xl border border-base shadow-sm p-5">
             <h3 class="text-sm font-bold text-heading mb-3">Datos de la convocatoria</h3>
             <dl class="space-y-2.5 text-sm">
-              <div class="flex justify-between"><dt class="text-body-subtle">Estado</dt><dd>{% if convocatoria.activo %}<span class="badge badge-success badge-dot">Activa</span>{% else %}<span class="badge badge-gray">Inactiva</span>{% endif %}</dd></div>
+              <div class="flex justify-between"><dt class="text-body-subtle">Estado</dt><dd>{% if convocatoria.activo %}<span class="badge badge-success badge-dot">Activa</span>{% else %}<span class="badge badge-danger badge-dot">Inactiva</span>{% endif %}</dd></div>
               <div class="flex justify-between"><dt class="text-body-subtle">Período</dt><dd class="text-heading font-medium">{{ convocatoria.fecha_inicio|date:"d/m/Y" }} → {{ convocatoria.fecha_fin|date:"d/m/Y" }}</dd></div>
               <div class="flex justify-between"><dt class="text-body-subtle">Fecha de creación</dt><dd class="text-heading font-medium">{{ convocatoria.creado|date:"d/m/Y" }}</dd></div>
             </dl>

--- a/users/templates/rol/rol_detail.html
+++ b/users/templates/rol/rol_detail.html
@@ -9,8 +9,8 @@
         <div>
             <div class="flex items-center gap-2 flex-wrap">
                 <h1 class="text-2xl font-bold text-gray-900">{{ group.name }}</h1>
-                {% if meta.protegido %}<span class="bg-amber-100 text-amber-800 px-2 py-0.5 rounded-full text-xs font-medium"><i class="fas fa-lock mr-1"></i>Protegido</span>{% endif %}
-                {% if meta and not meta.activo %}<span class="bg-gray-200 text-gray-700 px-2 py-0.5 rounded-full text-xs font-medium">Inactivo</span>{% else %}<span class="bg-green-100 text-green-800 px-2 py-0.5 rounded-full text-xs font-medium">Activo</span>{% endif %}
+                {% if meta.protegido %}<span class="badge badge-warning"><i class="fas fa-lock"></i>Protegido</span>{% endif %}
+                {% if meta and not meta.activo %}<span class="badge badge-danger badge-dot">Inactivo</span>{% else %}<span class="badge badge-success badge-dot">Activo</span>{% endif %}
             </div>
             <p class="text-gray-600 mt-1">{{ meta.descripcion|default:"Sin descripción" }}</p>
             <p class="text-sm text-gray-500 mt-1">Categoría: {{ meta.categoria|default:"—" }}{% if meta.programa %} · <i class="fas fa-folder mr-1"></i>Programa: {{ meta.programa.nombre }}{% endif %} · {{ num_usuarios }} usuario(s)</p>

--- a/users/templates/rol/rol_list.html
+++ b/users/templates/rol/rol_list.html
@@ -214,9 +214,9 @@
                     </td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">
                         {% if not item.meta or item.meta.activo %}
-                        <span class="badge badge-success">Activo</span>
+                        <span class="badge badge-success badge-dot">Activo</span>
                         {% else %}
-                        <span class="badge badge-gray">Inactivo</span>
+                        <span class="badge badge-danger badge-dot">Inactivo</span>
                         {% endif %}
                     </td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">

--- a/users/templates/user/user_list.html
+++ b/users/templates/user/user_list.html
@@ -99,9 +99,9 @@
                     </td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">
                         {% if user.is_active %}
-                        <span class="badge badge-success">Activo</span>
+                        <span class="badge badge-success badge-dot">Activo</span>
                         {% else %}
-                        <span class="badge badge-gray">Inactivo</span>
+                        <span class="badge badge-danger badge-dot">Inactivo</span>
                         {% endif %}
                     </td>
                     <td style="padding:13px 16px; border-top:1px solid var(--border-light);">


### PR DESCRIPTION
## Qué

Las cápsulas "Inactivo/Inactiva" se veían pobres (`badge-gray`, gris lavado y sin punto) al lado de "Activa" (`badge-success badge-dot`). Ahora **Inactivo usa el mismo diseño pill + punto pero en rojo** (`badge-danger badge-dot`), y el par queda simétrico y consistente en todo el sistema.

## Cambios

- **Inactivo/Inactiva** → `badge badge-danger badge-dot` en: Usuarios, Roles, Secretarías, Subsecretarías, y Becas (convocatorias, segmentos, preguntas).
- **Activo/Activa** → se le agrega `badge-dot` donde faltaba (Usuarios, Roles, Secretarías, Subsecretarías) para que combine con Inactivo.
- **Tailwind crudo → badges del DS**: `rol_detail` (Activo/Inactivo/Protegido) y conversaciones (`metricas`, `configurar_cola`).
- **Excepción**: en **Programas** "Inactivo" queda en gris-con-punto para no confundirse con "Suspendido" (que ya es rojo).

## Validación
- `design_audit.py --changed` → 0 errores
- `compile_templates.py` → 268 OK
- Sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)