### PR TITLE
[Fase 2] Guardas anti-regresión y alertas de performance

### DIFF
--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -1,0 +1,45 @@
+name: Performance Guard
+
+on:
+  pull_request:
+    branches:
+      - development
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  performance-budgets:
+    name: Query Budgets & Smoke Time
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y default-libmysqlclient-dev
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run performance query budgets
+        env:
+          DJANGO_SECRET_KEY: ci-test-key-not-a-real-secret
+          PYTEST_RUNNING: "1"
+          DJANGO_SYNCDB_PROJECT_APPS: "True"
+          DJANGO_DEBUG: "False"
+          PERF_TIMING_OUTPUT: ${{ runner.temp }}/perf-timing.json
+        run: python manage.py test --tag performance --verbosity=2
+
+      - name: Compare smoke duration
+        env:
+          PERF_TIMING_OUTPUT: ${{ runner.temp }}/perf-timing.json
+        run: python scripts/check_perf_timing.py --result "$PERF_TIMING_OUTPUT"

--- a/config/settings.py
+++ b/config/settings.py
@@ -21,6 +21,7 @@ elif (BASE_DIR / ".env.production").exists() and os.environ.get("ENVIRONMENT") =
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "False") == "True"
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")  # dev|qa|prd
+PYTEST_RUNNING = "pytest" in sys.argv or os.environ.get("PYTEST_RUNNING") == "1"
 
 websockets_enabled_env = os.environ.get("WEBSOCKETS_ENABLED")
 if websockets_enabled_env is None:
@@ -101,6 +102,9 @@ INSTALLED_APPS = [
 if DEBUG:
     INSTALLED_APPS += ["silk"]
 
+if PYTEST_RUNNING:
+    INSTALLED_APPS += ["zeal"]
+
 if os.environ.get("DJANGO_SYNCDB_PROJECT_APPS", "False") == "True":
     MIGRATION_MODULES = {
         "users": None,
@@ -126,6 +130,11 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "core.middleware.RequestLoggingMiddleware",
 ]
+
+if PYTEST_RUNNING:
+    MIDDLEWARE += ["zeal.middleware.zeal_middleware"]
+    ZEAL_RAISE = True
+    ZEAL_ALLOWLIST = []
 
 ROOT_URLCONF = "config.urls"
 WSGI_APPLICATION = "config.wsgi.application"
@@ -209,7 +218,7 @@ DATABASES = {
     }
 }
 
-if "pytest" in sys.argv or os.environ.get("PYTEST_RUNNING") == "1":
+if PYTEST_RUNNING:
     DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
@@ -289,6 +298,7 @@ HEALTH_CHECK = {
 DEFAULT_CACHE_TIMEOUT = 600
 DASHBOARD_CACHE_TIMEOUT = 600
 CIUDADANO_CACHE_TIMEOUT = 600
+SLOW_REQUEST_MS = int(os.environ.get("SLOW_REQUEST_MS", "3000"))
 
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",

--- a/core/management/commands/perf_report_requests.py
+++ b/core/management/commands/perf_report_requests.py
@@ -1,0 +1,76 @@
+import math
+import re
+import statistics
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+REQUEST_LOG_RE = re.compile(r"\bcore\.requests:\s+\S+\s+(?P<path>\S+).*?\bduration=(?P<duration>\d+)ms\b")
+REQUEST_LOG_FILES = ("info.log", "warning.log")
+
+
+def _percentile_nearest_rank(values, percentile):
+    ordered = sorted(values)
+    index = max(0, math.ceil(len(ordered) * percentile) - 1)
+    return ordered[index]
+
+
+def _collect_recent_durations(log_dir, days):
+    durations_by_path = defaultdict(list)
+    # DailyFileHandler crea carpetas con datetime.now(); usar la misma fecha
+    # evita desfasajes con TIME_ZONE cuando el host corre en otra zona.
+    today = datetime.now().date()
+    for offset in range(days):
+        daily_dir = log_dir / (today - timedelta(days=offset)).isoformat()
+        for filename in REQUEST_LOG_FILES:
+            log_path = daily_dir / filename
+            if not log_path.is_file():
+                continue
+            try:
+                lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+            except OSError as exc:
+                raise CommandError(f"No se pudo leer {log_path}: {exc}") from exc
+            for line in lines:
+                match = REQUEST_LOG_RE.search(line)
+                if match:
+                    durations_by_path[match.group("path")].append(int(match.group("duration")))
+    return durations_by_path
+
+
+class Command(BaseCommand):
+    help = "Resume count, p50, p95 y máximo de requests recientes agrupadas por path."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--days", type=int, default=7, help="Cantidad de días calendario a incluir (default: 7).")
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        if days < 1:
+            raise CommandError("--days debe ser mayor que cero")
+
+        durations_by_path = _collect_recent_durations(settings.LOG_DIR, days)
+        if not durations_by_path:
+            self.stdout.write(f"No se encontraron requests en los últimos {days} días.")
+            return
+
+        rows = []
+        for path, durations in durations_by_path.items():
+            rows.append(
+                {
+                    "path": path,
+                    "count": len(durations),
+                    "p50": statistics.median(durations),
+                    "p95": _percentile_nearest_rank(durations, 0.95),
+                    "max": max(durations),
+                }
+            )
+        rows.sort(key=lambda row: (-row["p95"], -row["max"], -row["count"], row["path"]))
+
+        self.stdout.write(f"Top 20 paths más lentos de los últimos {days} días (ms)")
+        self.stdout.write(f"{'Path':<60} {'Count':>7} {'p50':>10} {'p95':>10} {'Max':>10}")
+        for row in rows[:20]:
+            self.stdout.write(
+                f"{row['path']:<60} {row['count']:>7} {row['p50']:>10.1f} {row['p95']:>10} {row['max']:>10}"
+            )

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -105,7 +105,8 @@ class RequestLoggingMiddleware:
         username = user.username if user and user.is_authenticated else "anon"
         ip = request.META.get("HTTP_X_REAL_IP") or request.META.get("REMOTE_ADDR", "-")
 
-        logger.info(
+        log_request = logger.warning if duration_ms > settings.SLOW_REQUEST_MS else logger.info
+        log_request(
             "%s %s user=%s ip=%s status=%s duration=%dms",
             request.method,
             request.path,

--- a/core/tests/test_perf_report_requests.py
+++ b/core/tests/test_perf_report_requests.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timedelta
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, override_settings
+
+
+class PerfReportRequestsTests(SimpleTestCase):
+    def test_reports_count_and_percentiles_by_path_from_recent_logs(self):
+        with TemporaryDirectory() as temp_dir:
+            log_dir = Path(temp_dir)
+            today = datetime.now().date()
+            daily_dir = log_dir / today.isoformat()
+            daily_dir.mkdir()
+            (daily_dir / "info.log").write_text(
+                "\n".join(
+                    [
+                        "[2026-01-01] middleware INFO core.requests: GET /inicio/ user=a ip=- status=200 duration=100ms",
+                        "[2026-01-01] middleware INFO core.requests: GET /inicio/ user=b ip=- status=200 duration=300ms",
+                        "línea ajena al logger de requests",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (daily_dir / "warning.log").write_text(
+                "[2026-01-01] middleware WARNING core.requests: GET /lenta/ user=a ip=- status=200 duration=5000ms\n",
+                encoding="utf-8",
+            )
+            old_dir = log_dir / (today - timedelta(days=8)).isoformat()
+            old_dir.mkdir()
+            (old_dir / "info.log").write_text(
+                "[2026-01-01] middleware INFO core.requests: GET /vieja/ user=a ip=- status=200 duration=9000ms\n",
+                encoding="utf-8",
+            )
+
+            output = StringIO()
+            with override_settings(LOG_DIR=log_dir):
+                call_command("perf_report_requests", days=7, stdout=output)
+
+        report = output.getvalue()
+        self.assertRegex(report, r"/lenta/\s+1\s+5000\.0\s+5000\s+5000")
+        self.assertRegex(report, r"/inicio/\s+2\s+200\.0\s+300\s+300")
+        self.assertNotIn("/vieja/", report)

--- a/core/tests/test_perf_timing_guard.py
+++ b/core/tests/test_perf_timing_guard.py
@@ -1,0 +1,11 @@
+from django.test import SimpleTestCase
+
+from scripts.check_perf_timing import classify_ratio
+
+
+class PerfTimingGuardTests(SimpleTestCase):
+    def test_thresholds_are_strictly_greater_than_configured_multipliers(self):
+        self.assertEqual(classify_ratio(1.5, 1.5, 3.0), "ok")
+        self.assertEqual(classify_ratio(1.51, 1.5, 3.0), "warning")
+        self.assertEqual(classify_ratio(3.0, 1.5, 3.0), "warning")
+        self.assertEqual(classify_ratio(3.01, 1.5, 3.0), "failure")

--- a/core/tests/test_performance_budgets.py
+++ b/core/tests/test_performance_budgets.py
@@ -1,0 +1,56 @@
+import json
+import os
+from io import StringIO
+from pathlib import Path
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.management import call_command
+from django.test import TestCase, tag
+
+from scripts.perf_audit import _capture_request, build_clients, build_targets
+
+BUDGETS_PATH = settings.BASE_DIR / "scripts" / "perf_budgets.json"
+
+
+@tag("performance")
+class PerformanceBudgetTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        with StringIO() as output:
+            call_command("seed_perf", scale=200, stdout=output)
+
+    def test_key_routes_stay_within_query_budgets(self):
+        config = json.loads(BUDGETS_PATH.read_text(encoding="utf-8"))
+        manifest = build_targets()
+        targets = {target["key"]: target for target in manifest["targets"]}
+        budgets = config["budgets"]
+
+        self.assertEqual(set(targets), set(budgets), "Los presupuestos deben cubrir exactamente las URLs auditadas")
+
+        clients = build_clients(manifest["actors"])
+        failures = []
+        total_duration_ms = 0.0
+        for key, budget in budgets.items():
+            target = targets[key]
+            self.assertEqual(target["route"], budget["route"], f"Route desactualizada para {key}")
+            cache.clear()
+            measurement = _capture_request(clients[target["actor"]], target["url"])
+            query_count = measurement["query_count"]
+            total_duration_ms += measurement["duration_ms"]
+            expected_status = target.get("expected_status", 200)
+            self.assertEqual(measurement["response"].status_code, expected_status, f"Status inesperado en {key}")
+            if query_count > budget["max_queries"]:
+                failures.append(
+                    f"{key} ({target['url']}): {query_count} queries actuales vs presupuesto "
+                    f"{budget['max_queries']}. Probable N+1, falta select_related/prefetch_related o cache."
+                )
+
+        timing_output = os.environ.get("PERF_TIMING_OUTPUT")
+        if timing_output:
+            Path(timing_output).write_text(
+                json.dumps({"total_duration_ms": round(total_duration_ms, 2)}) + "\n",
+                encoding="utf-8",
+            )
+
+        self.assertFalse(failures, "Presupuestos de performance excedidos:\n" + "\n".join(failures))

--- a/core/tests/test_request_performance_logging.py
+++ b/core/tests/test_request_performance_logging.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from core.middleware import RequestLoggingMiddleware
+
+
+class RequestPerformanceLoggingTests(SimpleTestCase):
+    @override_settings(SLOW_REQUEST_MS=3000)
+    @patch("core.middleware.time.monotonic", side_effect=[100.0, 103.001])
+    def test_slow_request_is_logged_as_warning(self, _monotonic):
+        request = RequestFactory().get("/ruta-lenta/")
+        request.user = AnonymousUser()
+        middleware = RequestLoggingMiddleware(lambda _request: HttpResponse(status=200))
+
+        with self.assertLogs("core.requests", level="WARNING") as captured:
+            middleware(request)
+
+        self.assertIn("GET /ruta-lenta/ user=anon", captured.output[0])
+        self.assertIn("status=200 duration=3001ms", captured.output[0])
+
+    @override_settings(SLOW_REQUEST_MS=3000)
+    @patch("core.middleware.time.monotonic", side_effect=[100.0, 103.0])
+    def test_request_at_threshold_remains_info(self, _monotonic):
+        request = RequestFactory().get("/ruta-en-umbral/")
+        request.user = AnonymousUser()
+        middleware = RequestLoggingMiddleware(lambda _request: HttpResponse(status=200))
+
+        with self.assertLogs("core.requests", level="INFO") as captured:
+            middleware(request)
+
+        self.assertTrue(captured.output[0].startswith("INFO:core.requests:"))
+        self.assertIn("duration=3000ms", captured.output[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ channels-redis==4.1.0
 
 # Performance Profiling
 django-silk==5.0.4
+django-zeal==2.2.1
 
 # System Monitoring
 psutil==5.9.8

--- a/scripts/check_perf_timing.py
+++ b/scripts/check_perf_timing.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Compara el tiempo del smoke de performance contra la referencia commiteada."""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_BUDGETS = REPO / "scripts" / "perf_budgets.json"
+
+
+def classify_ratio(ratio, warning_multiplier, failure_multiplier):
+    if ratio > failure_multiplier:
+        return "failure"
+    if ratio > warning_multiplier:
+        return "warning"
+    return "ok"
+
+
+def _append_step_summary(message):
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a", encoding="utf-8") as summary:
+            summary.write(message + "\n")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--result", type=Path, required=True, help="JSON generado por el test de performance.")
+    parser.add_argument("--budgets", type=Path, default=DEFAULT_BUDGETS)
+    args = parser.parse_args(argv)
+
+    try:
+        result = json.loads(args.result.read_text(encoding="utf-8"))
+        config = json.loads(args.budgets.read_text(encoding="utf-8"))
+        timing = config["_meta"]["timing"]
+        measured_ms = float(result["total_duration_ms"])
+        reference_ms = float(timing["reference_total_ms"])
+        warning_multiplier = float(timing["warning_multiplier"])
+        failure_multiplier = float(timing["failure_multiplier"])
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"No se pudo evaluar el tiempo del smoke: {exc}", file=sys.stderr)
+        return 2
+
+    if reference_ms <= 0:
+        print("reference_total_ms debe ser mayor que cero", file=sys.stderr)
+        return 2
+
+    ratio = measured_ms / reference_ms
+    status = classify_ratio(ratio, warning_multiplier, failure_multiplier)
+    message = (
+        f"Performance smoke: {measured_ms:.2f} ms vs referencia {reference_ms:.2f} ms "
+        f"({ratio:.2f}x; warning >{warning_multiplier:g}x, failure >{failure_multiplier:g}x)."
+    )
+    print(message)
+    _append_step_summary(f"### Performance smoke\n\n{message}")
+
+    if status == "failure":
+        print(f"::error title=Performance smoke degradado::{message}")
+        return 1
+    if status == "warning":
+        print(f"::warning title=Performance smoke degradado::{message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/perf_budgets.json
+++ b/scripts/perf_budgets.json
@@ -1,0 +1,32 @@
+{
+  "_meta": {
+    "schema_version": 1,
+    "scale": 200,
+    "query_margin": "Baseline de Fase 1 + aproximadamente 20%, redondeado hacia arriba.",
+    "maintenance": "Subir un max_queries requiere editar este archivo en el mismo PR que introduce la necesidad, con justificacion visible para review.",
+    "timing": {
+      "reference_total_ms": 220.92,
+      "warning_multiplier": 1.5,
+      "failure_multiplier": 3.0,
+      "note": "El tiempo SQLite es una alarma gruesa; los presupuestos de queries son la guarda dura."
+    }
+  },
+  "budgets": {
+    "login": {"route": "users:login", "max_queries": 0},
+    "inicio": {"route": "core:inicio", "max_queries": 21},
+    "dashboard_redirect": {"route": "core:dashboard", "max_queries": 4},
+    "dashboard_metricas": {"route": "dashboard:api_metricas", "max_queries": 10},
+    "legajos_lista": {"route": "legajos:ciudadanos", "max_queries": 16},
+    "legajo_detalle": {"route": "legajos:ciudadano_detalle", "max_queries": 27},
+    "conversaciones_lista": {"route": "conversaciones:lista", "max_queries": 16},
+    "conversacion_detalle": {"route": "conversaciones:detalle", "max_queries": 14},
+    "portal_home": {"route": "portal:home", "max_queries": 4},
+    "portal_perfil": {"route": "portal:ciudadano_mi_perfil", "max_queries": 12},
+    "portal_programas": {"route": "portal:ciudadano_mis_programas", "max_queries": 11},
+    "portal_consultas": {"route": "portal:ciudadano_mis_consultas", "max_queries": 10},
+    "becas_segmentos": {"route": "becas:segmentos", "max_queries": 15},
+    "becas_convocatorias": {"route": "becas:convocatorias", "max_queries": 14},
+    "becas_relevamientos": {"route": "becas:relevamientos", "max_queries": 16},
+    "becas_relevamiento_detalle": {"route": "becas:relevamiento_detalle", "max_queries": 14}
+  }
+}


### PR DESCRIPTION
## Dependencia entre fases

PR apilado sobre #168 (`perf/fase-1-optimizacion-global`) para aislar el diff de Fase 2. Cuando #167 y #168 se integren, retargetear este PR a `development`.

Por esa base intermedia, el workflow nuevo no se dispara en este draft: su contrato deliberado es únicamente PRs a `development` o `main`.

## Guardas agregadas

### 1. Detector N+1 en tests

- Agrega `django-zeal==2.2.1`, release actual que prueba oficialmente Django 4.2 con Python 3.9–3.12:
  - https://pypi.org/project/django-zeal/2.2.1/
  - https://github.com/taobojlen/django-zeal/blob/main/.github/workflows/test.yaml
- Se carga en `INSTALLED_APPS` y `MIDDLEWARE` únicamente con el switch existente `PYTEST_RUNNING`.
- Queda en modo estricto: `ZEAL_RAISE=True`.
- `ZEAL_ALLOWLIST=[]`: la suite completa pasó sin deuda que justificar.
- Verificación explícita: fuera de tests, Zeal no aparece ni en apps ni en middleware.

### 2. Presupuestos por URL

`scripts/perf_budgets.json` cubre exactamente las 16 URLs de la baseline de Fase 1.

- Presupuesto = baseline fría + ~20%, redondeado hacia arriba.
- El propio JSON documenta que subir un `max_queries` debe hacerse en el mismo PR que lo requiere, con justificación visible.
- `core/tests/test_performance_budgets.py` está etiquetado `performance`, ejecuta `seed_perf --scale 200`, limpia cache por URL y compara queries frías.
- Un exceso falla con ruta, URL, queries actuales, presupuesto y pista accionable.

También se agregó `core/tests/__init__.py`: sin ese archivo, `manage.py test` omitía silenciosamente todo `core/tests/`, incluidas dos suites preexistentes. El total descubierto pasó de 318 a 329: 6 tests existentes ahora ejecutados + 5 nuevos.

### 3. CI de performance

Nuevo `.github/workflows/pr-performance.yml`:

- dispara en PRs a **`development` y `main`**;
- ejecuta `manage.py test --tag performance`;
- usa el JSON temporal emitido por el smoke para comparar tiempo total contra 220.92 ms;
- >1.5× agrega warning al step summary;
- >3× falla;
- los presupuestos de queries siguen siendo la guarda dura.

Corrida local del flujo temporal: **240.34 ms = 1.09×**, sin warning.

### 4. Alerta y reporte runtime

- `SLOW_REQUEST_MS` configurable por env, default 3000.
- `RequestLoggingMiddleware` mantiene INFO hasta el umbral y usa WARNING solo cuando `duration_ms > SLOW_REQUEST_MS`; por la configuración existente cae en `logs/<fecha>/warning.log`.
- Nuevo `manage.py perf_report_requests --days 7`: lee `info.log` + `warning.log`, agrupa por path y muestra top 20 por p95 con count, p50, p95 y max.
- Usa la misma fecha local de `DailyFileHandler` para evitar desfasajes de carpetas.
- No se integra con el dashboard legacy: la auditoría de Fase 0 concluyó que no es una fuente confiable.

## Prueba negativa obligatoria

Se bajó temporalmente `dashboard_redirect.max_queries` de 4 a 2. El test falló como estaba previsto:

```text
dashboard_redirect (/dashboard/): 3 queries actuales vs presupuesto 2.
Probable N+1, falta select_related/prefetch_related o cache.
```

El presupuesto se restauró a 4 mediante parche explícito y la suite final quedó verde.

## Validación final

Con `.venv\Scripts\python.exe`, `DJANGO_SECRET_KEY=test-key`, `PYTEST_RUNNING=1` y `DJANGO_DEBUG=False`:

- `manage.py check` ✅
- `manage.py makemigrations --check` → `No changes detected` ✅
- `python -m pip check` → sin dependencias rotas ✅
- `manage.py test --tag performance` → 1 test OK ✅
- `manage.py test` → **329 tests OK, 90.941 s**, con Zeal estricto ✅
- smoke temporal + comparador → 1.09×, OK ✅
- Ruff check/format, `py_compile`, JSON parse y `git diff --check` ✅

`actionlint` no está instalado localmente; el workflow se revisó contra `pr-backend.yml` y se validará en GitHub cuando la base sea `development` o `main`.

## Riesgos / seguimiento

- El tiempo SQLite varía entre runners; por diseño solo >3× bloquea.
- El reporte agrupa paths literales; rutas con IDs pueden generar alta cardinalidad, pero conserva el contrato actual del logger sin normalizaciones especulativas.
- Sigue presente el `UnorderedObjectListWarning` preexistente de conversaciones; no se cambió para evitar drift funcional/HTML.
