### PR TITLE
[Fase 0] Línea base reproducible de performance

### DIFF
--- a/core/management/commands/seed_perf.py
+++ b/core/management/commands/seed_perf.py
@@ -1,0 +1,431 @@
+"""Datos sintéticos, deterministas e idempotentes para auditorías de performance."""
+
+import os
+import sys
+from datetime import UTC, date, datetime, timedelta
+
+from django.contrib.auth.models import Group, User
+from django.core.cache import cache
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
+from django.utils import timezone
+
+from conversaciones.models import ColaAsignacion, Conversacion, Mensaje
+from core import rbac
+from core.models import Localidad, Municipio, Provincia
+from legajos.models import AlertaCiudadano, Ciudadano, HistorialContacto, LegajoAtencion, VinculoFamiliar
+from programas.management.commands.seed_becas import ROL_ADMIN, ROL_COORDINADOR, ROL_TERRITORIAL
+from programas.models import (
+    AsignacionCoordinador,
+    AsignacionTerritorial,
+    Convocatoria,
+    CupoSegmento,
+    DerivacionPrograma,
+    Formulario,
+    InscripcionPrograma,
+    Programa,
+    Relevamiento,
+    RequisitoNativo,
+    Segmento,
+    Subsegmento,
+    TipoCampo,
+)
+
+PERF_PREFIX = "PERF"
+PERF_ADMIN_USERNAME = "perf_admin"
+PERF_CITIZEN_USERNAME = "perf_ciudadano"
+PERF_FIRST_DNI = "80000000"
+
+
+def _ensure_user(username, *, first_name, last_name, is_staff=False, is_superuser=False):
+    user, created = User.objects.get_or_create(username=username)
+    user.first_name = first_name
+    user.last_name = last_name
+    user.email = f"{username}@perf.invalid"
+    user.is_active = True
+    user.is_staff = is_staff
+    user.is_superuser = is_superuser
+    user.last_login = timezone.now()
+    if created:
+        user.set_unusable_password()
+    user.save()
+    return user
+
+
+def _set_groups(user, *group_names):
+    groups = Group.objects.filter(name__in=group_names)
+    found = set(groups.values_list("name", flat=True))
+    missing = set(group_names) - found
+    if missing:
+        raise CommandError(f"Faltan roles requeridos por seed_perf: {', '.join(sorted(missing))}")
+    user.groups.set(groups)
+
+
+class Command(BaseCommand):
+    help = "Siembra datos sintéticos namespaced PERF para scripts/CI de performance. Nunca usa datos productivos."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--scale", type=int, default=200, help="Cantidad de entidades principales (default: 200).")
+
+    def handle(self, *args, **options):
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        scale = options["scale"]
+        if scale < 1:
+            raise CommandError("--scale debe ser mayor que cero")
+        if (
+            os.environ.get("PYTEST_RUNNING") != "1"
+            or connection.vendor != "sqlite"
+            or connection.settings_dict.get("NAME") not in (":memory:", "file:memorydb_default?mode=memory&cache=shared")
+        ):
+            raise CommandError("seed_perf solo puede ejecutarse con PYTEST_RUNNING=1 y SQLite in-memory")
+
+        if "auth_user" not in connection.introspection.table_names():
+            call_command("migrate", interactive=False, run_syncdb=True, verbosity=0)
+
+        with transaction.atomic():
+            self._seed(scale)
+
+    def _seed(self, scale):
+
+        call_command("seed_datos_base", verbosity=0)
+
+        admin = _ensure_user(
+            PERF_ADMIN_USERNAME,
+            first_name="Administrador",
+            last_name="Performance",
+            is_staff=True,
+            is_superuser=False,
+        )
+        citizen_user = _ensure_user(
+            PERF_CITIZEN_USERNAME,
+            first_name="Ciudadano",
+            last_name="Performance",
+        )
+        coordinator = _ensure_user(
+            "perf_coordinador",
+            first_name="Coordinador",
+            last_name="Performance",
+            is_staff=True,
+        )
+        operators = [
+            _ensure_user(
+                f"perf_operador_{index:02d}",
+                first_name=f"Operador {index:02d}",
+                last_name="Performance",
+                is_staff=True,
+            )
+            for index in range(1, 5)
+        ]
+
+        _set_groups(admin, rbac.ROL_ADMINISTRADOR, ROL_ADMIN)
+        _set_groups(citizen_user, rbac.GRUPO_CIUDADANO_PORTAL)
+        _set_groups(coordinator, ROL_COORDINADOR)
+        for operator in operators:
+            _set_groups(operator, "Administrador")
+            ColaAsignacion.objects.update_or_create(
+                operador=operator,
+                defaults={"activo": True, "max_conversaciones": 1000, "conversaciones_actuales": 0},
+            )
+
+        provincia = Provincia.objects.filter(nombre__icontains="chaco").first() or Provincia.objects.first()
+        if provincia is None:
+            provincia = Provincia.objects.create(nombre="Chaco PERF")
+        municipio = Municipio.objects.filter(provincia=provincia).first()
+        if municipio is None:
+            municipio = Municipio.objects.create(nombre="Municipio PERF", provincia=provincia)
+        localidad = Localidad.objects.filter(municipio=municipio).first()
+        if localidad is None:
+            localidad = Localidad.objects.create(nombre="Localidad PERF", municipio=municipio)
+
+        becas = Programa.objects.get(codigo="BECAS")
+        apoyo, _ = Programa.objects.update_or_create(
+            codigo="PERF-APOYO",
+            defaults={
+                "nombre": "Programa Apoyo PERF",
+                "tipo": Programa.TipoPrograma.ACOMPANAMIENTO_SOCIAL,
+                "descripcion": "Programa sintético para mediciones de performance.",
+                "naturaleza": Programa.Naturaleza.PERSISTENTE,
+                "estado": Programa.Estado.ACTIVO,
+                "orden": 900,
+            },
+        )
+
+        segment_count = max(10, scale // 10)
+        segmentos = []
+        convocatorias = []
+        territoriales = []
+        for index in range(segment_count):
+            segmento, _ = Segmento.objects.update_or_create(
+                nombre=f"PERF Segmento {index:03d}",
+                defaults={
+                    "descripcion": "Segmento sintético para auditoría de performance.",
+                    "cupo_maximo": max(scale, 200),
+                    "requiere_gps": index % 2 == 0,
+                    "activo": True,
+                },
+            )
+            subsegmento, _ = Subsegmento.objects.update_or_create(
+                segmento=segmento,
+                nombre=f"PERF Subsegmento {index:03d}",
+                defaults={"descripcion": "Subsegmento sintético.", "cupo_maximo": max(scale // 2, 100)},
+            )
+            CupoSegmento.objects.update_or_create(segmento=segmento, defaults={"cupo_ocupado": 0})
+            RequisitoNativo.objects.update_or_create(
+                segmento=segmento,
+                subsegmento=None,
+                texto=f"PERF requisito {index:03d}",
+                defaults={"tipo": TipoCampo.STRING, "orden": 900 + index, "obligatorio": True},
+            )
+            territorial = _ensure_user(
+                f"perf_territorial_{index:03d}",
+                first_name=f"Territorial {index:03d}",
+                last_name="Performance",
+            )
+            _set_groups(territorial, ROL_TERRITORIAL)
+            AsignacionCoordinador.objects.update_or_create(
+                segmento=segmento,
+                coordinador=coordinator,
+                defaults={"activo": True},
+            )
+            AsignacionTerritorial.objects.update_or_create(
+                territorial=territorial,
+                defaults={"segmento": segmento},
+            )
+            convocatoria, _ = Convocatoria.objects.update_or_create(
+                nombre=f"PERF Convocatoria {index:03d}",
+                segmento=segmento,
+                defaults={
+                    "subsegmento": subsegmento,
+                    "fecha_inicio": date(2025, 1, 1),
+                    "fecha_fin": date(2030, 12, 31),
+                    "descripcion": "Convocatoria sintética para auditoría de performance.",
+                    "activo": True,
+                },
+            )
+            segmentos.append(segmento)
+            convocatorias.append(convocatoria)
+            territoriales.append(territorial)
+
+        relevamientos = []
+        for index in range(scale):
+            bucket = 0 if index < min(50, scale) else index % segment_count
+            relevamiento, _ = Relevamiento.objects.update_or_create(
+                nombre=f"PERF Relevamiento {index:04d}",
+                defaults={
+                    "convocatoria": convocatorias[bucket],
+                    "territorial": territoriales[bucket],
+                    "fecha_asignada": date(2025, 2, 1) + timedelta(days=index % 28),
+                    "zona": f"Zona PERF {bucket:03d}",
+                    "observaciones": "Relevamiento sintético para auditoría de performance.",
+                    "estado": Relevamiento.Estado.EN_REVISION,
+                },
+            )
+            relevamientos.append(relevamiento)
+
+        ciudadanos = []
+        fixed_start = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        for index in range(scale):
+            dni = str(80000000 + index)
+            ciudadano, _ = Ciudadano.objects.update_or_create(
+                dni=dni,
+                defaults={
+                    "nombre": f"Nombre PERF {index:04d}",
+                    "apellido": f"Apellido PERF {index:04d}",
+                    "fecha_nacimiento": date(1980 + index % 30, index % 12 + 1, index % 27 + 1),
+                    "genero": Ciudadano.Genero.MASCULINO if index % 2 == 0 else Ciudadano.Genero.FEMENINO,
+                    "telefono": f"3704{index:06d}",
+                    "email": f"ciudadano{index:04d}@perf.invalid",
+                    "domicilio": f"Calle PERF {index}",
+                    "provincia": provincia,
+                    "municipio": municipio,
+                    "localidad": localidad,
+                    "activo": True,
+                    "usuario": citizen_user if index == 0 else None,
+                    "tipo_vivienda": Ciudadano.TipoVivienda.PROPIA,
+                    "tenencia_vivienda": Ciudadano.TenenciaVivienda.TITULAR,
+                    "condiciones_vivienda": "Condiciones sintéticas " + ("x" * 256),
+                    "situacion_laboral": Ciudadano.SituacionLaboral.EMPLEADO_FORMAL,
+                    "ingreso_estimado": Ciudadano.IngresoEstimado.ENTRE_1_2_CBT,
+                    "nivel_educativo": Ciudadano.NivelEducativo.SECUNDARIO_COMPLETO,
+                    "cobertura_medica": "Cobertura PERF",
+                    "medicacion_habitual": "Sin medicación habitual",
+                    "dni_fisico": Ciudadano.DniFisico.TIENE,
+                    "estado_renaper": Ciudadano.EstadoRenaper.REGISTRADO,
+                    "estado_migratorio": Ciudadano.EstadoMigratorio.NACIONAL,
+                    "observaciones": "Observación sintética " + ("y" * 512),
+                },
+            )
+            legajo, _ = LegajoAtencion.objects.update_or_create(
+                codigo=f"PERF-LEG-{index:05d}",
+                defaults={
+                    "responsable": operators[index % len(operators)],
+                    "estado": LegajoAtencion.Estado.EN_SEGUIMIENTO,
+                    "via_ingreso": LegajoAtencion.ViaIngreso.ESPONTANEA,
+                    "plan_vigente": index % 2 == 0,
+                    "nivel_riesgo": "ALTO" if index % 20 == 0 else "BAJO",
+                    "notas": "Notas sintéticas " + ("z" * 512),
+                },
+            )
+            inscripcion, _ = InscripcionPrograma.objects.update_or_create(
+                ciudadano=ciudadano,
+                programa=becas,
+                defaults={
+                    "estado": InscripcionPrograma.Estado.ACTIVO,
+                    "via_ingreso": InscripcionPrograma.ViaIngreso.DIRECTO,
+                    "responsable": operators[index % len(operators)],
+                    "legajo_id": legajo.pk,
+                    "notas": "Inscripción sintética PERF.",
+                },
+            )
+            InscripcionPrograma.objects.update_or_create(
+                ciudadano=ciudadano,
+                programa=apoyo,
+                defaults={
+                    "estado": InscripcionPrograma.Estado.EN_SEGUIMIENTO,
+                    "via_ingreso": InscripcionPrograma.ViaIngreso.DERIVACION_INTERNA,
+                    "responsable": operators[index % len(operators)],
+                    "notas": "Segunda inscripción sintética PERF.",
+                },
+            )
+            DerivacionPrograma.objects.update_or_create(
+                ciudadano=ciudadano,
+                programa_destino=apoyo,
+                defaults={
+                    "programa_origen": becas,
+                    "inscripcion_origen": inscripcion,
+                    "motivo": f"PERF derivación {index:04d}",
+                    "urgencia": DerivacionPrograma.Urgencia.MEDIA,
+                    "estado": DerivacionPrograma.Estado.PENDIENTE,
+                    "derivado_por": admin,
+                },
+            )
+            HistorialContacto.objects.update_or_create(
+                legajo=legajo,
+                motivo=f"PERF contacto {index:04d}",
+                defaults={
+                    "tipo_contacto": "LLAMADA",
+                    "fecha_contacto": fixed_start + timedelta(minutes=index),
+                    "duracion_minutos": 15,
+                    "profesional": operators[index % len(operators)],
+                    "estado": "EXITOSO",
+                    "resumen": "Resumen sintético para auditoría de performance.",
+                    "acuerdos": "Acuerdo sintético.",
+                    "proximos_pasos": "Seguimiento sintético.",
+                    "seguimiento_requerido": index % 3 == 0,
+                },
+            )
+            AlertaCiudadano.objects.update_or_create(
+                ciudadano=ciudadano,
+                tipo=AlertaCiudadano.TipoAlerta.SIN_PLAN,
+                mensaje=f"PERF alerta {index:04d}",
+                defaults={
+                    "legajo": legajo,
+                    "prioridad": AlertaCiudadano.Prioridad.ALTA if index % 20 == 0 else AlertaCiudadano.Prioridad.MEDIA,
+                    "activa": True,
+                },
+            )
+            form_relevamiento = relevamientos[0] if index < min(50, scale) else relevamientos[index]
+            Formulario.objects.update_or_create(
+                relevamiento=form_relevamiento,
+                ciudadano=ciudadano,
+                defaults={
+                    "estado": Formulario.Estado.ENVIADO,
+                    "validado_renaper": index % 2 == 0,
+                    "celular": f"3704{index:06d}",
+                    "email_contacto": f"formulario{index:04d}@perf.invalid",
+                    "data": {"origen": PERF_PREFIX, "indice": index, "texto": "d" * 512},
+                    "created_by": territoriales[index % segment_count],
+                },
+            )
+            ciudadanos.append(ciudadano)
+
+        if len(ciudadanos) > 1:
+            for index, ciudadano in enumerate(ciudadanos):
+                VinculoFamiliar.objects.update_or_create(
+                    ciudadano_principal=ciudadano,
+                    ciudadano_vinculado=ciudadanos[(index + 1) % len(ciudadanos)],
+                    tipo_vinculo="REFERENTE",
+                    defaults={"activo": True, "es_contacto_emergencia": index % 4 == 0},
+                )
+
+        conversation_times = [fixed_start + timedelta(days=1, minutes=index) for index in range(scale)]
+        existing = {
+            conversation.fecha_inicio: conversation
+            for conversation in Conversacion.objects.filter(
+                ciudadano_usuario=citizen_user,
+                fecha_inicio__in=conversation_times,
+            )
+        }
+        missing = []
+        for index, started_at in enumerate(conversation_times):
+            if started_at in existing:
+                continue
+            missing.append(
+                Conversacion(
+                    tipo="personal",
+                    estado=("pendiente", "activa", "cerrada")[index % 3],
+                    prioridad=("normal", "alta", "urgente")[index % 3],
+                    dni_ciudadano=PERF_FIRST_DNI,
+                    fecha_inicio=started_at,
+                    operador_asignado=None if index % 3 == 0 else operators[index % len(operators)],
+                    ciudadano_usuario=citizen_user,
+                )
+            )
+        Conversacion.objects.bulk_create(missing)
+        conversations = list(
+            Conversacion.objects.filter(ciudadano_usuario=citizen_user, fecha_inicio__in=conversation_times).order_by(
+                "fecha_inicio"
+            )
+        )
+        for index, conversation in enumerate(conversations):
+            conversation.tipo = "personal"
+            conversation.estado = ("pendiente", "activa", "cerrada")[index % 3]
+            conversation.prioridad = ("normal", "alta", "urgente")[index % 3]
+            conversation.dni_ciudadano = PERF_FIRST_DNI
+            conversation.operador_asignado = None if index % 3 == 0 else operators[index % len(operators)]
+            conversation.ciudadano_usuario = citizen_user
+        Conversacion.objects.bulk_update(
+            conversations,
+            ["tipo", "estado", "prioridad", "dni_ciudadano", "operador_asignado", "ciudadano_usuario"],
+        )
+
+        expected_messages = []
+        for index, conversation in enumerate(conversations):
+            message_count = 50 if index == 0 else 4
+            for message_index in range(message_count):
+                expected_messages.append(
+                    Mensaje(
+                        conversacion=conversation,
+                        remitente="ciudadano" if message_index % 2 == 0 else "operador",
+                        contenido=f"PERF-MSG-{index:04d}-{message_index:02d} " + ("m" * 128),
+                        fecha_envio=conversation.fecha_inicio + timedelta(seconds=message_index),
+                        leido=message_index % 3 == 0,
+                    )
+                )
+        existing_contents = set(
+            Mensaje.objects.filter(contenido__startswith="PERF-MSG-").values_list("contenido", flat=True)
+        )
+        Mensaje.objects.bulk_create(
+            [message for message in expected_messages if message.contenido not in existing_contents]
+        )
+        expected_by_content = {message.contenido: message for message in expected_messages}
+        stored_messages = list(Mensaje.objects.filter(contenido__in=expected_by_content))
+        for message in stored_messages:
+            expected = expected_by_content[message.contenido]
+            message.conversacion = expected.conversacion
+            message.remitente = expected.remitente
+            message.fecha_envio = expected.fecha_envio
+            message.leido = expected.leido
+        Mensaje.objects.bulk_update(stored_messages, ["conversacion", "remitente", "fecha_envio", "leido"])
+
+        cache.clear()
+        self.stdout.write(
+            self.style.SUCCESS(
+                "seed_perf completo: "
+                f"{scale} ciudadanos/legajos/conversaciones/formularios, "
+                f"{len(relevamientos)} relevamientos y {segment_count} segmentos. "
+                "Trámites: no aplicable (módulo actual sin modelos/rutas)."
+            )
+        )

--- a/core/management/commands/seed_perf.py
+++ b/core/management/commands/seed_perf.py
@@ -77,7 +77,8 @@ class Command(BaseCommand):
         if (
             os.environ.get("PYTEST_RUNNING") != "1"
             or connection.vendor != "sqlite"
-            or connection.settings_dict.get("NAME") not in (":memory:", "file:memorydb_default?mode=memory&cache=shared")
+            or connection.settings_dict.get("NAME")
+            not in (":memory:", "file:memorydb_default?mode=memory&cache=shared")
         ):
             raise CommandError("seed_perf solo puede ejecutarse con PYTEST_RUNNING=1 y SQLite in-memory")
 

--- a/scripts/perf_audit.py
+++ b/scripts/perf_audit.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python
+"""Auditoría mecánica y reproducible de performance para superficies Django clave."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import sys
+import time
+from collections import Counter
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO / "scripts" / "perf_baseline.json"
+WARM_SAMPLE_COUNT = 3
+
+HEX_BLOB_RE = re.compile(r"\b(?:0x[0-9a-f]+|x'[0-9a-f]+')\b", re.IGNORECASE)
+SQL_STRING_RE = re.compile(r"'(?:''|\\.|[^'])*'")
+SQL_NUMBER_RE = re.compile(r"(?<![\w])[-+]?\d+(?:\.\d+)?(?![\w])")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def bootstrap_django():
+    """Carga Django únicamente contra la SQLite in-memory usada por tests."""
+    os.environ["PYTEST_RUNNING"] = "1"
+    os.environ["DJANGO_SYNCDB_PROJECT_APPS"] = "True"
+    os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"
+    os.environ["DJANGO_SECRET_KEY"] = "perf-audit-test-key"
+    os.environ["DJANGO_DEBUG"] = "False"
+    os.environ["DJANGO_ALLOWED_HOSTS"] = "testserver,localhost"
+    os.environ["ENVIRONMENT"] = "dev"
+
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+
+    import django
+
+    django.setup()
+
+    from django.conf import settings
+
+    database = settings.DATABASES["default"]
+    if database["ENGINE"] != "django.db.backends.sqlite3" or database["NAME"] != ":memory:":
+        raise RuntimeError("perf_audit se negó a iniciar: la base configurada no es SQLite in-memory")
+
+
+def normalize_sql(sql: str) -> str:
+    """Elimina valores variables para comparar la forma de dos queries."""
+    normalized = HEX_BLOB_RE.sub("?", sql)
+    normalized = SQL_STRING_RE.sub("?", normalized)
+    normalized = SQL_NUMBER_RE.sub("?", normalized)
+    return WHITESPACE_RE.sub(" ", normalized).strip()
+
+
+def duplicate_query_groups(captured_queries):
+    groups = Counter(normalize_sql(query.get("sql", "")) for query in captured_queries)
+    repeated = [
+        {
+            "occurrences": occurrences,
+            "duplicates": occurrences - 1,
+            "sql": sql[:500],
+        }
+        for sql, occurrences in groups.items()
+        if occurrences > 1
+    ]
+    repeated.sort(key=lambda item: (-item["occurrences"], item["sql"]))
+    return repeated
+
+
+def build_targets():
+    """Resuelve el manifiesto después del seed, fuera de la captura SQL."""
+    from django.urls import reverse
+
+    from conversaciones.models import Conversacion
+    from core.management.commands.seed_perf import PERF_ADMIN_USERNAME, PERF_CITIZEN_USERNAME, PERF_FIRST_DNI
+    from legajos.models import Ciudadano
+    from programas.models import Relevamiento
+
+    ciudadano = Ciudadano.objects.get(dni=PERF_FIRST_DNI)
+    conversacion = (
+        Conversacion.objects.filter(ciudadano_usuario__username=PERF_CITIZEN_USERNAME)
+        .order_by("fecha_inicio")
+        .first()
+    )
+    relevamiento = Relevamiento.objects.get(nombre="PERF Relevamiento 0000")
+
+    if conversacion is None:
+        raise RuntimeError("seed_perf no creó la conversación PERF requerida")
+
+    return {
+        "actors": {
+            "backoffice": PERF_ADMIN_USERNAME,
+            "citizen": PERF_CITIZEN_USERNAME,
+        },
+        "targets": [
+            {"key": "login", "route": "users:login", "url": reverse("users:login"), "actor": "anonymous"},
+            {"key": "inicio", "route": "core:inicio", "url": reverse("core:inicio"), "actor": "backoffice"},
+            {
+                "key": "dashboard_redirect",
+                "route": "core:dashboard",
+                "url": reverse("core:dashboard"),
+                "actor": "backoffice",
+                "expected_status": 302,
+                "expected_redirect_view": "users:login",
+            },
+            {
+                "key": "dashboard_metricas",
+                "route": "dashboard:api_metricas",
+                "url": reverse("dashboard:api_metricas"),
+                "actor": "backoffice",
+            },
+            {
+                "key": "legajos_lista",
+                "route": "legajos:ciudadanos",
+                "url": reverse("legajos:ciudadanos"),
+                "actor": "backoffice",
+            },
+            {
+                "key": "legajo_detalle",
+                "route": "legajos:ciudadano_detalle",
+                "url": reverse("legajos:ciudadano_detalle", kwargs={"pk": ciudadano.pk}),
+                "actor": "backoffice",
+            },
+            {
+                "key": "conversaciones_lista",
+                "route": "conversaciones:lista",
+                "url": reverse("conversaciones:lista"),
+                "actor": "backoffice",
+            },
+            {
+                "key": "conversacion_detalle",
+                "route": "conversaciones:detalle",
+                "url": reverse("conversaciones:detalle", kwargs={"conversacion_id": conversacion.pk}),
+                "actor": "backoffice",
+            },
+            {"key": "portal_home", "route": "portal:home", "url": reverse("portal:home"), "actor": "anonymous"},
+            {
+                "key": "portal_perfil",
+                "route": "portal:ciudadano_mi_perfil",
+                "url": reverse("portal:ciudadano_mi_perfil"),
+                "actor": "citizen",
+            },
+            {
+                "key": "portal_programas",
+                "route": "portal:ciudadano_mis_programas",
+                "url": reverse("portal:ciudadano_mis_programas"),
+                "actor": "citizen",
+            },
+            {
+                "key": "portal_consultas",
+                "route": "portal:ciudadano_mis_consultas",
+                "url": reverse("portal:ciudadano_mis_consultas"),
+                "actor": "citizen",
+            },
+            {
+                "key": "becas_segmentos",
+                "route": "becas:segmentos",
+                "url": reverse("becas:segmentos"),
+                "actor": "backoffice",
+            },
+            {
+                "key": "becas_convocatorias",
+                "route": "becas:convocatorias",
+                "url": reverse("becas:convocatorias"),
+                "actor": "backoffice",
+            },
+            {
+                "key": "becas_relevamientos",
+                "route": "becas:relevamientos",
+                "url": reverse("becas:relevamientos"),
+                "actor": "backoffice",
+            },
+            {
+                "key": "becas_relevamiento_detalle",
+                "route": "becas:relevamiento_detalle",
+                "url": reverse("becas:relevamiento_detalle", kwargs={"pk": relevamiento.pk}),
+                "actor": "backoffice",
+            },
+        ],
+    }
+
+
+def build_clients(actor_usernames):
+    from django.contrib.auth import get_user_model
+    from django.test import Client
+
+    user_model = get_user_model()
+    clients = {
+        "anonymous": Client(raise_request_exception=False),
+        "backoffice": Client(raise_request_exception=False),
+        "citizen": Client(raise_request_exception=False),
+    }
+    clients["backoffice"].force_login(user_model.objects.get(username=actor_usernames["backoffice"]))
+    clients["citizen"].force_login(user_model.objects.get(username=actor_usernames["citizen"]))
+    return clients
+
+
+def _resolved_view(url):
+    from django.urls import Resolver404, resolve
+
+    try:
+        return resolve(urlparse(url).path).view_name
+    except Resolver404:
+        return None
+
+
+def _capture_request(client, url):
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    with CaptureQueriesContext(connection) as captured:
+        started = time.perf_counter_ns()
+        response = client.get(url, follow=False)
+        body = response.content
+        duration_ms = (time.perf_counter_ns() - started) / 1_000_000
+
+    duplicate_groups = duplicate_query_groups(captured.captured_queries)
+    return {
+        "response": response,
+        "body": body,
+        "query_count": len(captured),
+        "duplicate_query_count": sum(group["duplicates"] for group in duplicate_groups),
+        "duration_ms": duration_ms,
+        "duplicate_groups": duplicate_groups,
+    }
+
+
+def measure_target(target, client):
+    from django.core.cache import cache
+
+    cache.clear()
+    cold = _capture_request(client, target["url"])
+    warm_samples = [_capture_request(client, target["url"]) for _ in range(WARM_SAMPLE_COUNT)]
+
+    response = cold["response"]
+    body = cold["body"]
+
+    redirect_to = response.get("Location") if 300 <= response.status_code < 400 else None
+    redirect_view = _resolved_view(urljoin(target["url"], redirect_to)) if redirect_to else None
+    result = {
+        "key": target["key"],
+        "route": target["route"],
+        "url": target["url"],
+        "actor": target["actor"],
+        "resolved_view": _resolved_view(target["url"]),
+        "status_code": response.status_code,
+        "redirect_to": redirect_to,
+        "redirect_resolved_view": redirect_view,
+        "query_count": cold["query_count"],
+        "duplicate_query_count": cold["duplicate_query_count"],
+        "duration_ms": round(cold["duration_ms"], 2),
+        "warm_sample_count": WARM_SAMPLE_COUNT,
+        "warm_query_count": int(statistics.median(sample["query_count"] for sample in warm_samples)),
+        "warm_duplicate_query_count": int(
+            statistics.median(sample["duplicate_query_count"] for sample in warm_samples)
+        ),
+        "warm_duration_ms": round(statistics.median(sample["duration_ms"] for sample in warm_samples), 2),
+        "response_bytes": len(body),
+        "content_type": response.get("Content-Type", ""),
+        "duplicate_groups": cold["duplicate_groups"][:10],
+    }
+    expected_status = target.get("expected_status", 200)
+    errors = []
+    if response.status_code != expected_status:
+        errors.append(f"status {response.status_code}, esperado {expected_status}")
+    warm_statuses = {sample["response"].status_code for sample in warm_samples}
+    if warm_statuses != {expected_status}:
+        errors.append(f"status warm {sorted(warm_statuses)}, esperado solo {expected_status}")
+    if result["resolved_view"] != target["route"]:
+        errors.append(f"resuelve a {result['resolved_view']!r}, esperado {target['route']!r}")
+    expected_redirect_view = target.get("expected_redirect_view")
+    if expected_redirect_view and redirect_view != expected_redirect_view:
+        errors.append(f"redirect resuelve a {redirect_view!r}, esperado {expected_redirect_view!r}")
+    return result, errors
+
+
+def create_report(scale):
+    manifest = build_targets()
+    clients = build_clients(manifest["actors"])
+    results = []
+    failures = []
+    for target in manifest["targets"]:
+        result, errors = measure_target(target, clients[target["actor"]])
+        results.append(result)
+        if errors:
+            failures.append(f"{target['key']}: {'; '.join(errors)}")
+
+    report = {
+        "schema_version": 1,
+        "environment": {
+            "database": "sqlite-memory",
+            "scale": scale,
+            "cache_state": "cold request plus median of 3 warm requests per URL; primary fields are cold",
+            "duplicate_definition": "sum(occurrences - 1) for normalized SQL repeated in one request",
+            "timing_scope": "Django test client + middleware + render; no network/application server",
+        },
+        "coverage_notes": [
+            "dashboard_redirect documents that /dashboard/ redirects to the shadowed users login at /.",
+            "tramites is not measured because the current app has no models, views or URL patterns.",
+            "SQLite timings and query plans are not representative of MySQL production.",
+        ],
+        "summary": {
+            "url_count": len(results),
+            "successful_2xx": sum(1 for result in results if 200 <= result["status_code"] < 300),
+            "total_queries": sum(result["query_count"] for result in results),
+            "total_duplicate_queries": sum(result["duplicate_query_count"] for result in results),
+            "total_duration_ms": round(sum(result["duration_ms"] for result in results), 2),
+            "total_warm_queries": sum(result["warm_query_count"] for result in results),
+            "total_warm_duplicate_queries": sum(result["warm_duplicate_query_count"] for result in results),
+            "total_warm_duration_ms": round(sum(result["warm_duration_ms"] for result in results), 2),
+            "total_response_bytes": sum(result["response_bytes"] for result in results),
+        },
+        "results": results,
+    }
+    return report, failures
+
+
+def write_report(report, output):
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    temporary.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(output)
+
+
+def print_report(report):
+    print("\nPerformance baseline (cold + mediana de 3 warm por URL)")
+    print(f"{'URL':30} {'St':>3} {'Qc':>5} {'Qw':>5} {'Dc':>4} {'Dw':>4} {'ms c':>8} {'ms w':>8} {'Bytes':>9}")
+    print("-" * 88)
+    for result in report["results"]:
+        print(
+            f"{result['key'][:30]:30} {result['status_code']:>3} "
+            f"{result['query_count']:>5} {result['warm_query_count']:>5} "
+            f"{result['duplicate_query_count']:>4} {result['warm_duplicate_query_count']:>4} "
+            f"{result['duration_ms']:>8.2f} {result['warm_duration_ms']:>8.2f} {result['response_bytes']:>9}"
+        )
+
+    ranked = sorted(
+        (result for result in report["results"] if 200 <= result["status_code"] < 300),
+        key=lambda result: (-result["query_count"], -result["duplicate_query_count"], result["key"]),
+    )[:10]
+    print("\nTop 10 por queries cold (solo respuestas 2xx)")
+    for position, result in enumerate(ranked, 1):
+        print(
+            f"{position:>2}. {result['key']}: {result['query_count']} queries, "
+            f"{result['duplicate_query_count']} duplicadas, {result['duration_ms']:.2f} ms"
+        )
+
+    duplicated = sorted(
+        (result for result in report["results"] if 200 <= result["status_code"] < 300),
+        key=lambda result: (-result["duplicate_query_count"], -result["query_count"], result["key"]),
+    )[:10]
+    print("\nTop 10 por queries duplicadas cold (solo respuestas 2xx)")
+    for position, result in enumerate(duplicated, 1):
+        print(
+            f"{position:>2}. {result['key']}: {result['duplicate_query_count']} duplicadas "
+            f"sobre {result['query_count']} queries"
+        )
+
+
+def run(scale, output):
+    bootstrap_django()
+
+    from django.test.runner import DiscoverRunner
+
+    runner = DiscoverRunner(verbosity=0, interactive=False)
+    old_config = None
+    environment_ready = False
+    try:
+        runner.setup_test_environment()
+        environment_ready = True
+        old_config = runner.setup_databases()
+        seed_output = StringIO()
+        with redirect_stdout(seed_output), redirect_stderr(seed_output):
+            from django.core.management import call_command
+
+            call_command("seed_perf", scale=scale, verbosity=0)
+        report, failures = create_report(scale)
+        print_report(report)
+        if failures:
+            print("\nAudit abortado; no se escribió el baseline:", file=sys.stderr)
+            for failure in failures:
+                print(f"  - {failure}", file=sys.stderr)
+            return 1
+        write_report(report, output)
+        try:
+            display_output = output.relative_to(REPO)
+        except ValueError:
+            display_output = output
+        print(f"\nBaseline escrito en {display_output}")
+        return 0
+    finally:
+        if old_config is not None:
+            runner.teardown_databases(old_config)
+        if environment_ready:
+            runner.teardown_test_environment()
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scale", type=int, default=200)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args(argv)
+    if args.scale < 1:
+        parser.error("--scale debe ser mayor que cero")
+    output = args.output if args.output.is_absolute() else REPO / args.output
+    return run(args.scale, output)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/perf_audit.py
+++ b/scripts/perf_audit.py
@@ -31,7 +31,7 @@ def bootstrap_django():
     os.environ["PYTEST_RUNNING"] = "1"
     os.environ["DJANGO_SYNCDB_PROJECT_APPS"] = "True"
     os.environ["DJANGO_SETTINGS_MODULE"] = "config.settings"
-    os.environ["DJANGO_SECRET_KEY"] = "perf-audit-test-key"
+    os.environ.setdefault("DJANGO_SECRET_KEY", "test-key")
     os.environ["DJANGO_DEBUG"] = "False"
     os.environ["DJANGO_ALLOWED_HOSTS"] = "testserver,localhost"
     os.environ["ENVIRONMENT"] = "dev"
@@ -84,9 +84,7 @@ def build_targets():
 
     ciudadano = Ciudadano.objects.get(dni=PERF_FIRST_DNI)
     conversacion = (
-        Conversacion.objects.filter(ciudadano_usuario__username=PERF_CITIZEN_USERNAME)
-        .order_by("fecha_inicio")
-        .first()
+        Conversacion.objects.filter(ciudadano_usuario__username=PERF_CITIZEN_USERNAME).order_by("fecha_inicio").first()
     )
     relevamiento = Relevamiento.objects.get(nombre="PERF Relevamiento 0000")
 

--- a/scripts/perf_baseline.json
+++ b/scripts/perf_baseline.json
@@ -1,0 +1,482 @@
+{
+  "schema_version": 1,
+  "environment": {
+    "database": "sqlite-memory",
+    "scale": 200,
+    "cache_state": "cold request plus median of 3 warm requests per URL; primary fields are cold",
+    "duplicate_definition": "sum(occurrences - 1) for normalized SQL repeated in one request",
+    "timing_scope": "Django test client + middleware + render; no network/application server"
+  },
+  "coverage_notes": [
+    "dashboard_redirect documents that /dashboard/ redirects to the shadowed users login at /.",
+    "tramites is not measured because the current app has no models, views or URL patterns.",
+    "SQLite timings and query plans are not representative of MySQL production."
+  ],
+  "summary": {
+    "url_count": 16,
+    "successful_2xx": 15,
+    "total_queries": 221,
+    "total_duplicate_queries": 38,
+    "total_duration_ms": 237.83,
+    "total_warm_queries": 182,
+    "total_warm_duplicate_queries": 35,
+    "total_warm_duration_ms": 148.17,
+    "total_response_bytes": 2301900
+  },
+  "results": [
+    {
+      "key": "login",
+      "route": "users:login",
+      "url": "/",
+      "actor": "anonymous",
+      "resolved_view": "users:login",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 0,
+      "duplicate_query_count": 0,
+      "duration_ms": 23.49,
+      "warm_sample_count": 3,
+      "warm_query_count": 0,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 0.78,
+      "response_bytes": 12097,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": []
+    },
+    {
+      "key": "inicio",
+      "route": "core:inicio",
+      "url": "/inicio/",
+      "actor": "backoffice",
+      "resolved_view": "core:inicio",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 22,
+      "duplicate_query_count": 3,
+      "duration_ms": 26.88,
+      "warm_sample_count": 3,
+      "warm_query_count": 14,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 10.98,
+      "response_bytes": 184863,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT COUNT(*) AS \"__count\" FROM \"conversaciones_conversacion\" WHERE (\"conversaciones_conversacion\".\"estado\" = ? AND \"conversaciones_conversacion\".\"operador_asignado_id\" IS NULL)"
+        }
+      ]
+    },
+    {
+      "key": "dashboard_redirect",
+      "route": "core:dashboard",
+      "url": "/dashboard/",
+      "actor": "backoffice",
+      "resolved_view": "core:dashboard",
+      "status_code": 302,
+      "redirect_to": "/",
+      "redirect_resolved_view": "users:login",
+      "query_count": 3,
+      "duplicate_query_count": 0,
+      "duration_ms": 1.23,
+      "warm_sample_count": 3,
+      "warm_query_count": 3,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 1.06,
+      "response_bytes": 0,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": []
+    },
+    {
+      "key": "dashboard_metricas",
+      "route": "dashboard:api_metricas",
+      "url": "/api/metricas/",
+      "actor": "backoffice",
+      "resolved_view": "dashboard:api_metricas",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 10,
+      "duplicate_query_count": 0,
+      "duration_ms": 3.14,
+      "warm_sample_count": 3,
+      "warm_query_count": 3,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 1.15,
+      "response_bytes": 185,
+      "content_type": "application/json",
+      "duplicate_groups": []
+    },
+    {
+      "key": "legajos_lista",
+      "route": "legajos:ciudadanos",
+      "url": "/legajos/ciudadanos/",
+      "actor": "backoffice",
+      "resolved_view": "legajos:ciudadanos",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 18,
+      "duplicate_query_count": 3,
+      "duration_ms": 10.28,
+      "warm_sample_count": 3,
+      "warm_query_count": 11,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 7.46,
+      "response_bytes": 172986,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT COUNT(*) AS \"__count\" FROM \"legajos_ciudadano\" WHERE \"legajos_ciudadano\".\"activo\""
+        }
+      ]
+    },
+    {
+      "key": "legajo_detalle",
+      "route": "legajos:ciudadano_detalle",
+      "url": "/legajos/ciudadanos/1/",
+      "actor": "backoffice",
+      "resolved_view": "legajos:ciudadano_detalle",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 41,
+      "duplicate_query_count": 17,
+      "duration_ms": 30.1,
+      "warm_sample_count": 3,
+      "warm_query_count": 40,
+      "warm_duplicate_query_count": 17,
+      "warm_duration_ms": 20.15,
+      "response_bytes": 263515,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 15,
+          "duplicates": 14,
+          "sql": "SELECT \"auth_user\".\"id\", \"auth_user\".\"password\", \"auth_user\".\"last_login\", \"auth_user\".\"is_superuser\", \"auth_user\".\"username\", \"auth_user\".\"first_name\", \"auth_user\".\"last_name\", \"auth_user\".\"email\", \"auth_user\".\"is_staff\", \"auth_user\".\"is_active\", \"auth_user\".\"date_joined\" FROM \"auth_user\" WHERE \"auth_user\".\"id\" = ? LIMIT ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"programas_inscripcionprograma\".\"id\", \"programas_inscripcionprograma\".\"creado\", \"programas_inscripcionprograma\".\"modificado\", \"programas_inscripcionprograma\".\"ciudadano_id\", \"programas_inscripcionprograma\".\"programa_id\", \"programas_inscripcionprograma\".\"codigo\", \"programas_inscripcionprograma\".\"estado\", \"programas_inscripcionprograma\".\"via_ingreso\", \"programas_inscripcionprograma\".\"fecha_inscripcion\", \"programas_inscripcionprograma\".\"fecha_inicio\", \"programas_inscripcionprograma\".\"fecha_c"
+        }
+      ]
+    },
+    {
+      "key": "conversaciones_lista",
+      "route": "conversaciones:lista",
+      "url": "/conversaciones/",
+      "actor": "backoffice",
+      "resolved_view": "conversaciones:lista",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 17,
+      "duplicate_query_count": 3,
+      "duration_ms": 19.09,
+      "warm_sample_count": 3,
+      "warm_query_count": 13,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 14.48,
+      "response_bytes": 275492,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT COUNT(*) AS \"__count\" FROM \"conversaciones_conversacion\" WHERE (\"conversaciones_conversacion\".\"estado\" = ? AND \"conversaciones_conversacion\".\"operador_asignado_id\" IS NULL)"
+        }
+      ]
+    },
+    {
+      "key": "conversacion_detalle",
+      "route": "conversaciones:detalle",
+      "url": "/conversaciones/1/",
+      "actor": "backoffice",
+      "resolved_view": "conversaciones:detalle",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 15,
+      "duplicate_query_count": 2,
+      "duration_ms": 12.44,
+      "warm_sample_count": 3,
+      "warm_query_count": 14,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 8.38,
+      "response_bytes": 166829,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        }
+      ]
+    },
+    {
+      "key": "portal_home",
+      "route": "portal:home",
+      "url": "/portal/",
+      "actor": "anonymous",
+      "resolved_view": "portal:home",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 3,
+      "duplicate_query_count": 0,
+      "duration_ms": 4.14,
+      "warm_sample_count": 3,
+      "warm_query_count": 0,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 0.9,
+      "response_bytes": 44221,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": []
+    },
+    {
+      "key": "portal_perfil",
+      "route": "portal:ciudadano_mi_perfil",
+      "url": "/portal/mi-perfil/",
+      "actor": "citizen",
+      "resolved_view": "portal:ciudadano_mi_perfil",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 10,
+      "duplicate_query_count": 0,
+      "duration_ms": 8.73,
+      "warm_sample_count": 3,
+      "warm_query_count": 10,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 5.51,
+      "response_bytes": 39240,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": []
+    },
+    {
+      "key": "portal_programas",
+      "route": "portal:ciudadano_mis_programas",
+      "url": "/portal/mi-perfil/programas/",
+      "actor": "citizen",
+      "resolved_view": "portal:ciudadano_mis_programas",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 9,
+      "duplicate_query_count": 0,
+      "duration_ms": 7.01,
+      "warm_sample_count": 3,
+      "warm_query_count": 9,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 4.72,
+      "response_bytes": 27022,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": []
+    },
+    {
+      "key": "portal_consultas",
+      "route": "portal:ciudadano_mis_consultas",
+      "url": "/portal/mi-perfil/consultas/",
+      "actor": "citizen",
+      "resolved_view": "portal:ciudadano_mis_consultas",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 8,
+      "duplicate_query_count": 0,
+      "duration_ms": 19.95,
+      "warm_sample_count": 3,
+      "warm_query_count": 8,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 19.13,
+      "response_bytes": 353849,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": []
+    },
+    {
+      "key": "becas_segmentos",
+      "route": "becas:segmentos",
+      "url": "/becas/config/segmentos/",
+      "actor": "backoffice",
+      "resolved_view": "becas:segmentos",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 16,
+      "duplicate_query_count": 2,
+      "duration_ms": 20.46,
+      "warm_sample_count": 3,
+      "warm_query_count": 14,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 11.73,
+      "response_bytes": 213453,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        }
+      ]
+    },
+    {
+      "key": "becas_convocatorias",
+      "route": "becas:convocatorias",
+      "url": "/becas/convocatorias/",
+      "actor": "backoffice",
+      "resolved_view": "becas:convocatorias",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 15,
+      "duplicate_query_count": 2,
+      "duration_ms": 15.19,
+      "warm_sample_count": 3,
+      "warm_query_count": 13,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 12.66,
+      "response_bytes": 180102,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        }
+      ]
+    },
+    {
+      "key": "becas_relevamientos",
+      "route": "becas:relevamientos",
+      "url": "/becas/relevamientos/",
+      "actor": "backoffice",
+      "resolved_view": "becas:relevamientos",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 19,
+      "duplicate_query_count": 4,
+      "duration_ms": 20.06,
+      "warm_sample_count": 3,
+      "warm_query_count": 17,
+      "warm_duplicate_query_count": 4,
+      "warm_duration_ms": 16.28,
+      "response_bytes": 169478,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"programas_convocatoria\".\"id\", \"programas_convocatoria\".\"creado\", \"programas_convocatoria\".\"modificado\", \"programas_convocatoria\".\"nombre\", \"programas_convocatoria\".\"segmento_id\", \"programas_convocatoria\".\"subsegmento_id\", \"programas_convocatoria\".\"fecha_inicio\", \"programas_convocatoria\".\"fecha_fin\", \"programas_convocatoria\".\"descripcion\", \"programas_convocatoria\".\"activo\", \"programas_segmento\".\"id\", \"programas_segmento\".\"creado\", \"programas_segmento\".\"modificado\", \"programas_segmento\".\"n"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT DISTINCT \"auth_user\".\"id\", \"auth_user\".\"password\", \"auth_user\".\"last_login\", \"auth_user\".\"is_superuser\", \"auth_user\".\"username\", \"auth_user\".\"first_name\", \"auth_user\".\"last_name\", \"auth_user\".\"email\", \"auth_user\".\"is_staff\", \"auth_user\".\"is_active\", \"auth_user\".\"date_joined\", \"programas_asignacionterritorial\".\"id\", \"programas_asignacionterritorial\".\"creado\", \"programas_asignacionterritorial\".\"modificado\", \"programas_asignacionterritorial\".\"segmento_id\", \"programas_asignacionterritorial\".\""
+        }
+      ]
+    },
+    {
+      "key": "becas_relevamiento_detalle",
+      "route": "becas:relevamiento_detalle",
+      "url": "/becas/relevamientos/1/",
+      "actor": "backoffice",
+      "resolved_view": "becas:relevamiento_detalle",
+      "status_code": 200,
+      "redirect_to": null,
+      "redirect_resolved_view": null,
+      "query_count": 15,
+      "duplicate_query_count": 2,
+      "duration_ms": 15.64,
+      "warm_sample_count": 3,
+      "warm_query_count": 13,
+      "warm_duplicate_query_count": 2,
+      "warm_duration_ms": 12.8,
+      "response_bytes": 198568,
+      "content_type": "text/html; charset=utf-8",
+      "duplicate_groups": [
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
+        },
+        {
+          "occurrences": 2,
+          "duplicates": 1,
+          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Objetivo

Dejar una línea base reproducible de performance backend sin cambiar comportamiento funcional. Esta fase agrega datos sintéticos protegidos, un smoke auditado con el test client y el baseline que guiará la Fase 1.

Refs #162.

## Alcance

- `manage.py seed_perf --scale 200`: seed determinista e idempotente, namespaced con `PERF`, que reutiliza `seed_datos_base`.
- Protección estricta: solo corre con `PYTEST_RUNNING=1` y SQLite in-memory; rechaza cualquier otra base.
- Volumen representativo: 200 ciudadanos/legajos, relaciones, 200 conversaciones con 846 mensajes, usuarios con roles distintos y 200 relevamientos/formularios de Becas.
- `scripts/perf_audit.py`: levanta el entorno de test en un único proceso, seedea y recorre 16 rutas con clientes anónimo, backoffice y ciudadano.
- `scripts/perf_baseline.json`: snapshot commiteado de queries, SQL duplicado normalizado, tiempo y bytes de respuesta.
- No modifica vistas, templates, modelos, índices ni comportamiento de producción.

### Metodología

Cada ruta se mide primero con cache frío y luego tres veces con cache caliente; el JSON conserva la corrida fría como campo principal y la mediana caliente por separado. “Queries duplicadas” es la suma de `ocurrencias - 1` para SQL normalizado repetido dentro de una misma request.

Los tiempos cubren Django test client + middleware + render. Son orientativos porque usan SQLite in-memory; las queries y duplicados son la señal reproducible que se usará para decidir optimizaciones. No se extrapolan planes ni tiempos a MySQL.

## Línea base — top 10 por queries

| Ruta | Status | Queries frío / caliente | Duplicadas frío / caliente | Tiempo ms frío / caliente |
|---|---:|---:|---:|---:|
| `/legajos/ciudadanos/1/` | 200 | 41 / 40 | 17 / 17 | 30.10 / 20.15 |
| `/inicio/` | 200 | 22 / 14 | 3 / 2 | 26.88 / 10.98 |
| `/becas/relevamientos/` | 200 | 19 / 17 | 4 / 4 | 20.06 / 16.28 |
| `/legajos/ciudadanos/` | 200 | 18 / 11 | 3 / 2 | 10.28 / 7.46 |
| `/conversaciones/` | 200 | 17 / 13 | 3 / 2 | 19.09 / 14.48 |
| `/becas/config/segmentos/` | 200 | 16 / 14 | 2 / 2 | 20.46 / 11.73 |
| `/conversaciones/1/` | 200 | 15 / 14 | 2 / 2 | 12.44 / 8.38 |
| `/becas/convocatorias/` | 200 | 15 / 13 | 2 / 2 | 15.19 / 12.66 |
| `/becas/relevamientos/1/` | 200 | 15 / 13 | 2 / 2 | 15.64 / 12.80 |
| `/api/metricas/` | 200 | 10 / 3 | 0 / 0 | 3.14 / 1.15 |

Totales de las 16 rutas: 221 queries y 38 duplicadas en frío; 182 y 35 en caliente.

Hallazgos de cobertura:

- `/dashboard/` devuelve 302 a `/`, que hoy resuelve `users:login`; se registra como diagnóstico y no se corrige en esta fase.
- `tramites` no entra en el smoke porque la app actual no tiene modelos, vistas ni URLs.
- El listado de conversaciones emite `UnorderedObjectListWarning`; queda como evidencia para la Fase 1.
- Silk está instalado en DEBUG, pero no tiene `SilkyMiddleware` ni decoradores activos, por lo que hoy no perfila requests de punta a punta.

## Auditoría del módulo legacy

**Veredicto global:** la superficie está cableada y visible, pero no es una fuente de observabilidad confiable. Mezcla métricas de proceso con afirmaciones globales, silencia errores y contiene operaciones DDL/globales peligrosas. No se construirá encima ni se integrará con las guardas; el comando de logs de Fase 2 será la nueva fuente de verdad. Solo las invalidaciones de cache y el logging de requests actual demostraron valor real.

| Archivo | Veredicto |
|---|---|
| `core/performance/__init__.py` | Vacío; sin comportamiento. |
| `core/performance/cache_utils.py` | Única pieza materialmente activa: señales registradas desde `CoreConfig.ready()`. Invalida caches usados, aunque un `except` amplio puede dejar datos viejos y una key no tiene consumidor. Conservar hasta extraerla. |
| `core/performance/performance_analyzer.py` | Ejecutable pero engañoso: observa solo `connection.queries` del hilo actual, normalmente vacío en producción, y normaliza SQL de forma frágil. |
| `core/performance/monitoring.py` | Alimenta APIs, pero mezcla métricas por proceso con métricas globales; “conexiones”, presencia, throughput y estado del cache no representan lo que sus nombres prometen. Su middleware no está activo. |
| `core/performance/database_optimizations.py` | Manual y riesgoso: ejecuta `SET GLOBAL`/análisis MySQL, referencia tablas inexistentes y puede informar éxito parcial como total. No usar. |
| `core/performance/database_partitioning.py` | Código muerto/teatral: tablas inexistentes, “particionado” por índices y archivado sin transacción. Riesgo de pérdida si se adapta o activa. |
| `core/performance/advanced_connection_pool.py` | No conectado al ORM; abre conexiones PyMySQL paralelas propias. Añade consumo sin beneficiar requests. |
| `core/performance/advanced_partitioning.py` | No operativo y crítico si se activa: DDL inválido/campos inexistentes, archivado y potencial `DROP TABLE`, con errores silenciados. |
| `core/performance/intelligent_query_optimizer.py` | Lee `performance_schema` y emite recomendaciones genéricas; no optimiza queries y guarda estado por proceso. |
| `core/performance/intelligent_indexing.py` | Parser regex frágil; propone índices redundantes y puede ejecutar `CREATE INDEX` fuera de migraciones. No usar. |
| `core/performance/phase2_manager.py` | Orquestador teatral: threads efímeros desde comandos, éxitos después de errores silenciados y apagado que puede esperar workers dormidos. |
| `core/views/performance.py` | Dashboard/APIs realmente expuestos, con permisos desparejos. Una API depende del middleware inactivo y el endpoint de prueba Phase 2 puede disparar DDL síncrono. No apto como fuente de verdad. |
| `config/middlewares/query_counter.py` | No está en `MIDDLEWARE`; sus estadísticas no existen en runtime normal aunque una API las asume. |
| `config/middlewares/performance.py` | No está activo; no influye hoy. |
| `core/management/commands/analyze_performance.py` | Analiza la conexión nueva del propio comando, no tráfico real; resultado normalmente vacío. |
| `core/management/commands/monitor_performance.py` | Duerme y observa la conexión del comando, por lo que no monitorea requests del servidor. |
| `core/management/commands/performance_report.py` | Algunas consultas son reales, pero etiqueta cualquier cache como Redis y declara estado “optimizado” sin evidencia suficiente. |
| `core/management/commands/optimize_db.py` | Puede cambiar variables globales de MySQL y reportar éxito aunque pasos se omitan/fallen. No usar. |
| `core/management/commands/initialize_phase2.py` | El flag `--skip-partitioning` no gobierna correctamente el flujo; lanza threads efímeros y puede ejecutar DDL. |
| `core/management/commands/setup_system.py` | Mezcla migraciones, seeds, tuning global, collectstatic destructivo y reportes; pertenece a un arranque legacy, no al compose actual. |
| `legajos/management/commands/optimize_database.py` | Expone archivado y el falso particionado legacy fuera de migraciones. No usar. |

Limpieza propuesta para issue separado: retirar/aislar dashboard y endpoints legacy; eliminar middlewares y analizadores inactivos; remover pools/partitioners/DDL fuera de migraciones; extraer las señales útiles; retirar comandos/startup legacy; configurar Silk correctamente solo en dev o removerlo; y eliminar tolerancias de lint asociadas al código borrado.

No se creó el issue parcialmente: el token local de `gh` tiene `repo` y `workflow`, pero carece de `read:project`/`project`, scopes requeridos para agregarlo al Project #1 y dejarlo en Backlog. Comando requerido: `gh auth refresh -s read:project -s project`.

## Validación

- `manage.py check`: sin errores.
- `manage.py test`: 318 tests, todos verdes (`Ran 318 tests in 90.704s`).
- `scripts/perf_audit.py --scale 200`: ejecutado realmente dos veces; status, rutas, queries, duplicados y bytes estables entre corridas.
- Seed escala 200: idempotencia exacta y reconvergencia después de mutar fixtures verificadas.
- `ruff check`, `py_compile` y `git diff --check`: verdes.
