### PR TITLE
Main limpio para el cliente: publicación automática desde development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,16 @@
 *.sh text eol=lf
+
+# Exclusiones del snapshot de release para main.
+/.claude export-ignore
+/.amazonq export-ignore
+/.github export-ignore
+/.mcp.json export-ignore
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/ESTADOS.md export-ignore
+/PM.md export-ignore
+/QA.md export-ignore
+/docs export-ignore
+/mkdocs.yml export-ignore
+/scripts/design_audit.py export-ignore
+/scripts/compile_templates.py export-ignore

--- a/.github/workflows/docs-auto-deploy.yml
+++ b/.github/workflows/docs-auto-deploy.yml
@@ -3,7 +3,7 @@ name: Docs Auto Deploy
 on:
   push:
     branches:
-      - main
+      - development
     paths:
       - 'docs/client/**'
       - 'mkdocs.yml'

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,0 +1,62 @@
+name: Publish main
+
+on:
+  push:
+    branches:
+      - development
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-main
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Construir árbol de release
+        run: mkdir -p "$RUNNER_TEMP/release" && git archive HEAD | tar -x -C "$RUNNER_TEMP/release"
+
+      - name: Guard
+        shell: bash
+        run: |
+          fail=0
+          for path in .claude .amazonq .github .mcp.json AGENTS.md CLAUDE.md ESTADOS.md PM.md QA.md docs mkdocs.yml scripts/design_audit.py scripts/compile_templates.py; do
+            if [ -e "$RUNNER_TEMP/release/$path" ]; then
+              echo "::error::El archivo prohibido $path aparece en el release"
+              fail=1
+            fi
+          done
+          for path in manage.py requirements.txt docker-compose.prod.yml docker/django/Dockerfile scripts/startup.sh scripts/deploy_prod.sh nginx.conf docker-entrypoint.sh; do
+            if [ ! -e "$RUNNER_TEMP/release/$path" ]; then
+              echo "::error::Falta el archivo de runtime requerido $path en el release"
+              fail=1
+            fi
+          done
+          exit "$fail"
+
+      - name: Publicar snapshot en main
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git worktree add -B main "$RUNNER_TEMP/mainwt" origin/main
+          rsync -a --delete --exclude=.git "$RUNNER_TEMP/release/" "$RUNNER_TEMP/mainwt/"
+          cd "$RUNNER_TEMP/mainwt"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "main al día"
+            exit 0
+          fi
+          subj="$(git -C "$GITHUB_WORKSPACE" log -1 --pretty=%s)"
+          short="$(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)"
+          git commit -m "release: $subj (development@$short)"
+          git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,9 @@ Todos los agentes (Analista, QA, PM Assistant) usan el **MCP de GitHub**
 Project #1 de `Mkdir-arg` (https://github.com/users/Mkdir-arg/projects/1/),
 con fallback a la CLI `gh`. Las escrituras estructuradas al Project usan la
 receta `gh` de `AGENTS.md`.
+
+## Ramas y releases
+
+`development` es la rama de trabajo y la rama por defecto. `main` es una release
+generada automáticamente y no se toca a mano. Las exclusiones están en
+`.gitattributes`; el detalle operativo vive en `docs/internal/branching.md`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Chaco
+
+Chaco es un sistema de gestión compuesto por un backoffice para equipos
+administrativos y un portal ciudadano para realizar trámites y consultas.
+
+Está construido con Django 4.2, MySQL 8 y Docker Compose.
+
+## Requisitos
+
+- Docker Engine con el plugin Docker Compose (`docker compose`).
+- Git.
+- Acceso al repositorio y a las credenciales de producción.
+
+## Configuración inicial
+
+1. Clone el repositorio y ubíquese en su directorio raíz.
+2. Cree `.env.production` a partir de `.env.local.example`.
+3. Complete los valores de producción, especialmente las claves, credenciales
+   de base de datos y dominios permitidos.
+4. No versionar nunca `.env.production` ni compartir sus secretos.
+
+## Despliegue
+
+Para crear o actualizar los servicios manualmente:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+También puede usar el script de despliegue:
+
+```bash
+scripts/deploy_prod.sh
+```
+
+El script realiza backup de archivos relevantes, valida la configuración,
+espera el health check y revierte al commit anterior si el despliegue falla.
+
+## Verificación
+
+Una vez iniciados los servicios, verifique que el endpoint responda HTTP 200:
+
+```bash
+curl -i http://localhost/health/
+```
+
+## Actualización
+
+1. Confirme que el árbol de trabajo del servidor esté limpio.
+2. Actualice exclusivamente desde la rama de release:
+
+   ```bash
+   git pull --ff-only origin main
+   ```
+
+3. Recree los servicios de aplicación y websocket:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d --build --force-recreate web websocket
+   ```
+
+4. Reinicie Nginx:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml restart nginx
+   ```
+
+`main` es una rama de release generada automáticamente. No haga commits sobre
+ella ni la actualice manualmente.

--- a/docs/internal/branching.md
+++ b/docs/internal/branching.md
@@ -12,14 +12,21 @@ runtime requeridos.
 
 ## Checklist de cutover (una única vez)
 
-1. Mergear esta rama a `development`.
-2. Cambiar la rama por defecto del repositorio a `development`.
-3. Re-apuntar los PR abiertos a `development`.
-4. Ejecutar **Publish main** con `workflow_dispatch`; su primer commit deja
-   `main` con el árbol de release limpio.
-5. Proteger `main` con un ruleset: restringir actualizaciones y bloquear force
+1. Mergear esta rama a `development`. Ese merge trae el workflow a
+   `development` y, por ser un push a esa rama, **dispara automáticamente la
+   primera publicación** de `main`.
+2. Verificar en la pestaña **Actions** que **Publish main** terminó OK y que el
+   árbol de `main` quedó limpio. Para este primer run `main` todavía **no** debe
+   estar protegida, o el bot no podrá pushear.
+3. Cambiar la rama por defecto del repositorio a `development` y re-apuntar los
+   PR abiertos.
+4. Proteger `main` con un ruleset: restringir actualizaciones y bloquear force
    pushes, con bypass solo para la app GitHub Actions.
-6. Verificar en el servidor que `git status` esté limpio antes del primer pull.
+5. Verificar en el servidor que `git status` esté limpio antes del primer pull.
+
+Nota: el disparo manual por `workflow_dispatch` (botón **Run workflow**) queda
+disponible para republicar a mano; solo aparece una vez que `development` es la
+rama por defecto.
 
 ## Reglas permanentes
 

--- a/docs/internal/branching.md
+++ b/docs/internal/branching.md
@@ -1,0 +1,34 @@
+# Ramas y publicación a main
+
+## Modelo
+
+`development` es la rama de trabajo. `main` es la rama de release generada por
+`.github/workflows/publish-main.yml`.
+
+El manifiesto de exclusiones vive en `.gitattributes`, mediante
+`export-ignore`. El guard del workflow es la segunda defensa: rechaza un
+release que incluya archivos de desarrollo o al que le falten archivos de
+runtime requeridos.
+
+## Checklist de cutover (una única vez)
+
+1. Mergear esta rama a `development`.
+2. Cambiar la rama por defecto del repositorio a `development`.
+3. Re-apuntar los PR abiertos a `development`.
+4. Ejecutar **Publish main** con `workflow_dispatch`; su primer commit deja
+   `main` con el árbol de release limpio.
+5. Proteger `main` con un ruleset: restringir actualizaciones y bloquear force
+   pushes, con bypass solo para la app GitHub Actions.
+6. Verificar en el servidor que `git status` esté limpio antes del primer pull.
+
+## Reglas permanentes
+
+- Un nuevo archivo de desarrollo requiere agregar `export-ignore` y el guard
+  correspondiente si es crítico.
+- Nunca pushear ni mergear a `main` a mano.
+- Un hotfix se resuelve con un PR a `development` y luego se publica.
+- Nunca reescribir la historia de `main`: el servidor usa `git pull --ff-only`.
+
+El árbol de `main` queda limpio, pero su historia anterior conserva los
+archivos de desarrollo. Esto es aceptado: limpiarla exigiría un force-push y
+rompería el pull del servidor.


### PR DESCRIPTION
# IMPORTANTE !!!
## Pasos posteriores al merge (una sola vez, los hace el administrador del repo)

1. Al mergear este PR, la **primera publicación de `main` se dispara sola**. Revisar en la pestaña "Actions" que el proceso **Publish main** haya terminado bien y que `main` haya quedado limpia. Importante: en ese primer momento `main` todavía no debe estar protegida, o el proceso no podrá publicar.
2. Cambiar la rama por defecto del repositorio a `development` y re-apuntar los PRs abiertos.
3. Proteger `main` para que nadie pueda modificarla a mano (bloquear cambios y force-push, con excepción solo para GitHub Actions).
4. En el servidor, verificar que no haya cambios locales antes de la primera actualización.

El detalle técnico y las reglas permanentes quedan documentados en `docs/internal/branching.md` (visible solo en `development`).

## Qué estamos haciendo

El equipo pasa a trabajar siempre en la rama `development`, y `main` deja de tocarse a mano: se genera sola. El mecanismo funciona así:

1. Existe una **lista maestra** que marca qué archivos son de uso interno del equipo (instrucciones para los asistentes, documentos de gestión, guías internas, etc.).
2. Cada vez que se aprueba un cambio en `development`, un **proceso automático** entra en acción: saca una copia del proyecto y le quita todos los archivos que figuran en esa lista.
3. Antes de entregar esa copia, un **control de seguridad** la revisa: si detecta que se coló un archivo interno, o que falta alguno de los que el sistema necesita para arrancar, **frena la publicación** y avisa del error.
4. Si la copia pasa el control, se publica en `main` como una **nueva versión que se suma a las anteriores**, sin borrar ni alterar el historial previo (para no romper la forma en que el servidor se actualiza).

Así, la limpieza no depende de que alguien se acuerde de sacar los archivos internos: ocurre sola en cada publicación, y con una red de seguridad que la detiene si algo sale mal.

## Cuál es el resultado

- El cliente, al descargar o actualizar `main`, recibe **solo lo justo y necesario para instalar y correr el sistema**: el código, la configuración de despliegue y una guía de instalación (README) escrita para él.
- La forma de actualizar el servidor de producción **no cambia en nada**: sigue siendo la misma operación de siempre sobre `main`.
- Esto vale para hoy (la primera publicación deja `main` limpia de inmediato) y para siempre (`main` deja de recibir cambios a mano; todo pasa por el filtro automático).

