### PR TITLE
[Fase 1] Optimización backend guiada por baseline

### DIFF
--- a/conversaciones/context_processors.py
+++ b/conversaciones/context_processors.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.contrib.auth.models import Group
+from django.db.models import Prefetch, prefetch_related_objects
 from django.utils.asyncio import async_unsafe
 
 from core import rbac
@@ -9,7 +11,11 @@ def user_groups(request):
     """Context processor: datos de grupos (para JS) y flags de capacidad del usuario."""
     if request.user.is_authenticated:
         try:
-            groups = list(request.user.groups.values_list("name", flat=True))
+            prefetch_related_objects(
+                [request.user],
+                Prefetch("groups", queryset=Group.objects.order_by("pk")),
+            )
+            groups = [group.name for group in request.user.groups.all()]
         except Exception:
             groups = []
         return {

--- a/conversaciones/selectors/conversaciones.py
+++ b/conversaciones/selectors/conversaciones.py
@@ -55,6 +55,14 @@ def get_conversaciones_queryset_para_lista(user, filtros):
     return queryset
 
 
+def get_conversaciones_pendientes_count(user):
+    return cache.get_or_set(
+        f"sidebar:conversaciones_pendientes:user:{user.pk}",
+        lambda: Conversacion.objects.filter(estado="pendiente", operador_asignado__isnull=True).count(),
+        30,
+    )
+
+
 def get_estadisticas_lista():
     return get_estadisticas_tiempo_real()
 

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -7,7 +7,6 @@ no rompe el render: simplemente no muestra el badge).
 """
 
 from django.conf import settings
-from django.core.cache import cache
 
 from core import rbac
 
@@ -34,14 +33,11 @@ def sidebar_badges(request):
     # Conversaciones sin asignar (pendientes y sin operador)
     if rbac.puede(user, "conversacion.operar"):
         try:
-            from conversaciones.models import Conversacion
+            from conversaciones.selectors import get_conversaciones_pendientes_count
 
-            # Corre en todos los requests del backoffice: cache corto compartido.
-            badges["badge_conversaciones"] = cache.get_or_set(
-                "sidebar:conversaciones_pendientes",
-                lambda: Conversacion.objects.filter(estado="pendiente", operador_asignado__isnull=True).count(),
-                30,
-            )
+            # Corre en todos los requests del backoffice: cache corto por usuario,
+            # reutilizado también por la vista de inicio.
+            badges["badge_conversaciones"] = get_conversaciones_pendientes_count(user)
         except Exception:
             badges["badge_conversaciones"] = 0
 

--- a/core/views/public.py
+++ b/core/views/public.py
@@ -94,11 +94,12 @@ def inicio_view(request):
 
     try:
         from conversaciones.models import Conversacion
+        from conversaciones.selectors import get_conversaciones_pendientes_count
 
         conversaciones_sin_asignar = Conversacion.objects.filter(
             estado="pendiente", operador_asignado__isnull=True
         ).order_by("-fecha_inicio")
-        context["conversaciones_sin_asignar_count"] = conversaciones_sin_asignar.count()
+        context["conversaciones_sin_asignar_count"] = get_conversaciones_pendientes_count(request.user)
         context["conversaciones_sin_asignar"] = conversaciones_sin_asignar[:8]
     except Exception:
         context["conversaciones_sin_asignar_count"] = 0

--- a/dashboard/api_views/__init__.py
+++ b/dashboard/api_views/__init__.py
@@ -27,14 +27,16 @@ def metricas_dashboard(request):
 
 def _calcular_metricas_dashboard():
     total_ciudadanos = Ciudadano.objects.count()
-    legajos_activos = InscripcionPrograma.objects.filter(estado__in=["ACTIVO", "EN_SEGUIMIENTO"]).count()
     alertas_activas = AlertaCiudadano.objects.filter(activa=True).count()
 
     hoy = timezone.now().date()
-    seguimientos_hoy = InscripcionPrograma.objects.filter(fecha_inscripcion=hoy).count()
-
-    estados = InscripcionPrograma.objects.values("estado").annotate(count=Count("id"))
-    estados_dict = {estado["estado"]: estado["count"] for estado in estados}
+    inscripciones = InscripcionPrograma.objects.aggregate(
+        legajos_activos=Count("id", filter=Q(estado__in=["ACTIVO", "EN_SEGUIMIENTO"])),
+        seguimientos_hoy=Count("id", filter=Q(fecha_inscripcion=hoy)),
+        abiertos=Count("id", filter=Q(estado="ACTIVO")),
+        seguimiento=Count("id", filter=Q(estado="EN_SEGUIMIENTO")),
+        cerrados=Count("id", filter=Q(estado="CERRADO")),
+    )
 
     hace_24h = timezone.now() - timedelta(hours=24)
     usuarios_activos = User.objects.filter(last_login__gte=hace_24h).count()
@@ -42,15 +44,15 @@ def _calcular_metricas_dashboard():
     return {
         "metricas": {
             "ciudadanos": total_ciudadanos,
-            "legajos": legajos_activos,
-            "seguimientos": seguimientos_hoy,
+            "legajos": inscripciones["legajos_activos"],
+            "seguimientos": inscripciones["seguimientos_hoy"],
             "alertas": alertas_activas,
         },
         "estados_legajos": {
-            "abiertos": estados_dict.get("ACTIVO", 0),
-            "seguimiento": estados_dict.get("EN_SEGUIMIENTO", 0),
+            "abiertos": inscripciones["abiertos"],
+            "seguimiento": inscripciones["seguimiento"],
             "derivados": DerivacionPrograma.objects.filter(estado="PENDIENTE").count(),
-            "cerrados": estados_dict.get("CERRADO", 0),
+            "cerrados": inscripciones["cerrados"],
         },
         "usuarios_conectados": usuarios_activos,
     }

--- a/legajos/selectors/ciudadanos.py
+++ b/legajos/selectors/ciudadanos.py
@@ -60,10 +60,10 @@ def get_ciudadanos_queryset(search=""):
         queryset = queryset.filter(
             Q(dni__icontains=search) | Q(nombre__icontains=search) | Q(apellido__icontains=search)
         )
-    return queryset.order_by("apellido", "nombre")
+    return queryset.only("id", "nombre", "apellido", "dni").order_by("apellido", "nombre")
 
 
-def _build_ciudadanos_dashboard_metrics():
+def _build_ciudadanos_dashboard_metrics(total_ciudadanos=None):
     total_inscripciones_activas = InscripcionPrograma.objects.filter(
         estado__in=[InscripcionPrograma.Estado.ACTIVO, InscripcionPrograma.Estado.EN_SEGUIMIENTO]
     ).count()
@@ -71,7 +71,9 @@ def _build_ciudadanos_dashboard_metrics():
     tasa_adherencia = round((total_inscripciones_activas / total_inscripciones * 100) if total_inscripciones > 0 else 0)
 
     return {
-        "total_ciudadanos": Ciudadano.objects.filter(activo=True).count(),
+        "total_ciudadanos": (
+            total_ciudadanos if total_ciudadanos is not None else Ciudadano.objects.filter(activo=True).count()
+        ),
         "legajos_activos": total_inscripciones_activas,
         "alertas_criticas": AlertaCiudadano.objects.filter(activa=True).count(),
         "seguimientos_hoy": InscripcionPrograma.objects.filter(fecha_inscripcion=date.today()).count(),
@@ -83,9 +85,13 @@ def _build_ciudadanos_dashboard_metrics():
     }
 
 
-def get_ciudadanos_dashboard_metrics():
+def get_ciudadanos_dashboard_metrics(total_ciudadanos=None):
     # ~6 COUNTs globales por cada página del listado: cache corto compartido.
-    return cache.get_or_set("legajos:ciudadanos_dashboard_metrics", _build_ciudadanos_dashboard_metrics, 60)
+    return cache.get_or_set(
+        "legajos:ciudadanos_dashboard_metrics",
+        lambda: _build_ciudadanos_dashboard_metrics(total_ciudadanos),
+        60,
+    )
 
 
 def build_ciudadano_detail_context(ciudadano, user=None):
@@ -109,17 +115,19 @@ def build_ciudadano_detail_context(ciudadano, user=None):
         .order_by("-fecha_inscripcion")
     )
 
+    todas_las_solapas = SolapasService.obtener_solapas_ciudadano(ciudadano)
+    solapas = [
+        solapa for solapa in todas_las_solapas if solapa["id"] != "legajos" and "ACOMPANAMIENTO" not in solapa["id"]
+    ]
+    programas_activos = [solapa["inscripcion"] for solapa in todas_las_solapas if "inscripcion" in solapa]
+
     context = {
         "puede_ver_sensible": puede_ver_sensible,
         "legajos": LegajoAtencion.objects.none(),
         "acompanamientos": acompanamientos,
         "acompanamientos_activos_count": acompanamientos.count(),
-        "solapas": [
-            solapa
-            for solapa in SolapasService.obtener_solapas_ciudadano(ciudadano)
-            if solapa["id"] != "legajos" and "ACOMPANAMIENTO" not in solapa["id"]
-        ],
-        "programas_activos": SolapasService.obtener_programas_activos(ciudadano),
+        "solapas": solapas,
+        "programas_activos": programas_activos,
     }
     context["solapas_programas"] = [s for s in context["solapas"] if not s["estatica"]]
 
@@ -149,9 +157,11 @@ def build_ciudadano_detail_context(ciudadano, user=None):
     try:
         from conversaciones.models import Conversacion
 
-        context["conversaciones_ciudadano"] = Conversacion.objects.filter(dni_ciudadano=ciudadano.dni).order_by(
-            "-fecha_inicio"
-        )[:20]
+        context["conversaciones_ciudadano"] = (
+            Conversacion.objects.filter(dni_ciudadano=ciudadano.dni)
+            .select_related("operador_asignado")
+            .order_by("-fecha_inicio")[:20]
+        )
     except Exception:
         context["conversaciones_ciudadano"] = []
 

--- a/legajos/views/ciudadanos.py
+++ b/legajos/views/ciudadanos.py
@@ -33,7 +33,10 @@ class CiudadanoListView(CapacidadRequeridaMixin, LoginRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["metricas"] = get_ciudadanos_dashboard_metrics()
+        total_ciudadanos = None
+        if not self.request.GET.get("search"):
+            total_ciudadanos = context["paginator"].count
+        context["metricas"] = get_ciudadanos_dashboard_metrics(total_ciudadanos)
         return context
 
 

--- a/programas/forms.py
+++ b/programas/forms.py
@@ -269,13 +269,13 @@ class _SelectConSegmento(forms.Select):
     pertenecen al segmento de la convocatoria elegida).
     """
 
-    def __init__(self, *args, segmento_por_valor=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.segmento_por_valor = segmento_por_valor or {}
-
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         option = super().create_option(name, value, label, selected, index, subindex=subindex, attrs=attrs)
-        segmento_id = self.segmento_por_valor.get(str(value))
+        instance = getattr(value, "instance", None)
+        segmento_id = getattr(instance, "segmento_id", None)
+        if segmento_id is None:
+            asignacion = getattr(instance, "asignacion_territorial", None)
+            segmento_id = getattr(asignacion, "segmento_id", None)
         if segmento_id:
             option["attrs"]["data-segmento"] = segmento_id
         return option
@@ -304,21 +304,10 @@ class RelevamientoForm(forms.ModelForm):
         conv_qs = Convocatoria.objects.select_related("segmento").filter(activo=True)
         if segmentos_permitidos is not None:
             conv_qs = conv_qs.filter(segmento__in=segmentos_permitidos)
-        # data-segmento por opción para el filtro dependiente del template.
-        # Los widgets se reemplazan ANTES de asignar los querysets: el setter de
-        # queryset es el que propaga las choices al widget vigente.
-        conv_map = {str(c.pk): str(c.segmento_id) for c in conv_qs}
-        terr_map = {}
-        for usuario in terr_qs:
-            asignacion = getattr(usuario, "asignacion_territorial", None)
-            if asignacion is not None:
-                terr_map[str(usuario.pk)] = str(asignacion.segmento_id)
-        self.fields["convocatoria"].widget = _SelectConSegmento(
-            attrs={"class": INPUT_CLASS}, segmento_por_valor=conv_map
-        )
-        self.fields["territorial"].widget = _SelectConSegmento(
-            attrs={"class": INPUT_CLASS}, segmento_por_valor=terr_map
-        )
+        # ModelChoiceIteratorValue expone la instancia de cada opción; así el
+        # widget agrega data-segmento sin evaluar ambos querysets por duplicado.
+        self.fields["convocatoria"].widget = _SelectConSegmento(attrs={"class": INPUT_CLASS})
+        self.fields["territorial"].widget = _SelectConSegmento(attrs={"class": INPUT_CLASS})
         self.fields["territorial"].queryset = terr_qs
         self.fields["territorial"].label_from_instance = lambda u: u.get_full_name() or u.username
         self.fields[

--- a/programas/services/solapas.py
+++ b/programas/services/solapas.py
@@ -34,7 +34,7 @@ class SolapasService:
                 ciudadano=ciudadano,
                 estado__in=["ACTIVO", "EN_SEGUIMIENTO"],
             )
-            .select_related("programa")
+            .select_related("programa", "responsable")
             .order_by("programa__orden")
         )
 

--- a/programas/views/relevamientos.py
+++ b/programas/views/relevamientos.py
@@ -38,6 +38,7 @@ CAP_REPORTES = "becas.programa.administrar"
 def _convocatorias_qs(request):
     return (
         Convocatoria.objects.select_related("segmento", "subsegmento")
+        .defer("descripcion", "segmento__descripcion", "subsegmento__descripcion")
         .annotate(n_relevamientos=Count("relevamientos", distinct=True))
         .filter(segmento__in=segmentos_visibles(request.user))
         .order_by("-fecha_inicio", "nombre")
@@ -295,6 +296,7 @@ class RelevamientoListView(CapacidadRequeridaMixin, LoginRequiredMixin, ListView
     def get_queryset(self):
         qs = (
             Relevamiento.objects.select_related("convocatoria__segmento", "territorial")
+            .defer("observaciones", "convocatoria__descripcion", "convocatoria__segmento__descripcion")
             .filter(convocatoria__segmento__in=segmentos_visibles(self.request.user))
             .order_by("-fecha_asignada", "nombre")
         )

--- a/scripts/perf_baseline.json
+++ b/scripts/perf_baseline.json
@@ -15,12 +15,12 @@
   "summary": {
     "url_count": 16,
     "successful_2xx": 15,
-    "total_queries": 221,
-    "total_duplicate_queries": 38,
-    "total_duration_ms": 237.83,
-    "total_warm_queries": 182,
-    "total_warm_duplicate_queries": 35,
-    "total_warm_duration_ms": 148.17,
+    "total_queries": 164,
+    "total_duplicate_queries": 1,
+    "total_duration_ms": 220.92,
+    "total_warm_queries": 128,
+    "total_warm_duplicate_queries": 0,
+    "total_warm_duration_ms": 135.02,
     "total_response_bytes": 2301900
   },
   "results": [
@@ -35,11 +35,11 @@
       "redirect_resolved_view": null,
       "query_count": 0,
       "duplicate_query_count": 0,
-      "duration_ms": 23.49,
+      "duration_ms": 23.12,
       "warm_sample_count": 3,
       "warm_query_count": 0,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 0.78,
+      "warm_duration_ms": 0.87,
       "response_bytes": 12097,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": []
@@ -53,32 +53,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 22,
-      "duplicate_query_count": 3,
-      "duration_ms": 26.88,
+      "query_count": 17,
+      "duplicate_query_count": 0,
+      "duration_ms": 26.32,
       "warm_sample_count": 3,
-      "warm_query_count": 14,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 10.98,
+      "warm_query_count": 9,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 9.67,
       "response_bytes": 184863,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT COUNT(*) AS \"__count\" FROM \"conversaciones_conversacion\" WHERE (\"conversaciones_conversacion\".\"estado\" = ? AND \"conversaciones_conversacion\".\"operador_asignado_id\" IS NULL)"
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "dashboard_redirect",
@@ -95,7 +79,7 @@
       "warm_sample_count": 3,
       "warm_query_count": 3,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 1.06,
+      "warm_duration_ms": 1.0,
       "response_bytes": 0,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": []
@@ -109,13 +93,13 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 10,
+      "query_count": 8,
       "duplicate_query_count": 0,
-      "duration_ms": 3.14,
+      "duration_ms": 3.0,
       "warm_sample_count": 3,
       "warm_query_count": 3,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 1.15,
+      "warm_duration_ms": 1.06,
       "response_bytes": 185,
       "content_type": "application/json",
       "duplicate_groups": []
@@ -129,32 +113,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 18,
-      "duplicate_query_count": 3,
-      "duration_ms": 10.28,
+      "query_count": 13,
+      "duplicate_query_count": 0,
+      "duration_ms": 8.78,
       "warm_sample_count": 3,
-      "warm_query_count": 11,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 7.46,
+      "warm_query_count": 7,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 6.05,
       "response_bytes": 172986,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT COUNT(*) AS \"__count\" FROM \"legajos_ciudadano\" WHERE \"legajos_ciudadano\".\"activo\""
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "legajo_detalle",
@@ -165,37 +133,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 41,
-      "duplicate_query_count": 17,
-      "duration_ms": 30.1,
+      "query_count": 22,
+      "duplicate_query_count": 0,
+      "duration_ms": 23.39,
       "warm_sample_count": 3,
-      "warm_query_count": 40,
-      "warm_duplicate_query_count": 17,
-      "warm_duration_ms": 20.15,
+      "warm_query_count": 21,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 15.63,
       "response_bytes": 263515,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 15,
-          "duplicates": 14,
-          "sql": "SELECT \"auth_user\".\"id\", \"auth_user\".\"password\", \"auth_user\".\"last_login\", \"auth_user\".\"is_superuser\", \"auth_user\".\"username\", \"auth_user\".\"first_name\", \"auth_user\".\"last_name\", \"auth_user\".\"email\", \"auth_user\".\"is_staff\", \"auth_user\".\"is_active\", \"auth_user\".\"date_joined\" FROM \"auth_user\" WHERE \"auth_user\".\"id\" = ? LIMIT ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"programas_inscripcionprograma\".\"id\", \"programas_inscripcionprograma\".\"creado\", \"programas_inscripcionprograma\".\"modificado\", \"programas_inscripcionprograma\".\"ciudadano_id\", \"programas_inscripcionprograma\".\"programa_id\", \"programas_inscripcionprograma\".\"codigo\", \"programas_inscripcionprograma\".\"estado\", \"programas_inscripcionprograma\".\"via_ingreso\", \"programas_inscripcionprograma\".\"fecha_inscripcion\", \"programas_inscripcionprograma\".\"fecha_inicio\", \"programas_inscripcionprograma\".\"fecha_c"
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "conversaciones_lista",
@@ -206,26 +153,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 17,
-      "duplicate_query_count": 3,
-      "duration_ms": 19.09,
+      "query_count": 13,
+      "duplicate_query_count": 1,
+      "duration_ms": 17.44,
       "warm_sample_count": 3,
-      "warm_query_count": 13,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 14.48,
+      "warm_query_count": 9,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 13.06,
       "response_bytes": 275492,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        },
         {
           "occurrences": 2,
           "duplicates": 1,
@@ -242,27 +179,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 15,
-      "duplicate_query_count": 2,
-      "duration_ms": 12.44,
+      "query_count": 11,
+      "duplicate_query_count": 0,
+      "duration_ms": 9.75,
       "warm_sample_count": 3,
-      "warm_query_count": 14,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 8.38,
+      "warm_query_count": 10,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 7.48,
       "response_bytes": 166829,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "portal_home",
@@ -275,11 +201,11 @@
       "redirect_resolved_view": null,
       "query_count": 3,
       "duplicate_query_count": 0,
-      "duration_ms": 4.14,
+      "duration_ms": 4.17,
       "warm_sample_count": 3,
       "warm_query_count": 0,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 0.9,
+      "warm_duration_ms": 0.88,
       "response_bytes": 44221,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": []
@@ -295,11 +221,11 @@
       "redirect_resolved_view": null,
       "query_count": 10,
       "duplicate_query_count": 0,
-      "duration_ms": 8.73,
+      "duration_ms": 8.65,
       "warm_sample_count": 3,
       "warm_query_count": 10,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 5.51,
+      "warm_duration_ms": 5.04,
       "response_bytes": 39240,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": []
@@ -315,11 +241,11 @@
       "redirect_resolved_view": null,
       "query_count": 9,
       "duplicate_query_count": 0,
-      "duration_ms": 7.01,
+      "duration_ms": 5.22,
       "warm_sample_count": 3,
       "warm_query_count": 9,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 4.72,
+      "warm_duration_ms": 4.17,
       "response_bytes": 27022,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": []
@@ -335,11 +261,11 @@
       "redirect_resolved_view": null,
       "query_count": 8,
       "duplicate_query_count": 0,
-      "duration_ms": 19.95,
+      "duration_ms": 20.1,
       "warm_sample_count": 3,
       "warm_query_count": 8,
       "warm_duplicate_query_count": 0,
-      "warm_duration_ms": 19.13,
+      "warm_duration_ms": 18.5,
       "response_bytes": 353849,
       "content_type": "text/html; charset=utf-8",
       "duplicate_groups": []
@@ -353,27 +279,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 16,
-      "duplicate_query_count": 2,
-      "duration_ms": 20.46,
+      "query_count": 12,
+      "duplicate_query_count": 0,
+      "duration_ms": 20.27,
       "warm_sample_count": 3,
-      "warm_query_count": 14,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 11.73,
+      "warm_query_count": 10,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 10.89,
       "response_bytes": 213453,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "becas_convocatorias",
@@ -384,27 +299,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 15,
-      "duplicate_query_count": 2,
-      "duration_ms": 15.19,
+      "query_count": 11,
+      "duplicate_query_count": 0,
+      "duration_ms": 14.78,
       "warm_sample_count": 3,
-      "warm_query_count": 13,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 12.66,
+      "warm_query_count": 9,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 12.95,
       "response_bytes": 180102,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "becas_relevamientos",
@@ -415,37 +319,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 19,
-      "duplicate_query_count": 4,
-      "duration_ms": 20.06,
+      "query_count": 13,
+      "duplicate_query_count": 0,
+      "duration_ms": 19.19,
       "warm_sample_count": 3,
-      "warm_query_count": 17,
-      "warm_duplicate_query_count": 4,
-      "warm_duration_ms": 16.28,
+      "warm_query_count": 11,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 14.94,
       "response_bytes": 169478,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"programas_convocatoria\".\"id\", \"programas_convocatoria\".\"creado\", \"programas_convocatoria\".\"modificado\", \"programas_convocatoria\".\"nombre\", \"programas_convocatoria\".\"segmento_id\", \"programas_convocatoria\".\"subsegmento_id\", \"programas_convocatoria\".\"fecha_inicio\", \"programas_convocatoria\".\"fecha_fin\", \"programas_convocatoria\".\"descripcion\", \"programas_convocatoria\".\"activo\", \"programas_segmento\".\"id\", \"programas_segmento\".\"creado\", \"programas_segmento\".\"modificado\", \"programas_segmento\".\"n"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT DISTINCT \"auth_user\".\"id\", \"auth_user\".\"password\", \"auth_user\".\"last_login\", \"auth_user\".\"is_superuser\", \"auth_user\".\"username\", \"auth_user\".\"first_name\", \"auth_user\".\"last_name\", \"auth_user\".\"email\", \"auth_user\".\"is_staff\", \"auth_user\".\"is_active\", \"auth_user\".\"date_joined\", \"programas_asignacionterritorial\".\"id\", \"programas_asignacionterritorial\".\"creado\", \"programas_asignacionterritorial\".\"modificado\", \"programas_asignacionterritorial\".\"segmento_id\", \"programas_asignacionterritorial\".\""
-        }
-      ]
+      "duplicate_groups": []
     },
     {
       "key": "becas_relevamiento_detalle",
@@ -456,27 +339,16 @@
       "status_code": 200,
       "redirect_to": null,
       "redirect_resolved_view": null,
-      "query_count": 15,
-      "duplicate_query_count": 2,
-      "duration_ms": 15.64,
+      "query_count": 11,
+      "duplicate_query_count": 0,
+      "duration_ms": 15.51,
       "warm_sample_count": 3,
-      "warm_query_count": 13,
-      "warm_duplicate_query_count": 2,
-      "warm_duration_ms": 12.8,
+      "warm_query_count": 9,
+      "warm_duplicate_query_count": 0,
+      "warm_duration_ms": 12.83,
       "response_bytes": 198568,
       "content_type": "text/html; charset=utf-8",
-      "duplicate_groups": [
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ?"
-        },
-        {
-          "occurrences": 2,
-          "duplicates": 1,
-          "sql": "SELECT \"auth_group\".\"id\", \"auth_group\".\"name\" FROM \"auth_group\" INNER JOIN \"auth_user_groups\" ON (\"auth_group\".\"id\" = \"auth_user_groups\".\"group_id\") WHERE \"auth_user_groups\".\"user_id\" = ? ORDER BY \"auth_group\".\"id\" ASC LIMIT ?"
-        }
-      ]
+      "duplicate_groups": []
     }
   ]
 }


### PR DESCRIPTION
## Dependencia entre fases

PR apilado sobre #167 (`perf/fase-0-linea-base`) para que este diff contenga únicamente la Fase 1. Cuando #167 se integre, este PR puede retargetearse a `development`.

## Qué cambia

- Elimina N+1 y queries duplicadas de grupos en el context processor mediante prefetch explícito.
- Centraliza y cachea por usuario (30 s) el conteo de conversaciones pendientes, compartido entre sidebar e inicio.
- Agrupa las métricas de inscripciones del dashboard en un solo `aggregate`.
- Acota columnas del listado de ciudadanos y reutiliza el count del paginator.
- Reutiliza las solapas ya cargadas en el detalle de legajo y trae programa/responsable/operador con `select_related`.
- Evita evaluar dos veces los querysets del formulario de relevamientos usando `ModelChoiceIteratorValue.instance`.
- Difiere columnas TEXT no usadas en listados medidos de becas.
- Actualiza `scripts/perf_baseline.json` con una corrida real `--scale 200`.

No se modifican templates, modelos, migraciones ni comportamiento funcional.

## Resultado antes/después

SQLite in-memory, escala 200. “Fría” es la primera request; “warm” es la mediana de 3 requests posteriores. Los tiempos son orientativos y ruidosos; la señal principal son queries/duplicadas.

| Ruta | Queries fría | Duplicadas fría | Tiempo fría ms | Queries warm | Tiempo warm ms |
|---|---:|---:|---:|---:|---:|
| login | 0 → 0 | 0 → 0 | 23.49 → 23.12 | 0 → 0 | 0.78 → 0.87 |
| inicio | 22 → 17 | 3 → 0 | 26.88 → 26.32 | 14 → 9 | 10.98 → 9.67 |
| dashboard redirect | 3 → 3 | 0 → 0 | 1.23 → 1.23 | 3 → 3 | 1.06 → 1.00 |
| dashboard métricas | 10 → 8 | 0 → 0 | 3.14 → 3.00 | 3 → 3 | 1.15 → 1.06 |
| legajos lista | 18 → 13 | 3 → 0 | 10.28 → 8.78 | 11 → 7 | 7.46 → 6.05 |
| legajo detalle | 41 → 22 | 17 → 0 | 30.10 → 23.39 | 40 → 21 | 20.15 → 15.63 |
| conversaciones lista | 17 → 13 | 3 → 1 | 19.09 → 17.44 | 13 → 9 | 14.48 → 13.06 |
| conversación detalle | 15 → 11 | 2 → 0 | 12.44 → 9.75 | 14 → 10 | 8.38 → 7.48 |
| portal home | 3 → 3 | 0 → 0 | 4.14 → 4.17 | 0 → 0 | 0.90 → 0.88 |
| portal perfil | 10 → 10 | 0 → 0 | 8.73 → 8.65 | 10 → 10 | 5.51 → 5.04 |
| portal programas | 9 → 9 | 0 → 0 | 7.01 → 5.22 | 9 → 9 | 4.72 → 4.17 |
| portal consultas | 8 → 8 | 0 → 0 | 19.95 → 20.10 | 8 → 8 | 19.13 → 18.50 |
| becas segmentos | 16 → 12 | 2 → 0 | 20.46 → 20.27 | 14 → 10 | 11.73 → 10.89 |
| becas convocatorias | 15 → 11 | 2 → 0 | 15.19 → 14.78 | 13 → 9 | 12.66 → 12.95 |
| becas relevamientos | 19 → 13 | 4 → 0 | 20.06 → 19.19 | 17 → 11 | 16.28 → 14.94 |
| becas relevamiento detalle | 15 → 11 | 2 → 0 | 15.64 → 15.51 | 13 → 9 | 12.80 → 12.83 |
| **Total** | **221 → 164 (-25.8%)** | **38 → 1 (-97.4%)** | **237.83 → 220.92** | **182 → 128 (-29.7%)** | **148.17 → 135.02** |

Las 16 rutas conservaron exactamente el status HTTP y el tamaño de respuesta. Una segunda auditoría completa produjo los mismos conteos, duplicadas, status y bytes: `total_queries=164`, `total_duplicates=1`.

El duplicado frío restante en conversaciones normaliza igual dos COUNT con parámetros distintos (`pendiente` para sidebar y `activa` para estadísticas); no es la misma consulta lógica repetida ni un N+1.

## Decisiones medidas

- **Índices:** no se agrega ninguno. La baseline muestra sobre todo N+1/duplicación; SQLite no justifica un índice para MySQL y no se ejecutó Docker/EXPLAIN. Antes de crear índices conviene validar en MySQL las queries de ciudadanos activos ordenados por apellido/nombre y relevamientos filtrados por segmento/fecha.
- **Paginación:** no se modifica. Paginar segmentos/convocatorias sin tocar templates ocultaría filas y cambiaría comportamiento; coordinar esa UI por separado.
- **Cache:** solo conteo global barato, con timeout corto y key por usuario como guardia de aislamiento.
- **Orden de conversaciones:** se conserva el queryset actual. Agregar orden explícito cambió el HTML, por lo que se revirtió para respetar cero cambio funcional; queda el warning preexistente del paginator como seguimiento.

## Validación

Con `.venv\Scripts\python.exe` y `DJANGO_SECRET_KEY=test-key`:

- `manage.py check` ✅
- `manage.py makemigrations --check` → `No changes detected` ✅
- `manage.py test` → 318 tests OK (97.443 s) ✅
- `scripts/perf_audit.py --scale 200`, dos corridas estructuralmente estables ✅
- Ruff check/format, `py_compile` y `git diff --check` sobre los archivos tocados ✅

## Riesgos / seguimiento

- Los tiempos SQLite no representan MySQL productivo; los presupuestos de Fase 2 se basarán en queries y usarán tiempo solo como alarma gruesa.
- Se mantiene el `UnorderedObjectListWarning` preexistente de conversaciones para no introducir drift visual/funcional.
- El dashboard legacy de performance no se usa como fuente de verdad: la auditoría de Fase 0 lo clasificó como no confiable.
