### PR TITLE
chore(repo): remove orphan root package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Chaco-v1-Junio-26",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Qué cambia

Elimina el `package-lock.json` ubicado en la raíz del repositorio.

## Por qué

No existe un `package.json` raíz ni referencias al lockfile. El único flujo npm versionado usa explícitamente `mobile/package-lock.json`, y Tailwind se carga desde CDN sin build Node raíz.

## Validación

- Búsqueda focalizada en Dockerfiles, Docker Compose, workflows, scripts y documentación.
- Verificación de ausencia de `package.json` raíz local y versionado.
- `git diff --check`.