### PR TITLE
UI: estandarizar badges/chips restantes al design system

### DIFF
--- a/conversaciones/templates/conversaciones/configurar_cola.html
+++ b/conversaciones/templates/conversaciones/configurar_cola.html
@@ -106,9 +106,9 @@
                         </td>
                         <td class="px-4 py-4 whitespace-nowrap">
                             {% if cola.puede_recibir_conversacion %}
-                                <span class="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs font-medium">Sí</span>
+                                <span class="badge badge-success">Sí</span>
                             {% else %}
-                                <span class="bg-red-100 text-red-800 px-2 py-1 rounded-full text-xs font-medium">No</span>
+                                <span class="badge badge-gray">No</span>
                             {% endif %}
                         </td>
                     </tr>

--- a/conversaciones/templates/conversaciones/detalle.html
+++ b/conversaciones/templates/conversaciones/detalle.html
@@ -17,8 +17,7 @@
             <div>
                 <h1 class="text-2xl font-bold text-gray-900">Conversación #{{ conversacion.id }}</h1>
                 <div class="flex items-center gap-4 mt-2">
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                        {% if conversacion.tipo == 'personal' %}bg-green-100 text-green-800{% else %}bg-blue-100 text-blue-800{% endif %}">
+                    <span class="badge {% if conversacion.tipo == 'personal' %}badge-brand{% else %}badge-gray{% endif %}">
                         {{ conversacion.get_tipo_display }}
                     </span>
                     {% if conversacion.dni_ciudadano %}

--- a/conversaciones/templates/conversaciones/lista.html
+++ b/conversaciones/templates/conversaciones/lista.html
@@ -145,8 +145,7 @@
                     <span class="text-sm font-medium text-gray-700">
                         {{ operador.get_full_name|default:operador.username }}
                     </span>
-                    <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
-                        {% if operador.conversaciones_activas > 5 %}bg-red-100 text-red-800{% elif operador.conversaciones_activas > 2 %}bg-yellow-100 text-yellow-800{% else %}bg-green-100 text-green-800{% endif %}">
+                    <span class="badge {% if operador.conversaciones_activas > 5 %}badge-danger{% elif operador.conversaciones_activas > 2 %}badge-warning{% else %}badge-success{% endif %}">
                         {{ operador.conversaciones_activas }} activas
                     </span>
                 </div>
@@ -183,8 +182,7 @@
                             #{{ conversacion.id }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                                {% if conversacion.tipo == 'personal' %}bg-green-100 text-green-800{% else %}bg-blue-100 text-blue-800{% endif %}">
+                            <span class="badge {% if conversacion.tipo == 'personal' %}badge-brand{% else %}badge-gray{% endif %}">
                                 {{ conversacion.get_tipo_display }}
                             </span>
                         </td>
@@ -199,8 +197,7 @@
                             {% endif %}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                                {% if conversacion.estado == 'activa' %}bg-green-100 text-green-800{% else %}bg-gray-100 text-gray-800{% endif %}">
+                            <span class="badge {% if conversacion.estado == 'activa' %}badge-success badge-dot{% elif conversacion.estado == 'pendiente' %}badge-warning{% else %}badge-gray{% endif %}">
                                 {{ conversacion.get_estado_display }}
                             </span>
                         </td>
@@ -215,11 +212,11 @@
                             {{ conversacion.fecha_inicio|date:"d/m/Y H:i" }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                            <span class="badge badge-gray">
                                 {{ conversacion.total_mensajes }}
                             </span>
                             {% if conversacion.mensajes_no_leidos %}
-                                <span class="contador-mensajes ml-1 inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                <span class="contador-mensajes ml-1 badge badge-danger">
                                     {{ conversacion.mensajes_no_leidos }} sin leer
                                 </span>
                             {% endif %}
@@ -276,12 +273,10 @@
                     <div class="flex-1">
                         <div class="flex items-center gap-2 mb-2">
                             <span class="font-medium text-gray-900">#{{ conversacion.id }}</span>
-                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
-                                {% if conversacion.tipo == 'personal' %}bg-green-100 text-green-800{% else %}bg-blue-100 text-blue-800{% endif %}">
+                            <span class="badge {% if conversacion.tipo == 'personal' %}badge-brand{% else %}badge-gray{% endif %}">
                                 {{ conversacion.get_tipo_display }}
                             </span>
-                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
-                                {% if conversacion.estado == 'activa' %}bg-green-100 text-green-800{% else %}bg-gray-100 text-gray-800{% endif %}">
+                            <span class="badge {% if conversacion.estado == 'activa' %}badge-success badge-dot{% elif conversacion.estado == 'pendiente' %}badge-warning{% else %}badge-gray{% endif %}">
                                 {{ conversacion.get_estado_display }}
                             </span>
                         </div>
@@ -306,11 +301,11 @@
                     
                     <div class="flex flex-col items-end gap-2">
                         <div class="flex items-center gap-1">
-                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                            <span class="badge badge-gray">
                                 {{ conversacion.total_mensajes }}
                             </span>
                             {% if conversacion.mensajes_no_leidos %}
-                                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                <span class="badge badge-danger">
                                     {{ conversacion.mensajes_no_leidos }}
                                 </span>
                             {% endif %}

--- a/portal/templates/portal/home.html
+++ b/portal/templates/portal/home.html
@@ -296,10 +296,9 @@
                     </div>
                     <div class="flex-1 min-w-0">
                         <h3 class="font-bold text-[var(--text-heading)] leading-tight">{{ programa.nombre }}</h3>
-                        <div class="inline-block mt-1 text-xs font-semibold px-2 py-0.5 rounded-full"
-                             style="background: {{ programa.color|default:'var(--bg-brand)' }}1A; color: {{ programa.color|default:'var(--bg-brand)' }};">
+                        <span class="badge badge-success badge-dot mt-1">
                             Activo
-                        </div>
+                        </span>
                     </div>
                 </div>
                 {% if programa.descripcion %}

--- a/programas/templates/programas/becas/relevamientos/relevamiento_detail.html
+++ b/programas/templates/programas/becas/relevamientos/relevamiento_detail.html
@@ -164,7 +164,7 @@
                   {% if f.validado_renaper %}
                     <span class="badge badge-success">Validado</span>
                   {% else %}
-                    <span class="badge badge-gray">Pendiente</span>
+                    <span class="badge badge-warning">Pendiente</span>
                   {% endif %}
                 </td>
                 <td class="px-4 py-[13px] text-sm border-t border-light">

--- a/programas/templates/programas/becas/revision/formulario_detalle.html
+++ b/programas/templates/programas/becas/revision/formulario_detalle.html
@@ -62,7 +62,7 @@
             {% if formulario.validado_renaper %}
               <span class="badge badge-success">Validado</span>
             {% else %}
-              <span class="badge badge-gray">Pendiente</span>
+              <span class="badge badge-warning">Pendiente</span>
               {% if puede_revalidar_renaper %}<form method="post" action="{% url 'becas:formulario_revalidar_renaper' formulario.pk %}" class="inline-block ml-2">
                 {% csrf_token %}
                 <button type="submit" class="btn-nodo btn-tertiary btn-sm"><i class="fas fa-rotate"></i> Revalidar</button>

--- a/programas/templates/programas/becas/revision/formulario_list.html
+++ b/programas/templates/programas/becas/revision/formulario_list.html
@@ -76,7 +76,7 @@
               {% if f.validado_renaper %}
                 <span class="badge badge-success">Validado</span>
               {% else %}
-                <span class="badge badge-gray">Pendiente</span>
+                <span class="badge badge-warning">Pendiente</span>
               {% endif %}
             </td>
             <td class="px-4 py-[13px] text-sm border-t border-light">

--- a/programas/templates/programas/becas/revision/personas_list.html
+++ b/programas/templates/programas/becas/revision/personas_list.html
@@ -69,7 +69,7 @@
               {% if f.validado_renaper %}
                 <span class="badge badge-success">Validado</span>
               {% else %}
-                <span class="badge badge-gray">Pendiente</span>
+                <span class="badge badge-warning">Pendiente</span>
               {% endif %}
             </td>
             <td class="px-4 py-[13px] text-sm border-t border-light">

--- a/static/custom/css/nodo-badges.css
+++ b/static/custom/css/nodo-badges.css
@@ -30,7 +30,7 @@
    canónico del mapa BADGE (canon §7). .badge-brand no tiene token exacto en
    chaco-tokens.css (su fondo/borde/texto son propios del mapa de badges, distintos
    de las primitivas --color-pink-*/--color-brand-*) → se deja el hex tal cual. */
-.badge-gray    { background: var(--color-gray-050, #F9FAFB); border: 1px solid var(--color-gray-200, #E5E7EB); color: var(--color-gray-700, #374151); }
+.badge-gray    { background: var(--color-gray-050, #F9FAFB); border: 1px solid var(--color-gray-300, #D1D5DB); color: var(--color-gray-700, #374151); }
 .badge-white   { background: var(--bg-white, #FFFFFF); border: 1px solid var(--color-gray-200, #E5E7EB); color: var(--color-gray-700, #374151); }
 .badge-brand   { background: #FFEAF6; border: 1px solid #FFB9DC; color: #A11F60; } /* design-audit: allow — mapa canónico §7, sin token exacto */
 .badge-success { background: var(--color-emerald-050, #ECFDF5); border: 1px solid var(--color-emerald-200, #A4F4CF); color: var(--color-emerald-800, #006045); }

--- a/templates/components/widget_contactos.html
+++ b/templates/components/widget_contactos.html
@@ -65,7 +65,7 @@ function cargarWidgetContactos() {
                     <div class="list-group-item border-0 px-0 py-1">
                         <div class="d-flex justify-content-between align-items-center">
                             <small>${tipo}</small>
-                            <span class="badge bg-light text-dark">${count}</span>
+                            <span class="badge badge-gray">${count}</span>
                         </div>
                     </div>
                 `;

--- a/templates/legajos/alertas_dashboard.html
+++ b/templates/legajos/alertas_dashboard.html
@@ -244,10 +244,10 @@
                                 </div>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                                    {% if alerta.tipo == 'RIESGO_CRITICO' %}bg-red-100 text-red-800
-                                    {% elif alerta.tipo == 'NUEVA_CONVERSACION' %}bg-green-100 text-green-800
-                                    {% else %}bg-blue-100 text-blue-800{% endif %}">
+                                <span class="badge
+                                    {% if alerta.tipo == 'RIESGO_CRITICO' %}badge-danger
+                                    {% elif alerta.tipo == 'NUEVA_CONVERSACION' %}badge-success
+                                    {% else %}badge-info{% endif %}">
                                     {{ alerta.get_tipo_display }}
                                 </span>
                             </td>
@@ -256,12 +256,12 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
                                 {% if alerta.vista %}
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                                        <i class="fas fa-eye mr-1"></i>Vista
+                                    <span class="badge badge-gray">
+                                        <i class="fas fa-eye text-xs"></i>Vista
                                     </span>
                                 {% else %}
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                                        <i class="fas fa-eye-slash mr-1"></i>Pendiente
+                                    <span class="badge badge-warning">
+                                        <i class="fas fa-eye-slash text-xs"></i>Pendiente
                                     </span>
                                 {% endif %}
                             </td>


### PR DESCRIPTION
## Qué

Barrido system-wide (auditoría del `chaco-design-reviewer`) de todo lo que hace de badge pero no usaba el diseño píldora del DS. La mayoría ya estaba bien; se corrigen los outliers y los dos casos reportados.

## P1 — Casos reportados
- **RENAPER "Pendiente"**: `badge-gray` → **`badge-warning`** (el kit canónico lo define warning), en `personas_list`, `formulario_list`, `formulario_detalle`, `relevamiento_detail`. "Validado" sigue `badge-success`.
- **badge-gray lavado** (afecta "Asignado" y todos los grises): se refuerza **solo el borde** (`--color-gray-200` → `--color-gray-300`) en `nodo-badges.css`. El fondo se deja (`#F9FAFB` es el valor canónico del kit) y "Asignado" sigue gris (así lo define el kit) pero ahora el pill se distingue sobre las tablas.

## P2-P4 — Outliers
- **conversaciones** (chips Tailwind crudo → `.badge`): carga de trabajo, tipo (Personal/Anónima), estado (3 estados: activa/pendiente/cerrada), contadores; en `lista` y `detalle`; `configurar_cola` Sí/No.
- **alertas_dashboard**: tipo de alerta (danger/success/info), Vista (gray) / Pendiente (warning).
- **widget_contactos** (Bootstrap `badge bg-light` → `badge-gray`), **portal/home** pill "Activo" → `badge-success badge-dot`.

## Notas
- `configurar_cola` "No puede recibir" pasó de rojo a **gris** (a capacidad no es un error). Si preferís que quede en warning/danger, lo cambio.
- Fuera de alcance (no son badges de estado): contadores de tabs, chip removible de roles, performance dashboard interno.

## Validación
- `design_audit.py --changed` → 0 errores / 2 warnings preexistentes
- `compile_templates.py` → 268 OK · `manage.py check` → sin issues · sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)