### PR TITLE
Becas: relevamientos mobile offline y mejoras de revisión

### DIFF
--- a/docs/client/financiero/detalle-tareas.md
+++ b/docs/client/financiero/detalle-tareas.md
@@ -238,6 +238,7 @@
 | 2026-07-29 | Matías Abate | Transversal | Reunión de equipo | Reunión de seguimiento del equipo | 60 min |
 | 2026-07-29 | Pablo Cao | Transversal | Reunión de equipo | Reunión de seguimiento del equipo | 60 min |
 | 2026-07-29 | Juani Portilla | Transversal | Reunión de equipo | Reunión de seguimiento del equipo | 60 min |
+| 2026-07-30 | Pablo Cao | Becas | Issues #208 y #209 — backoffice y app mobile offline | Corrección del selector de subsegmentos; persistencia y sincronización offline sin pérdida ni duplicados; trazabilidad temporal y GPS; mejoras de revisión, adjuntos, fechas, identidad, sexo y apoderado; pruebas locales, en APK y servidor. | 290 min |
 | 2026-07-31 | Matías Fariña | Transversal | Reunión de equipo | Reunión de seguimiento del equipo | 60 min |
 | 2026-07-31 | Matías Abate | Transversal | Reunión de equipo | Reunión de seguimiento del equipo | 60 min |
 | 2026-07-31 | Pablo Cao | Transversal | Reunión de equipo | Reunión de seguimiento del equipo | 60 min |
@@ -247,11 +248,11 @@
 
 | Programa | Horas julio |
 |---|---:|
-| Becas | 126 h 08 min |
+| Becas | 130 h 58 min |
 | Dispositivos (incluye Merenderos) | 226 h 0 min |
 | Transversal | 73 h 47 min |
 
-| **Total julio 2026 (al 31/07)** | **425 h 55 min** |
+| **Total julio 2026 (al 31/07)** | **430 h 45 min** |
 
 
 ---
@@ -281,7 +282,7 @@
 !!! success "Contador total"
 
 
-    **55.507 minutos** (925 h 07 min)
+    **55.797 minutos** (929 h 57 min)
 
 
     

--- a/docs/client/financiero/mes-2026-07.md
+++ b/docs/client/financiero/mes-2026-07.md
@@ -1,7 +1,7 @@
 # :material-cash-multiple: Julio 2026 — Mes en curso
 
 !!! info "Mes en curso"
-    Julio 2026 está en ejecución. Al **31/07** se llevan **425 h 55 min consumidas** sobre un presupuesto de **500 horas** (85%). Esta página se actualiza a medida que se registran horas.
+    Julio 2026 está en ejecución. Al **31/07** se llevan **430 h 45 min consumidas** sobre un presupuesto de **500 horas** (86%). Esta página se actualiza a medida que se registran horas.
 
 !!! note "Regularización de horas (29/07/2026)"
     El consumo incluye **125 horas** de desarrollo backend del Programa Dispositivos trabajadas por Juani Portilla durante julio y **56 horas** de reuniones de seguimiento del equipo (lunes, miércoles y viernes, 1 h por integrante, 14 reuniones × 4 integrantes) que se consolidaron en el registro el 29/07, con la reunión del 31/07 registrada por adelantado. El detalle por día está en el [registro de consumo](detalle-tareas.md).
@@ -24,7 +24,7 @@
 
     ---
 
-    **425 h 55 min** (85%)
+    **430 h 45 min** (86%)
 
     Horas consumidas al 31/07
 
@@ -32,7 +32,7 @@
 
     ---
 
-    **74 h 05 min**
+    **69 h 15 min**
 
     Disponibles para el resto del mes
 
@@ -46,10 +46,10 @@ Desde julio 2026 el consumo se imputa por programa.
 
 | Programa | Horas | % del consumo |
 |---|---:|---:|
-| [Programa Becas](../funcionalidades/programa-becas.md) | 126.1 | 30% |
+| [Programa Becas](../funcionalidades/programa-becas.md) | 131.0 | 30% |
 | [Programa Dispositivos](../funcionalidades/programa-dispositivos.md) (incluye Merenderos) | 226.0 | 53% |
 | Transversal (gestión, reuniones, soporte, video) | 73.8 | 17% |
-| **Total julio 2026 (al 31/07)** | **425.9** | **100%** |
+| **Total julio 2026 (al 31/07)** | **430.8** | **100%** |
 
 ---
 
@@ -60,8 +60,8 @@ Desde julio 2026 el consumo se imputa por programa.
 | Juani Portilla | Desarrollo backend de Dispositivos y Merenderos; refinamiento y permisos de Becas; listado de Usuarios, filtros de Roles y performance transversal | 206.5 | 48% |
 | Matías Fariña | Pruebas funcionales y QA del backoffice de Becas; análisis, estimación y documentación/creación de tareas de Dispositivos; creación de video del sistema | 146.0 | 34% |
 | Matías Abate | Pruebas funcionales y QA del backoffice de Becas | 46.0 | 11% |
-| Pablo Cao | App de campo; revisión funcional y UX del backoffice | 27.4 | 7% |
-| **Total julio 2026 (al 31/07)** | | **425.9** | **100%** |
+| Pablo Cao | App de campo; revisión funcional y UX del backoffice | 32.2 | 7% |
+| **Total julio 2026 (al 31/07)** | | **430.8** | **100%** |
 
 [:material-table-arrow-right: Ver detalle de consumo día por día](detalle-tareas.md){ .md-button }
 

--- a/programas/api/serializers.py
+++ b/programas/api/serializers.py
@@ -45,17 +45,25 @@ class RelevamientoDetailSerializer(RelevamientoListSerializer):
 
 class FormularioSerializer(serializers.ModelSerializer):
     ciudadano_dni = serializers.CharField(source="ciudadano.dni", read_only=True)
+    ciudadano_nombre = serializers.CharField(source="ciudadano.nombre", read_only=True)
+    ciudadano_apellido = serializers.CharField(source="ciudadano.apellido", read_only=True)
+    client_uuid = serializers.UUIDField(required=False, allow_null=True)
+    capturado_en = serializers.DateTimeField(required=False, allow_null=True)
 
     class Meta:
         model = Formulario
         fields = [
             "id",
+            "client_uuid",
+            "capturado_en",
             "relevamiento",
             "estado",
             "motivo_rechazo",
             "validado_renaper",
             "ciudadano",
             "ciudadano_dni",
+            "ciudadano_nombre",
+            "ciudadano_apellido",
             "datos_identificacion",
             "celular",
             "email_contacto",
@@ -75,6 +83,8 @@ class FormularioSerializer(serializers.ModelSerializer):
             "motivo_rechazo",
             "ciudadano",
             "ciudadano_dni",
+            "ciudadano_nombre",
+            "ciudadano_apellido",
             "creado",
             "modificado",
         ]

--- a/programas/api/views.py
+++ b/programas/api/views.py
@@ -4,13 +4,16 @@ Auth por token (DRF authtoken). El territorial solo ve/gestiona SUS relevamiento
 y formularios. Capacidad requerida: ``becas.campo``.
 """
 
+from datetime import timedelta
+
 from django.db.models import Count
 from django.utils import timezone
-from rest_framework import mixins, status, viewsets
+from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.decorators import action, api_view, authentication_classes, permission_classes
+from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import BasePermission, IsAuthenticated
 from rest_framework.response import Response
@@ -27,6 +30,15 @@ from programas.models import Formulario, Relevamiento
 from programas.services.becas import resolver_ciudadano_offline
 
 CAP = "becas.campo"
+
+
+def _captura_habilitada(relevamiento, capturado_en=None):
+    """Permite operar hoy o sincronizar después una captura hecha en fecha."""
+    if capturado_en is None:
+        return relevamiento.fecha_asignada == timezone.localdate()
+    if capturado_en > timezone.now() + timedelta(minutes=5):
+        return False
+    return timezone.localdate(capturado_en) == relevamiento.fecha_asignada
 
 
 class CampoBecasPermission(BasePermission):
@@ -122,12 +134,15 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsAuthenticated, CampoBecasPermission]
 
     def get_queryset(self):
-        return (
+        queryset = (
             Relevamiento.objects.filter(territorial=self.request.user)
             .select_related("convocatoria__segmento", "convocatoria__subsegmento")
             .annotate(formularios_count=Count("formularios"))
             .order_by("-fecha_asignada")
         )
+        if self.action == "list":
+            queryset = queryset.filter(fecha_asignada=timezone.localdate())
+        return queryset
 
     def get_serializer_class(self):
         if self.action == "retrieve":
@@ -137,6 +152,11 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def iniciar(self, request, pk=None):
         rel = self.get_object()
+        if rel.fecha_asignada != timezone.localdate():
+            return Response(
+                {"detail": "Solo se puede relevar durante la fecha asignada."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         if rel.estado != Relevamiento.Estado.ASIGNADO:
             return Response({"detail": "Solo se puede iniciar un relevamiento asignado."}, status=400)
         rel.estado = Relevamiento.Estado.EN_CURSO
@@ -146,6 +166,20 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def finalizar(self, request, pk=None):
         rel = self.get_object()
+        capturado_en = request.data.get("capturado_en")
+        if capturado_en:
+            try:
+                capturado_en = serializers.DateTimeField().to_internal_value(capturado_en)
+            except serializers.ValidationError:
+                return Response(
+                    {"capturado_en": "La fecha de captura no es válida."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        if not _captura_habilitada(rel, capturado_en):
+            return Response(
+                {"detail": "Solo se puede relevar durante la fecha asignada."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         if rel.estado not in (Relevamiento.Estado.EN_CURSO, Relevamiento.Estado.FINALIZANDO):
             return Response({"detail": "El relevamiento no está en curso."}, status=400)
         rel.estado = Relevamiento.Estado.FINALIZADO
@@ -156,6 +190,11 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, methods=["post"])
     def reabrir(self, request, pk=None):
         rel = self.get_object()
+        if rel.fecha_asignada != timezone.localdate():
+            return Response(
+                {"detail": "Solo se puede relevar durante la fecha asignada."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         if rel.estado != Relevamiento.Estado.FINALIZADO:
             return Response({"detail": "Solo se puede reabrir un relevamiento finalizado."}, status=400)
         rel.estado = Relevamiento.Estado.EN_CURSO
@@ -175,6 +214,17 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
 
         serializer = FormularioSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        capturado_en = serializer.validated_data.get("capturado_en")
+        if not _captura_habilitada(rel, capturado_en):
+            return Response(
+                {"detail": "La captura se realizó fuera de la fecha asignada."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        client_uuid = serializer.validated_data.get("client_uuid")
+        if client_uuid:
+            existente = rel.formularios.filter(client_uuid=client_uuid).first()
+            if existente:
+                return Response(FormularioSerializer(existente).data, status=status.HTTP_200_OK)
         formulario = serializer.save(relevamiento=rel, created_by=request.user)
         _actualizar_validacion_identidad(
             formulario,
@@ -197,6 +247,10 @@ class FormularioViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, view
         )
 
     def perform_update(self, serializer):
+        formulario = serializer.instance
+        capturado_en = formulario.capturado_en or serializer.validated_data.get("capturado_en")
+        if not _captura_habilitada(formulario.relevamiento, capturado_en):
+            raise ValidationError({"detail": "El relevamiento está fuera de su fecha asignada."})
         formulario = serializer.save()
         _actualizar_validacion_identidad(
             formulario,
@@ -216,6 +270,11 @@ class FormularioViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, view
         if request.method == "GET":
             return Response(AdjuntoFormularioSerializer(formulario.adjuntos.all(), many=True).data)
 
+        if not _captura_habilitada(formulario.relevamiento, formulario.capturado_en):
+            return Response(
+                {"detail": "El relevamiento está fuera de su fecha asignada."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         serializer = AdjuntoFormularioSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         adjunto = serializer.save(formulario=formulario)

--- a/programas/forms.py
+++ b/programas/forms.py
@@ -922,7 +922,10 @@ class FormularioRevisionForm(forms.ModelForm):
             "email_contacto": forms.EmailInput(attrs={"class": INPUT_CLASS}),
             "apoderado_nombre": forms.TextInput(attrs={"class": INPUT_CLASS}),
             "apoderado_apellido": forms.TextInput(attrs={"class": INPUT_CLASS}),
-            "apoderado_fecha_nacimiento": forms.DateInput(attrs={"class": INPUT_CLASS, "type": "date"}),
+            "apoderado_fecha_nacimiento": forms.DateInput(
+                format="%Y-%m-%d",
+                attrs={"class": INPUT_CLASS, "type": "date"},
+            ),
         }
 
     def clean(self):
@@ -943,3 +946,13 @@ class FormularioRevisionForm(forms.ModelForm):
                 if not cleaned_data.get(campo):
                     self.add_error(campo, "Este dato es obligatorio cuando la persona relevada es menor de edad.")
         return cleaned_data
+
+
+class CiudadanoGeneroRevisionForm(forms.Form):
+    """Carga el sexo registral requerido para consultar RENAPER."""
+
+    genero = forms.ChoiceField(
+        label="Sexo",
+        choices=[("", "Seleccionar..."), ("M", "M"), ("F", "F"), ("X", "X")],
+        widget=forms.RadioSelect(),
+    )

--- a/programas/migrations/0029_formulario_captura_mobile.py
+++ b/programas/migrations/0029_formulario_captura_mobile.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("programas", "0028_indicadores_dispositivos"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="formulario",
+            name="capturado_en",
+            field=models.DateTimeField(
+                blank=True,
+                editable=False,
+                null=True,
+                verbose_name="Fecha de captura en el dispositivo",
+            ),
+        ),
+        migrations.AddField(
+            model_name="formulario",
+            name="client_uuid",
+            field=models.UUIDField(
+                blank=True,
+                editable=False,
+                null=True,
+                unique=True,
+                verbose_name="Identificador de captura mobile",
+            ),
+        ),
+    ]

--- a/programas/models/__init__.py
+++ b/programas/models/__init__.py
@@ -1540,6 +1540,19 @@ class Formulario(TimeStamped):
         db_index=True,
         verbose_name="Estado",
     )
+    client_uuid = models.UUIDField(
+        null=True,
+        blank=True,
+        unique=True,
+        editable=False,
+        verbose_name="Identificador de captura mobile",
+    )
+    capturado_en = models.DateTimeField(
+        null=True,
+        blank=True,
+        editable=False,
+        verbose_name="Fecha de captura en el dispositivo",
+    )
     motivo_rechazo = models.TextField(blank=True, verbose_name="Motivo de rechazo")
     validado_renaper = models.BooleanField(default=False, verbose_name="Validado RENAPER")
 

--- a/programas/services/becas.py
+++ b/programas/services/becas.py
@@ -135,15 +135,24 @@ def resolver_ciudadano_offline(formulario):
     dni = datos.get("dni")
     if not dni:
         return None
+    genero = str(datos.get("sexo") or datos.get("genero") or "").strip().upper()
+    if genero not in Ciudadano.Genero.values:
+        genero = ""
 
-    ciudadano, _creado = Ciudadano.objects.get_or_create(
+    ciudadano, creado = Ciudadano.objects.get_or_create(
         dni=dni,
         defaults={
             "nombre": datos.get("nombre", ""),
             "apellido": datos.get("apellido", ""),
             "fecha_nacimiento": datos.get("fecha_nacimiento") or None,
+            "genero": genero,
         },
     )
+    # Si el ciudadano ya existía, completamos el sexo únicamente cuando todavía
+    # no tenía uno registrado. Nunca pisamos un dato previo del legajo.
+    if not creado and not ciudadano.genero and genero:
+        ciudadano.genero = genero
+        ciudadano.save(update_fields=["genero", "modificado"])
     formulario.ciudadano = ciudadano
     formulario.datos_identificacion = None
     formulario.save(update_fields=["ciudadano", "datos_identificacion", "modificado"])

--- a/programas/templates/programas/becas/_respuesta_valor.html
+++ b/programas/templates/programas/becas/_respuesta_valor.html
@@ -1,11 +1,37 @@
 {% if item.es_archivo %}
   {% if item.adjunto %}
+    {% if item.es_imagen %}
+    <button type="button"
+            data-image-preview
+            data-image-url="{{ item.adjunto.archivo.url }}"
+            data-image-title="{{ item.label }}"
+            class="group block text-left">
+      <img src="{{ item.adjunto.archivo.url }}"
+           alt="{{ item.label }}"
+           loading="lazy"
+           class="h-24 w-32 rounded-lg border border-base object-cover shadow-sm transition group-hover:opacity-90">
+      <span class="mt-1.5 inline-flex items-center gap-1.5 text-xs text-fg-brand font-semibold">
+        <i class="fas fa-expand" aria-hidden="true"></i> Ampliar imagen
+      </span>
+    </button>
+    {% else %}
   <a href="{{ item.adjunto.archivo.url }}" target="_blank" rel="noopener" class="inline-flex items-center gap-1.5 text-fg-brand font-semibold hover:underline">
     <i class="fas fa-paperclip"></i> Ver archivo
   </a>
+    {% endif %}
   {% else %}
   <span class="badge badge-danger">Sin adjunto</span>
   {% endif %}
 {% else %}
-  {{ item.valor }}
+  {% if item.es_multiple %}
+    <span class="flex flex-wrap gap-1.5">
+      {% for opcion in item.valor %}
+        <span class="badge badge-gray">{{ opcion }}</span>
+      {% empty %}
+        <span class="text-body-subtle">Sin selección</span>
+      {% endfor %}
+    </span>
+  {% else %}
+    {{ item.valor }}
+  {% endif %}
 {% endif %}

--- a/programas/templates/programas/becas/relevamientos/convocatoria_list.html
+++ b/programas/templates/programas/becas/relevamientos/convocatoria_list.html
@@ -5,7 +5,7 @@
 {% block main-content %}
 <style>[x-cloak]{display:none!important}</style>
 <div class="mb-8"
-     x-data="{ modalCrear: false }"
+     x-data="convocatoriasPage('{% url 'becas:segmento_subsegmentos_json' pk=0 %}')"
      @becas-saved.window="modalCrear=false">
 
   <div class="flex items-end justify-between gap-4 flex-wrap mb-6">
@@ -44,7 +44,10 @@
         </button>
       </div>
 
-      <form method="post" action="{% url 'becas:convocatoria_crear' %}" data-ajax>
+      <form method="post"
+            action="{% url 'becas:convocatoria_crear' %}"
+            data-ajax
+            data-convocatoria-modal>
         {% csrf_token %}
         <input type="hidden" name="activo" value="on">
         <div class="p-6 space-y-4">
@@ -62,6 +65,14 @@
             <div>
               <label class="block text-sm font-medium text-heading mb-1">Subsegmento</label>
               {{ form_convocatoria.subsegmento }}
+              <p x-show="loadingSubsegmentos"
+                 class="mt-1 text-xs text-body-subtle"
+                 role="status"
+                 aria-live="polite">Cargando subsegmentos…</p>
+              <p x-show="subsegmentosError"
+                 x-text="subsegmentosError"
+                 class="mt-1 text-xs text-fg-danger"
+                 role="alert"></p>
               <p class="mt-1 text-xs text-fg-danger hidden" data-error="subsegmento"></p>
             </div>
           </div>
@@ -93,4 +104,60 @@
 </div>
 {% endblock %}
 
-{% block customJS %}{% include "programas/becas/_ajax_js.html" %}{% include "programas/becas/relevamientos/_reactivar_convocatoria_js.html" %}{% endblock %}
+{% block customJS %}
+{% include "programas/becas/_ajax_js.html" %}
+{% include "programas/becas/relevamientos/_reactivar_convocatoria_js.html" %}
+<script>
+function convocatoriasPage(subsegmentosUrlTemplate) {
+  return {
+    modalCrear: false,
+    loadingSubsegmentos: false,
+    subsegmentosError: '',
+    requestSequence: 0,
+
+    init() {
+      const form = this.$el.querySelector('[data-convocatoria-modal]');
+      const segmento = form?.querySelector('[name="segmento"]');
+      const subsegmento = form?.querySelector('[name="subsegmento"]');
+      if (!segmento || !subsegmento) return;
+
+      subsegmento.disabled = !segmento.value;
+      segmento.addEventListener('change', () => {
+        this.cargarSubsegmentos(segmento.value, subsegmento);
+      });
+    },
+
+    async cargarSubsegmentos(segmentoId, subsegmento) {
+      const sequence = ++this.requestSequence;
+      subsegmento.replaceChildren(new Option('---------', ''));
+      this.subsegmentosError = '';
+      if (!segmentoId) {
+        subsegmento.disabled = true;
+        return;
+      }
+
+      this.loadingSubsegmentos = true;
+      subsegmento.disabled = true;
+      try {
+        const url = subsegmentosUrlTemplate.replace('/0/', `/${segmentoId}/`);
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const subsegmentos = await response.json();
+        if (sequence !== this.requestSequence) return;
+        subsegmentos.forEach((item) => {
+          subsegmento.add(new Option(item.nombre, item.id));
+        });
+        subsegmento.disabled = false;
+      } catch (_) {
+        if (sequence !== this.requestSequence) return;
+        this.subsegmentosError = 'No se pudieron cargar los subsegmentos. Intentá nuevamente.';
+      } finally {
+        if (sequence === this.requestSequence) {
+          this.loadingSubsegmentos = false;
+        }
+      }
+    },
+  };
+}
+</script>
+{% endblock %}

--- a/programas/templates/programas/becas/revision/formulario_detalle.html
+++ b/programas/templates/programas/becas/revision/formulario_detalle.html
@@ -3,6 +3,42 @@
 {% block title %}Becas · Formulario #{{ formulario.pk }}{% endblock %}
 
 {% block main-content %}
+<style>
+  .sexo-pill input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .sexo-pill span {
+    display: inline-flex;
+    width: 38px;
+    height: 38px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-base);
+    border-radius: 9999px;
+    background: var(--bg-primary);
+    color: var(--text-body);
+    font-size: 13px;
+    font-weight: 700;
+    transition: background-color .15s ease, border-color .15s ease, color .15s ease;
+  }
+  .sexo-pill:hover span {
+    border-color: var(--border-brand);
+    color: var(--text-fg-brand);
+  }
+  .sexo-pill input:checked + span {
+    border-color: var(--bg-brand);
+    background: var(--bg-brand);
+    color: #fff;
+  }
+  .sexo-pill input:focus-visible + span {
+    outline: 2px solid var(--border-brand);
+    outline-offset: 2px;
+  }
+</style>
 <div class="max-w-[1180px] mx-auto space-y-6">
 
   {# Header #}
@@ -37,7 +73,7 @@
       <h2 class="text-heading font-bold" style="font-size:16px;">Identidad</h2>
     </div>
     <div class="p-6">
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-5">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
         <div>
           <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">Nombre completo</dt>
           <dd class="text-heading font-medium text-sm">
@@ -63,6 +99,49 @@
           </dd>
         </div>
         <div>
+          <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">Sexo</dt>
+          <dd class="text-sm">
+            {% if formulario.ciudadano %}
+              {% if formulario.validado_renaper and formulario.ciudadano.genero %}
+                <span class="text-heading font-medium">
+                  {{ formulario.ciudadano.get_genero_display|default:"Sin informar" }}
+                </span>
+              {% elif puede_revalidar_renaper %}
+                <form method="post"
+                      action="{% url 'becas:formulario_actualizar_genero' formulario.pk %}"
+                      class="flex items-center gap-2">
+                  {% csrf_token %}
+                  <div class="flex items-center gap-1.5" role="radiogroup" aria-label="Sexo">
+                    {% for opcion in genero_form.genero %}
+                      {% if opcion.data.value %}
+                        <label class="sexo-pill cursor-pointer">
+                          {{ opcion.tag }}
+                          <span>{{ opcion.choice_label }}</span>
+                        </label>
+                      {% endif %}
+                    {% endfor %}
+                    {% for error in genero_form.genero.errors %}
+                      <p class="mt-1 text-xs text-fg-danger">{{ error }}</p>
+                    {% endfor %}
+                  </div>
+                  <button type="submit"
+                          class="btn-nodo btn-tertiary btn-sm"
+                          style="width:38px;height:38px;padding:0;display:inline-flex;align-items:center;justify-content:center;"
+                          aria-label="Guardar sexo"
+                          title="Guardar sexo">
+                    <i class="fas fa-save" aria-hidden="true"></i>
+                    <span class="sr-only">Guardar sexo</span>
+                  </button>
+                </form>
+              {% else %}
+                {{ formulario.ciudadano.get_genero_display|default:"Sin informar" }}
+              {% endif %}
+            {% else %}
+              <span class="text-body-subtle">Sin ciudadano vinculado</span>
+            {% endif %}
+          </dd>
+        </div>
+        <div>
           <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">RENAPER</dt>
           <dd class="text-sm">
             {% if formulario.validado_renaper %}
@@ -80,19 +159,99 @@
     </div>
   </section>
 
-  {# 2. Datos de contacto y apoderado (editable) #}
+  {# 2. Trazabilidad temporal y ubicación #}
+  <section class="bg-white rounded-xl border border-base shadow-sm overflow-hidden">
+    <div class="px-5 py-4 border-b border-light">
+      <h2 class="text-heading font-bold" style="font-size:16px;">
+        <i class="fas fa-clock mr-1 text-fg-brand" aria-hidden="true"></i>
+        Trazabilidad de la toma
+      </h2>
+    </div>
+    <div class="p-6 space-y-6">
+      <dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        <div>
+          <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">Fecha asignada</dt>
+          <dd class="text-heading text-sm">{{ relevamiento.fecha_asignada|date:"d/m/Y" }}</dd>
+        </div>
+        <div>
+          <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">Capturado en el dispositivo</dt>
+          <dd class="text-heading text-sm">
+            {% if formulario.capturado_en %}
+              {{ formulario.capturado_en|date:"d/m/Y H:i:s" }}
+            {% else %}
+              <span class="text-body-subtle">No informado</span>
+            {% endif %}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">Recibido en el servidor</dt>
+          <dd class="text-heading text-sm">{{ formulario.creado|date:"d/m/Y H:i:s" }}</dd>
+        </div>
+        <div>
+          <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">Última actualización</dt>
+          <dd class="text-heading text-sm">{{ formulario.modificado|date:"d/m/Y H:i:s" }}</dd>
+        </div>
+      </dl>
+
+      <div class="border-t border-light pt-5">
+        <div class="flex items-center justify-between gap-3 mb-3 flex-wrap">
+          <div>
+            <h3 class="text-heading font-semibold text-sm">
+              <i class="fas fa-map-marker-alt mr-1 text-fg-brand" aria-hidden="true"></i>
+              Lugar de la toma
+            </h3>
+            {% if mapa %}
+              <p class="text-xs text-body-subtle mt-1">{{ mapa.latitud }}, {{ mapa.longitud }}</p>
+            {% endif %}
+          </div>
+          {% if mapa %}
+            <a href="{{ mapa.open_url }}" target="_blank" rel="noopener noreferrer"
+               class="btn-nodo btn-tertiary btn-sm">
+              <i class="fas fa-external-link-alt" aria-hidden="true"></i> Abrir mapa
+            </a>
+          {% endif %}
+        </div>
+        {% if mapa %}
+          <iframe
+            title="Mapa del lugar donde se realizó la toma"
+            src="{{ mapa.embed_url }}"
+            class="w-full rounded-xl border border-base"
+            style="height:320px;"
+            loading="lazy">
+          </iframe>
+        {% else %}
+          <div class="rounded-xl bg-secondary border border-light p-5 text-sm text-body-subtle">
+            Este formulario no tiene coordenadas GPS registradas.
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  {# 3. Datos de contacto y apoderado (editable) #}
   <form method="post" class="bg-white rounded-xl border border-base shadow-sm overflow-hidden">
     {% csrf_token %}
     <div class="px-5 py-4 border-b border-light">
-      <h2 class="text-heading font-bold" style="font-size:16px;">Datos de contacto y apoderado</h2>
+      <h2 class="text-heading font-bold" style="font-size:16px;">Datos de contacto</h2>
     </div>
     <div class="p-6">
       {% if form.non_field_errors %}
         <div class="mb-4 rounded-lg bg-danger-soft p-3 text-sm text-fg-danger">{{ form.non_field_errors }}</div>
       {% endif %}
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {% for field in form %}<div>{% include "programas/becas/_field.html" %}</div>{% endfor %}
+        <div>{% with field=form.celular %}{% include "programas/becas/_field.html" %}{% endwith %}</div>
+        <div>{% with field=form.email_contacto %}{% include "programas/becas/_field.html" %}{% endwith %}</div>
       </div>
+      {% if mostrar_apoderado %}
+        <div class="border-t border-light mt-2 pt-5">
+          <h3 class="text-heading font-semibold text-sm mb-4">Datos del apoderado</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div>{% with field=form.apoderado_nombre %}{% include "programas/becas/_field.html" %}{% endwith %}</div>
+            <div>{% with field=form.apoderado_apellido %}{% include "programas/becas/_field.html" %}{% endwith %}</div>
+            <div>{% with field=form.apoderado_fecha_nacimiento %}{% include "programas/becas/_field.html" %}{% endwith %}</div>
+          </div>
+        </div>
+      {% endif %}
       <p class="text-xs text-body-subtle mt-2"><i class="fas fa-history mr-1"></i> Cada cambio queda registrado en la traza.</p>
     </div>
     <div class="flex justify-end px-6 py-4 border-t border-light bg-secondary">
@@ -125,9 +284,9 @@
       <h2 class="text-heading font-bold" style="font-size:16px;">Requisitos del segmento</h2>
     </div>
     <div class="p-6">
-      {% if requisitos_list %}
+      {% if requisitos_segmento %}
       <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-5">
-        {% for item in requisitos_list %}
+        {% for item in requisitos_segmento %}
         <div>
           <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">{{ item.label }}</dt>
           <dd class="text-heading text-sm">{% include "programas/becas/_respuesta_valor.html" %}</dd>
@@ -138,7 +297,26 @@
     </div>
   </section>
 
-  {# 5. Resultado SIS (placeholder de integración pendiente) #}
+  {# 5. Requisitos del subsegmento #}
+  <section class="bg-white rounded-xl border border-base shadow-sm overflow-hidden">
+    <div class="px-5 py-4 border-b border-light">
+      <h2 class="text-heading font-bold" style="font-size:16px;">Requisitos del subsegmento</h2>
+    </div>
+    <div class="p-6">
+      {% if requisitos_subsegmento %}
+      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-5">
+        {% for item in requisitos_subsegmento %}
+        <div>
+          <dt class="text-body-subtle text-xs uppercase tracking-wide font-semibold mb-1">{{ item.label }}</dt>
+          <dd class="text-heading text-sm">{% include "programas/becas/_respuesta_valor.html" %}</dd>
+        </div>
+        {% endfor %}
+      </dl>
+      {% else %}<p class="text-sm text-body-subtle">Sin respuestas.</p>{% endif %}
+    </div>
+  </section>
+
+  {# 6. Resultado SIS (placeholder de integración pendiente) #}
   <section class="rounded-xl border border-base p-6" style="background:var(--bg-secondary);">
     <div class="flex items-center gap-2 mb-2">
       <i class="fas fa-plug text-fg-brand"></i>
@@ -220,12 +398,62 @@
       </div>
     </div>
   </div>
+
+  <div id="image-preview-overlay"
+       class="fixed inset-0 z-[1002] hidden items-center justify-center p-4 sm:p-8"
+       style="background:rgba(0,0,0,.86);"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="image-preview-title">
+    <button type="button" id="image-preview-close"
+            aria-label="Cerrar imagen ampliada"
+            class="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full text-white"
+            style="background:rgba(255,255,255,.16);">
+      <i class="fas fa-times text-xl" aria-hidden="true"></i>
+    </button>
+    <figure class="flex h-full w-full flex-col items-center justify-center gap-3">
+      <img id="image-preview-img"
+           src=""
+           alt=""
+           class="max-h-[82vh] max-w-full rounded-xl object-contain shadow-2xl">
+      <figcaption id="image-preview-title" class="text-center text-sm font-semibold text-white"></figcaption>
+    </figure>
+  </div>
 </div>
 {% endblock %}
 
 {% block customJS %}
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+  const imageOverlay = document.getElementById('image-preview-overlay');
+  const imagePreview = document.getElementById('image-preview-img');
+  const imageTitle = document.getElementById('image-preview-title');
+  const imageClose = document.getElementById('image-preview-close');
+  let imagePreviouslyFocused = null;
+
+  function closeImagePreview() {
+    imageOverlay.classList.add('hidden');
+    imageOverlay.style.display = 'none';
+    imagePreview.src = '';
+    if (imagePreviouslyFocused) imagePreviouslyFocused.focus();
+  }
+
+  document.querySelectorAll('[data-image-preview]').forEach(function (trigger) {
+    trigger.addEventListener('click', function () {
+      imagePreviouslyFocused = trigger;
+      imagePreview.src = trigger.dataset.imageUrl;
+      imagePreview.alt = trigger.dataset.imageTitle || 'Imagen adjunta';
+      imageTitle.textContent = trigger.dataset.imageTitle || 'Imagen adjunta';
+      imageOverlay.classList.remove('hidden');
+      imageOverlay.style.display = 'flex';
+      imageClose.focus();
+    });
+  });
+  imageClose.addEventListener('click', closeImagePreview);
+  imageOverlay.addEventListener('click', function (event) {
+    if (event.target === imageOverlay) closeImagePreview();
+  });
+
   const btnAprobar = document.getElementById('btn-aprobar');
   if (btnAprobar) {
     btnAprobar.addEventListener('click', function () {
@@ -274,6 +502,10 @@ document.addEventListener('DOMContentLoaded', function () {
     if (e.target === rechazoOverlay) cerrarModalRechazo();
   });
   document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !imageOverlay.classList.contains('hidden')) {
+      closeImagePreview();
+      return;
+    }
     if (e.key === 'Escape' && !rechazoOverlay.classList.contains('hidden')) cerrarModalRechazo();
   });
 

--- a/programas/templates/programas/becas/revision/formulario_list.html
+++ b/programas/templates/programas/becas/revision/formulario_list.html
@@ -7,7 +7,13 @@
 
 
   <div class="flex items-start justify-between gap-4 flex-wrap mb-6">
-    <div>
+    <div class="flex items-start gap-3">
+      <a href="{% url 'becas:relevamiento_detalle' relevamiento.pk %}"
+         class="btn-tertiary btn-back-circle"
+         aria-label="Volver al detalle del relevamiento">
+        <i class="fas fa-arrow-left" aria-hidden="true"></i>
+      </a>
+      <div>
       <div class="flex items-center gap-3 flex-wrap">
         <h1 class="text-3xl font-extrabold text-heading tracking-tight">{{ relevamiento.nombre }}</h1>
         {% with rel=relevamiento %}{% include "programas/becas/relevamientos/_estado_badge.html" %}{% endwith %}
@@ -15,6 +21,7 @@
       <p class="text-sm text-body-subtle mt-1">
         {{ relevamiento.convocatoria.segmento.nombre }} &middot; {{ pendientes }} pendiente(s) de revisión
       </p>
+      </div>
     </div>
     <div class="flex gap-2">
       {% if request.user|puede:"becas.revision.editar" %}

--- a/programas/tests/test_becas_api.py
+++ b/programas/tests/test_becas_api.py
@@ -1,12 +1,14 @@
 """Tests de la API REST de campo de Becas (#82)."""
 
-from datetime import date
+from datetime import date, timedelta
 from io import StringIO
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.contrib.auth.models import Group, User
 from django.core.management import call_command
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from legajos.models import Ciudadano
@@ -37,13 +39,13 @@ class _BaseApiTest(APITestCase):
         self.rel = Relevamiento.objects.create(
             convocatoria=self.conv,
             territorial=self.terri,
-            fecha_asignada=date(2026, 6, 1),
+            fecha_asignada=timezone.localdate(),
             zona="Centro",
         )
         self.rel_ajeno = Relevamiento.objects.create(
             convocatoria=self.conv,
             territorial=self.terri2,
-            fecha_asignada=date(2026, 6, 1),
+            fecha_asignada=timezone.localdate(),
             zona="Otra",
         )
 
@@ -83,6 +85,29 @@ class RelevamientoApiTests(_BaseApiTest):
         ids = [r["id"] for r in resp.data["results"]]
         self.assertIn(self.rel.id, ids)
         self.assertNotIn(self.rel_ajeno.id, ids)
+
+    def test_lista_solo_relevamientos_asignados_hoy(self):
+        vencido = Relevamiento.objects.create(
+            convocatoria=self.conv,
+            territorial=self.terri,
+            fecha_asignada=timezone.localdate() - timedelta(days=1),
+            zona="Vencida",
+        )
+        futuro = Relevamiento.objects.create(
+            convocatoria=self.conv,
+            territorial=self.terri,
+            fecha_asignada=timezone.localdate() + timedelta(days=1),
+            zona="Futura",
+        )
+        self.autenticar(self.terri)
+
+        resp = self.client.get(reverse("becas_api:relevamiento-list"))
+
+        self.assertEqual(resp.status_code, 200)
+        ids = [r["id"] for r in resp.data["results"]]
+        self.assertIn(self.rel.id, ids)
+        self.assertNotIn(vencido.id, ids)
+        self.assertNotIn(futuro.id, ids)
 
     def test_detalle_incluye_definicion(self):
         PreguntaGlobal.objects.create(texto="Tenencia", tipo=TipoCampo.STRING, activo=True, orden=1)
@@ -124,6 +149,16 @@ class RelevamientoApiTests(_BaseApiTest):
         self.autenticar(self.terri)
         resp = self.client.post(reverse("becas_api:relevamiento-iniciar", args=[self.rel.id]))
         self.assertEqual(resp.status_code, 400)
+
+    def test_no_permite_iniciar_relevamiento_fuera_de_fecha(self):
+        self.rel.fecha_asignada = timezone.localdate() - timedelta(days=1)
+        self.rel.save(update_fields=["fecha_asignada"])
+        self.autenticar(self.terri)
+
+        resp = self.client.post(reverse("becas_api:relevamiento-iniciar", args=[self.rel.id]))
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("fecha asignada", resp.data["detail"])
 
 
 class RenaperBecasApiTests(_BaseApiTest):
@@ -342,11 +377,25 @@ class FormularioSyncTests(_BaseApiTest):
         self.assertEqual(resp.status_code, 201)
 
     def test_listar_formularios_del_relevamiento(self):
-        Formulario.objects.create(relevamiento=self.rel, celular="1", email_contacto="a@b.com")
+        ciudadano = Ciudadano.objects.create(
+            dni="12345678",
+            nombre="Nombre",
+            apellido="Visible",
+            fecha_nacimiento=date(1990, 1, 1),
+        )
+        Formulario.objects.create(
+            relevamiento=self.rel,
+            ciudadano=ciudadano,
+            celular="1",
+            email_contacto="a@b.com",
+        )
         self.autenticar(self.terri)
         url = reverse("becas_api:relevamiento-formularios", args=[self.rel.id])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
+        formulario = resp.data["results"][0]
+        self.assertEqual(formulario["ciudadano_nombre"], "Nombre")
+        self.assertEqual(formulario["ciudadano_apellido"], "Visible")
 
     def test_actualizar_formulario(self):
         form = Formulario.objects.create(relevamiento=self.rel, celular="111", email_contacto="a@b.com")
@@ -356,3 +405,84 @@ class FormularioSyncTests(_BaseApiTest):
         self.assertEqual(resp.status_code, 200)
         form.refresh_from_db()
         self.assertEqual(form.celular, "999")
+
+    def test_no_permite_crear_formulario_fuera_de_fecha(self):
+        self.rel.fecha_asignada = timezone.localdate() - timedelta(days=1)
+        self.rel.save(update_fields=["fecha_asignada"])
+        self.autenticar(self.terri)
+
+        resp = self.client.post(
+            reverse("becas_api:relevamiento-formularios", args=[self.rel.id]),
+            {
+                "celular": "3624111222",
+                "email_contacto": "offline@demo.local",
+                "datos_identificacion": {"dni": "40400400"},
+                "data": {"globales": {}, "requisitos": {}},
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("fuera de la fecha", resp.data["detail"])
+
+    def test_permite_sincronizar_despues_una_captura_hecha_en_fecha(self):
+        capturado_en = timezone.now() - timedelta(days=1)
+        self.rel.fecha_asignada = timezone.localdate(capturado_en)
+        self.rel.save(update_fields=["fecha_asignada"])
+        client_uuid = uuid4()
+        self.autenticar(self.terri)
+
+        resp = self.client.post(
+            reverse("becas_api:relevamiento-formularios", args=[self.rel.id]),
+            {
+                "client_uuid": str(client_uuid),
+                "capturado_en": capturado_en.isoformat(),
+                "celular": "3624111222",
+                "email_contacto": "offline@demo.local",
+                "datos_identificacion": {"dni": "40400400"},
+                "data": {"globales": {}, "requisitos": {}},
+            },
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, 201)
+        formulario = Formulario.objects.get(client_uuid=client_uuid)
+        self.assertEqual(formulario.relevamiento, self.rel)
+        self.assertEqual(timezone.localdate(formulario.capturado_en), self.rel.fecha_asignada)
+
+    def test_reintento_con_mismo_uuid_no_duplica_formulario(self):
+        client_uuid = uuid4()
+        payload = {
+            "client_uuid": str(client_uuid),
+            "capturado_en": timezone.now().isoformat(),
+            "celular": "3624111222",
+            "email_contacto": "offline@demo.local",
+            "datos_identificacion": {"dni": "40400400"},
+            "data": {"globales": {}, "requisitos": {}},
+        }
+        self.autenticar(self.terri)
+        url = reverse("becas_api:relevamiento-formularios", args=[self.rel.id])
+
+        primera = self.client.post(url, payload, format="json")
+        segunda = self.client.post(url, payload, format="json")
+
+        self.assertEqual(primera.status_code, 201)
+        self.assertEqual(segunda.status_code, 200)
+        self.assertEqual(primera.data["id"], segunda.data["id"])
+        self.assertEqual(Formulario.objects.filter(client_uuid=client_uuid).count(), 1)
+
+    def test_no_permite_actualizar_formulario_fuera_de_fecha(self):
+        form = Formulario.objects.create(relevamiento=self.rel, celular="111", email_contacto="a@b.com")
+        self.rel.fecha_asignada = timezone.localdate() - timedelta(days=1)
+        self.rel.save(update_fields=["fecha_asignada"])
+        self.autenticar(self.terri)
+
+        resp = self.client.patch(
+            reverse("becas_api:formulario-detail", args=[form.id]),
+            {"celular": "999"},
+            format="json",
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        form.refresh_from_db()
+        self.assertEqual(form.celular, "111")

--- a/programas/tests/test_becas_convocatoria_subsegmentos.py
+++ b/programas/tests/test_becas_convocatoria_subsegmentos.py
@@ -60,3 +60,15 @@ class ConvocatoriaSubsegmentosTests(TestCase):
         self.assertContains(response, 'aria-live="polite"')
         self.assertContains(response, 'role="alert"')
         self.assertContains(response, ':aria-busy="loadingSubsegmentos.toString()"')
+
+    def test_modal_del_listado_carga_subsegmentos_dinamicamente(self):
+        response = self.client.get(reverse("becas:convocatorias"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "data-convocatoria-modal")
+        self.assertContains(response, "convocatoriasPage(")
+        self.assertContains(response, reverse("becas:segmento_subsegmentos_json", args=[0]))
+        self.assertContains(response, "cargarSubsegmentos(segmento.value, subsegmento)")
+        self.assertContains(response, "subsegmento.add(new Option(item.nombre, item.id))")
+        self.assertContains(response, 'aria-live="polite"')
+        self.assertContains(response, 'role="alert"')

--- a/programas/tests/test_becas_models.py
+++ b/programas/tests/test_becas_models.py
@@ -254,6 +254,7 @@ class FormularioTests(TestCase):
                 "nombre": "Juan",
                 "apellido": "Pérez",
                 "fecha_nacimiento": "1990-01-15",
+                "sexo": "M",
                 "origen": "manual",
             },
         )
@@ -261,6 +262,7 @@ class FormularioTests(TestCase):
         form.refresh_from_db()
         self.assertIsNotNone(form.ciudadano)
         self.assertEqual(form.ciudadano.dni, "99887766")
+        self.assertEqual(form.ciudadano.genero, "M")
         self.assertIsNone(form.datos_identificacion)
         self.assertTrue(Ciudadano.objects.filter(dni="99887766").exists())
 
@@ -280,6 +282,29 @@ class FormularioTests(TestCase):
         # No se modifican los datos del ciudadano existente
         self.assertEqual(existente.nombre, "Ana")
         self.assertEqual(existente.apellido, "López")
+
+    def test_sync_offline_completa_sexo_faltante_sin_pisar_uno_existente(self):
+        sin_genero = Ciudadano.objects.create(dni="55554445", nombre="Ana", apellido="López")
+        form = Formulario.objects.create(
+            relevamiento=self.rel,
+            celular="3624100200",
+            email_contacto="a@b.com",
+            datos_identificacion={"dni": sin_genero.dni, "sexo": "F"},
+        )
+        resolver_ciudadano_offline(form)
+        sin_genero.refresh_from_db()
+        self.assertEqual(sin_genero.genero, "F")
+
+        con_genero = Ciudadano.objects.create(dni="55554446", nombre="Luis", apellido="Pérez", genero="M")
+        otro_form = Formulario.objects.create(
+            relevamiento=self.rel,
+            celular="3624100201",
+            email_contacto="c@d.com",
+            datos_identificacion={"dni": con_genero.dni, "sexo": "F"},
+        )
+        resolver_ciudadano_offline(otro_form)
+        con_genero.refresh_from_db()
+        self.assertEqual(con_genero.genero, "M")
 
 
 class HelpersTests(TestCase):

--- a/programas/tests/test_becas_revision.py
+++ b/programas/tests/test_becas_revision.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import Group, User
 from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
@@ -16,17 +17,23 @@ from programas.forms import FormularioRevisionForm
 from programas.management.commands.seed_becas import ROL_ADMIN, ROL_COORDINADOR, ROL_TERRITORIAL
 from programas.models import (
     AsignacionCoordinador,
+    AdjuntoFormulario,
     Convocatoria,
     Formulario,
     ListaEspera,
+    PreguntaGlobal,
     Relevamiento,
     Segmento,
+    TipoCampo,
     TracaFormulario,
 )
 
 
 class _BaseRevisionTest(TestCase):
     def setUp(self):
+        # programa_becas() cachea una instancia de Programa. Cada TestCase
+        # revierte la base, por lo que no debe reutilizarse la PK del caso anterior.
+        cache.clear()
         call_command("seed_becas", stdout=StringIO())
         self.seg_a = Segmento.objects.create(nombre="Seg A", cupo_maximo=100)
         self.seg_b = Segmento.objects.create(nombre="Seg B", cupo_maximo=100)
@@ -116,6 +123,55 @@ class EdicionTrazaTests(_BaseRevisionTest):
         self.assertEqual(traza.first().valor_anterior, "3624100100")
         self.assertEqual(traza.first().valor_nuevo, "3624999999")
 
+    def test_adjunto_imagen_muestra_thumbnail_y_preview(self):
+        pregunta = PreguntaGlobal.objects.create(
+            texto="Foto DNI",
+            tipo=TipoCampo.ARCHIVO,
+            activo=True,
+        )
+        self.form_a.data = {
+            "globales": {str(pregunta.pk): {"archivo_adjunto": True}},
+            "requisitos": {},
+        }
+        self.form_a.save(update_fields=["data"])
+        AdjuntoFormulario.objects.create(
+            formulario=self.form_a,
+            pregunta_global=pregunta,
+            archivo=SimpleUploadedFile("dni.jpg", b"imagen", content_type="image/jpeg"),
+        )
+
+        resp = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "data-image-preview")
+        self.assertContains(resp, "<img", html=False)
+        self.assertContains(resp, "Ampliar imagen")
+
+    def test_detalle_muestra_fechas_y_mapa_de_la_toma(self):
+        self.form_a.gps_lat = "-34.577067"
+        self.form_a.gps_lng = "-58.486240"
+        self.form_a.save(update_fields=["gps_lat", "gps_lng"])
+
+        resp = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Trazabilidad de la toma")
+        self.assertContains(resp, "Fecha asignada")
+        self.assertContains(resp, "Capturado en el dispositivo")
+        self.assertContains(resp, "Recibido en el servidor")
+        self.assertContains(resp, "Última actualización")
+        self.assertContains(resp, "Mapa del lugar donde se realizó la toma")
+        self.assertContains(resp, "-34.577067")
+        self.assertContains(resp, "-58.486240")
+        self.assertContains(resp, "openstreetmap.org")
+
+    def test_detalle_sin_gps_informa_que_no_hay_coordenadas(self):
+        resp = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Este formulario no tiene coordenadas GPS registradas.")
+        self.assertNotContains(resp, "Mapa del lugar donde se realizó la toma")
+
     def test_editar_sin_cambios_no_traza(self):
         self.client.post(
             reverse("becas:formulario_detalle", args=[self.form_a.pk]),
@@ -155,6 +211,45 @@ class EdicionTrazaTests(_BaseRevisionTest):
             {"apoderado_nombre", "apoderado_apellido", "apoderado_fecha_nacimiento"},
         )
 
+    def test_detalle_adulto_sin_apoderado_oculta_sus_campos(self):
+        self.form_a.ciudadano = Ciudadano.objects.create(
+            dni="60600601",
+            nombre="Persona",
+            apellido="Adulta",
+            fecha_nacimiento=date(1990, 1, 1),
+        )
+        self.form_a.save(update_fields=["ciudadano"])
+
+        resp = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))
+
+        self.assertContains(resp, "Datos de contacto")
+        self.assertNotContains(resp, "Datos del apoderado")
+        self.assertNotContains(resp, 'name="apoderado_fecha_nacimiento"')
+
+    def test_detalle_menor_muestra_fecha_apoderado_en_formato_html(self):
+        self.form_a.ciudadano = Ciudadano.objects.create(
+            dni="60600602",
+            nombre="Persona",
+            apellido="Menor",
+            fecha_nacimiento=date(2020, 1, 1),
+        )
+        self.form_a.apoderado_nombre = "Ana"
+        self.form_a.apoderado_apellido = "Pérez"
+        self.form_a.apoderado_fecha_nacimiento = date(1993, 7, 13)
+        self.form_a.save(
+            update_fields=[
+                "ciudadano",
+                "apoderado_nombre",
+                "apoderado_apellido",
+                "apoderado_fecha_nacimiento",
+            ]
+        )
+
+        resp = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))
+
+        self.assertContains(resp, "Datos del apoderado")
+        self.assertContains(resp, 'value="1993-07-13"')
+
 
 class RevalidacionRenaperTests(_BaseRevisionTest):
     def setUp(self):
@@ -170,6 +265,27 @@ class RevalidacionRenaperTests(_BaseRevisionTest):
         self.form_a.ciudadano = self.ciudadano
         self.form_a.validado_renaper = False
         self.form_a.save(update_fields=["ciudadano", "validado_renaper"])
+
+    def test_admin_puede_completar_genero_desde_el_detalle(self):
+        self.ciudadano.genero = ""
+        self.ciudadano.save(update_fields=["genero"])
+        self.client.force_login(self.admin)
+
+        resp = self.client.post(
+            reverse("becas:formulario_actualizar_genero", args=[self.form_a.pk]),
+            {"genero": "F"},
+        )
+
+        self.assertRedirects(resp, reverse("becas:formulario_detalle", args=[self.form_a.pk]))
+        self.ciudadano.refresh_from_db()
+        self.assertEqual(self.ciudadano.genero, "F")
+        self.assertTrue(
+            TracaFormulario.objects.filter(
+                formulario=self.form_a,
+                campo="Ciudadano · sexo",
+                valor_nuevo="Femenino",
+            ).exists()
+        )
 
     @patch("programas.views.revision.consultar_datos_renaper")
     def test_admin_revalida_corrige_ciudadano_y_registra_traza(self, consultar):

--- a/programas/tests/test_becas_revision.py
+++ b/programas/tests/test_becas_revision.py
@@ -16,8 +16,8 @@ from legajos.models import Ciudadano
 from programas.forms import FormularioRevisionForm
 from programas.management.commands.seed_becas import ROL_ADMIN, ROL_COORDINADOR, ROL_TERRITORIAL
 from programas.models import (
-    AsignacionCoordinador,
     AdjuntoFormulario,
+    AsignacionCoordinador,
     Convocatoria,
     Formulario,
     ListaEspera,

--- a/programas/urls.py
+++ b/programas/urls.py
@@ -83,6 +83,11 @@ urlpatterns = [
     path("revision/formulario/<int:pk>/aprobar/", rev.formulario_aprobar, name="formulario_aprobar"),
     path("revision/formulario/<int:pk>/rechazar/", rev.formulario_rechazar, name="formulario_rechazar"),
     path(
+        "revision/formulario/<int:pk>/actualizar-genero/",
+        rev.formulario_actualizar_genero,
+        name="formulario_actualizar_genero",
+    ),
+    path(
         "revision/formulario/<int:pk>/revalidar-renaper/",
         rev.formulario_revalidar_renaper,
         name="formulario_revalidar_renaper",

--- a/programas/views/revision.py
+++ b/programas/views/revision.py
@@ -5,6 +5,9 @@ para iniciar revisión, editar contacto, aprobar/rechazar y terminar. Con alcanc
 por segmento. La validación SIS es un placeholder.
 """
 
+from pathlib import Path
+from urllib.parse import urlencode
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -16,7 +19,7 @@ from django.views.generic import ListView
 
 from core.rbac import CapacidadRequeridaMixin, puede, puede_alguna, requiere
 from legajos.services.consulta_renaper import consultar_datos_renaper
-from programas.forms import FormularioRevisionForm
+from programas.forms import CiudadanoGeneroRevisionForm, FormularioRevisionForm
 from programas.models import (
     Formulario,
     PreguntaGlobal,
@@ -26,12 +29,13 @@ from programas.models import (
     TipoCampo,
 )
 from programas.services.autorizacion import puede_gestionar_segmento, segmentos_visibles
-from programas.services.becas import registrar_traza
+from programas.services.becas import es_menor, registrar_traza
 from programas.services.cupo import aprobar_o_poner_en_espera
 
 CAP_REVISION_VER = "becas.revision.ver"
 CAP_REVISION_EDITAR = "becas.revision.editar"
 CAP_REVALIDAR_RENAPER = "becas.programa.administrar"
+EXTENSIONES_IMAGEN = {".avif", ".gif", ".jpeg", ".jpg", ".png", ".webp"}
 
 
 def _assert_scope_relevamiento(request, relevamiento):
@@ -157,11 +161,25 @@ def _respuestas_resueltas(formulario):
         label = campo.texto if campo else f"Campo #{k}"
         es_archivo = campo is not None and campo.tipo == TipoCampo.ARCHIVO
         adjunto = adjuntos_map.get(int(k)) if es_archivo and str(k).isdigit() else None
-        return {"label": label, "valor": v, "es_archivo": es_archivo, "adjunto": adjunto}
+        es_imagen = bool(
+            adjunto
+            and Path(adjunto.archivo.name or "").suffix.lower() in EXTENSIONES_IMAGEN
+        )
+        return {
+            "label": label,
+            "valor": v,
+            "es_multiple": isinstance(v, list),
+            "es_archivo": es_archivo,
+            "adjunto": adjunto,
+            "es_imagen": es_imagen,
+            "es_subsegmento": bool(getattr(campo, "subsegmento_id", None)),
+        }
 
     globales_list = [_fila(preguntas, adjuntos_pregunta, k, v) for k, v in globales.items()]
     requisitos_list = [_fila(requisitos_map, adjuntos_requisito, k, v) for k, v in requisitos.items()]
-    return globales_list, requisitos_list
+    requisitos_segmento = [item for item in requisitos_list if not item["es_subsegmento"]]
+    requisitos_subsegmento = [item for item in requisitos_list if item["es_subsegmento"]]
+    return globales_list, requisitos_segmento, requisitos_subsegmento
 
 
 @login_required
@@ -194,7 +212,42 @@ def formulario_detalle(request, pk):
     else:
         form = FormularioRevisionForm(instance=formulario)
 
-    globales_list, requisitos_list = _respuestas_resueltas(formulario)
+    globales_list, requisitos_segmento, requisitos_subsegmento = _respuestas_resueltas(formulario)
+    fecha_nacimiento = None
+    if formulario.ciudadano_id:
+        fecha_nacimiento = formulario.ciudadano.fecha_nacimiento
+    elif isinstance(formulario.datos_identificacion, dict):
+        fecha_nacimiento = formulario.datos_identificacion.get("fecha_nacimiento")
+        if isinstance(fecha_nacimiento, str):
+            fecha_nacimiento = parse_date(fecha_nacimiento)
+    tiene_datos_apoderado = bool(
+        formulario.apoderado_nombre
+        or formulario.apoderado_apellido
+        or formulario.apoderado_fecha_nacimiento
+    )
+    mostrar_apoderado = bool(es_menor(fecha_nacimiento) or tiene_datos_apoderado)
+    mapa = None
+    if formulario.gps_lat is not None and formulario.gps_lng is not None:
+        lat = float(formulario.gps_lat)
+        lng = float(formulario.gps_lng)
+        margen = 0.005
+        mapa = {
+            "latitud": formulario.gps_lat,
+            "longitud": formulario.gps_lng,
+            "embed_url": "https://www.openstreetmap.org/export/embed.html?"
+            + urlencode(
+                {
+                    "bbox": (
+                        f"{lng - margen:.6f},{lat - margen:.6f},"
+                        f"{lng + margen:.6f},{lat + margen:.6f}"
+                    ),
+                    "layer": "mapnik",
+                    "marker": f"{lat:.6f},{lng:.6f}",
+                }
+            ),
+            "open_url": "https://www.openstreetmap.org/?"
+            + urlencode({"mlat": f"{lat:.6f}", "mlon": f"{lng:.6f}", "zoom": 16}),
+        }
     return render(
         request,
         "programas/becas/revision/formulario_detalle.html",
@@ -202,12 +255,59 @@ def formulario_detalle(request, pk):
             "formulario": formulario,
             "relevamiento": formulario.relevamiento,
             "form": form,
+            "genero_form": CiudadanoGeneroRevisionForm(
+                initial={"genero": formulario.ciudadano.genero if formulario.ciudadano else ""}
+            ),
+            "mostrar_apoderado": mostrar_apoderado,
             "globales_list": globales_list,
-            "requisitos_list": requisitos_list,
+            "requisitos_segmento": requisitos_segmento,
+            "requisitos_subsegmento": requisitos_subsegmento,
+            "mapa": mapa,
             "trazas": formulario.trazas.select_related("editado_por")[:50],
             "puede_revalidar_renaper": puede(request.user, CAP_REVALIDAR_RENAPER),
         },
     )
+
+
+@login_required
+@requiere(CAP_REVALIDAR_RENAPER)
+def formulario_actualizar_genero(request, pk):
+    formulario = get_object_or_404(Formulario.objects.select_related("ciudadano"), pk=pk)
+    _assert_scope_formulario(request, formulario)
+    if request.method != "POST":
+        return redirect("becas:formulario_detalle", pk=formulario.pk)
+    if formulario.ciudadano is None:
+        messages.error(request, "El formulario no tiene un ciudadano vinculado.")
+        return redirect("becas:formulario_detalle", pk=formulario.pk)
+    if formulario.validado_renaper and formulario.ciudadano.genero:
+        messages.info(request, "La identidad ya fue validada por RENAPER; el sexo es de solo lectura.")
+        return redirect("becas:formulario_detalle", pk=formulario.pk)
+
+    form = CiudadanoGeneroRevisionForm(request.POST)
+    if not form.is_valid():
+        messages.error(request, "Seleccioná un sexo válido.")
+        return redirect("becas:formulario_detalle", pk=formulario.pk)
+
+    ciudadano = formulario.ciudadano
+    genero_anterior = ciudadano.genero
+    genero_nuevo = form.cleaned_data["genero"]
+    if genero_anterior == genero_nuevo:
+        messages.info(request, "El sexo no cambió.")
+        return redirect("becas:formulario_detalle", pk=formulario.pk)
+
+    etiquetas = dict(ciudadano.Genero.choices)
+    ciudadano.genero = genero_nuevo
+    ciudadano.save(update_fields=["genero", "modificado"])
+    registrar_traza(
+        formulario,
+        request.user,
+        [("Ciudadano · sexo", etiquetas.get(genero_anterior, "Sin informar"), etiquetas[genero_nuevo])],
+    )
+    if formulario.validado_renaper:
+        messages.success(request, "Sexo guardado.")
+    else:
+        messages.success(request, "Sexo guardado. Ya podés revalidar con RENAPER.")
+    return redirect("becas:formulario_detalle", pk=formulario.pk)
 
 
 @login_required

--- a/programas/views/revision.py
+++ b/programas/views/revision.py
@@ -161,10 +161,7 @@ def _respuestas_resueltas(formulario):
         label = campo.texto if campo else f"Campo #{k}"
         es_archivo = campo is not None and campo.tipo == TipoCampo.ARCHIVO
         adjunto = adjuntos_map.get(int(k)) if es_archivo and str(k).isdigit() else None
-        es_imagen = bool(
-            adjunto
-            and Path(adjunto.archivo.name or "").suffix.lower() in EXTENSIONES_IMAGEN
-        )
+        es_imagen = bool(adjunto and Path(adjunto.archivo.name or "").suffix.lower() in EXTENSIONES_IMAGEN)
         return {
             "label": label,
             "valor": v,
@@ -221,9 +218,7 @@ def formulario_detalle(request, pk):
         if isinstance(fecha_nacimiento, str):
             fecha_nacimiento = parse_date(fecha_nacimiento)
     tiene_datos_apoderado = bool(
-        formulario.apoderado_nombre
-        or formulario.apoderado_apellido
-        or formulario.apoderado_fecha_nacimiento
+        formulario.apoderado_nombre or formulario.apoderado_apellido or formulario.apoderado_fecha_nacimiento
     )
     mostrar_apoderado = bool(es_menor(fecha_nacimiento) or tiene_datos_apoderado)
     mapa = None
@@ -237,10 +232,7 @@ def formulario_detalle(request, pk):
             "embed_url": "https://www.openstreetmap.org/export/embed.html?"
             + urlencode(
                 {
-                    "bbox": (
-                        f"{lng - margen:.6f},{lat - margen:.6f},"
-                        f"{lng + margen:.6f},{lat + margen:.6f}"
-                    ),
+                    "bbox": (f"{lng - margen:.6f},{lat - margen:.6f},{lng + margen:.6f},{lat + margen:.6f}"),
                     "layer": "mapnik",
                     "marker": f"{lat:.6f},{lng:.6f}",
                 }


### PR DESCRIPTION
## Resumen
- corrige la carga dinámica de subsegmentos en nuevas convocatorias
- agrega recepción idempotente, fecha de captura y sincronización diferida para formularios mobile
- mejora la revisión con trazabilidad temporal, mapa, miniaturas, agrupación de respuestas y tratamiento de sexo/apoderado
- registra 4 h 50 min de trabajo en el informe financiero de julio

## App mobile relacionada
Los cambios complementarios se publicaron directamente en Mkdir-arg/Chaco-mobile@7139e0f.

## Validación
- 84 tests enfocados en Becas: OK
- django check: OK
- makemigrations --check --dry-run: sin cambios pendientes
- Expo Doctor: 18/18 checks
- export Android de Expo: OK

Closes #208
Closes #209