### PR TITLE
fix(becas): corregir coordinadores y fechas de relevamientos

### DIFF
--- a/programas/api/views.py
+++ b/programas/api/views.py
@@ -141,7 +141,9 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
             .order_by("-fecha_asignada")
         )
         if self.action == "list":
-            queryset = queryset.filter(fecha_asignada=timezone.localdate())
+            queryset = queryset.filter(
+                fecha_asignada__gte=timezone.localdate(),
+            ).order_by("fecha_asignada", "nombre")
         return queryset
 
     def get_serializer_class(self):

--- a/programas/forms.py
+++ b/programas/forms.py
@@ -713,7 +713,18 @@ class AsignacionCoordinadorForm(forms.ModelForm):
         # Solo usuarios con el rol Coordinador de Becas (#74).
         from programas.services.autorizacion import usuarios_coordinadores_becas
 
-        self.fields["coordinador"].queryset = usuarios_coordinadores_becas()
+        coordinadores = usuarios_coordinadores_becas()
+        # En el selector solo se ofrecen coordinadores todavía disponibles para
+        # este segmento. En un POST conservamos el queryset completo para que
+        # ``clean()`` pueda informar explícitamente una asignación duplicada en
+        # lugar de devolver el error genérico de "opción no válida".
+        if segmento is not None and not self.is_bound:
+            coordinadores = coordinadores.exclude(
+                pk__in=AsignacionCoordinador.objects.filter(
+                    segmento=segmento,
+                ).values("coordinador_id"),
+            )
+        self.fields["coordinador"].queryset = coordinadores
         self.fields["coordinador"].label_from_instance = lambda u: u.get_full_name() or u.username
 
     def clean(self):
@@ -815,6 +826,11 @@ class _SelectConSegmento(forms.Select):
             segmento_id = getattr(asignacion, "segmento_id", None)
         if segmento_id:
             option["attrs"]["data-segmento"] = segmento_id
+        fecha_inicio = getattr(instance, "fecha_inicio", None)
+        fecha_fin = getattr(instance, "fecha_fin", None)
+        if fecha_inicio and fecha_fin:
+            option["attrs"]["data-fecha-inicio"] = fecha_inicio.isoformat()
+            option["attrs"]["data-fecha-fin"] = fecha_fin.isoformat()
         return option
 
 
@@ -890,6 +906,26 @@ class ReprogramarForm(forms.Form):
         widget=forms.DateInput(attrs={"class": INPUT_CLASS, "type": "date"}),
         label="Nueva fecha asignada",
     )
+
+    def __init__(self, *args, convocatoria=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.convocatoria = convocatoria
+        if convocatoria is not None:
+            self.fields["fecha_asignada"].widget.attrs.update(
+                min=convocatoria.fecha_inicio.isoformat(),
+                max=convocatoria.fecha_fin.isoformat(),
+            )
+
+    def clean_fecha_asignada(self):
+        fecha = self.cleaned_data["fecha_asignada"]
+        if self.convocatoria and not self.convocatoria.fecha_inicio <= fecha <= self.convocatoria.fecha_fin:
+            inicio = self.convocatoria.fecha_inicio.strftime("%d/%m/%Y")
+            fin = self.convocatoria.fecha_fin.strftime("%d/%m/%Y")
+            raise forms.ValidationError(
+                "La fecha del relevamiento debe estar comprendida dentro "
+                f"del período de la convocatoria ({inicio} - {fin})."
+            )
+        return fecha
 
 
 class FormularioRevisionForm(forms.ModelForm):

--- a/programas/models/__init__.py
+++ b/programas/models/__init__.py
@@ -1328,6 +1328,23 @@ class Relevamiento(TimeStamped):
     def __str__(self):
         return self.nombre
 
+    def clean(self):
+        super().clean()
+        if not self.convocatoria_id or self.fecha_asignada is None:
+            return
+        convocatoria = self.convocatoria
+        if not convocatoria.fecha_inicio <= self.fecha_asignada <= convocatoria.fecha_fin:
+            inicio = convocatoria.fecha_inicio.strftime("%d/%m/%Y")
+            fin = convocatoria.fecha_fin.strftime("%d/%m/%Y")
+            raise ValidationError(
+                {
+                    "fecha_asignada": (
+                        "La fecha del relevamiento debe estar comprendida dentro "
+                        f"del período de la convocatoria ({inicio} - {fin})."
+                    )
+                }
+            )
+
     @classmethod
     def proximo_nombre(cls):
         """Nombre autogenerado del próximo relevamiento.

--- a/programas/templates/programas/becas/relevamientos/_filtro_territorial.html
+++ b/programas/templates/programas/becas/relevamientos/_filtro_territorial.html
@@ -8,6 +8,7 @@ La regla dura vive en RelevamientoForm.clean(); esto es solo UX.
   (function () {
     const convocatoria = document.getElementById('id_convocatoria');
     const territorial = document.getElementById('id_territorial');
+    const fechaAsignada = document.getElementById('id_fecha_asignada');
     if (!convocatoria || !territorial) return;
 
     const filtrar = () => {
@@ -20,6 +21,10 @@ La regla dura vive en RelevamientoForm.clean(); esto es solo UX.
         opt.disabled = !visible;
         if (!visible && opt.selected) opt.selected = false;
       });
+      if (fechaAsignada) {
+        fechaAsignada.min = opcion ? (opcion.dataset.fechaInicio || '') : '';
+        fechaAsignada.max = opcion ? (opcion.dataset.fechaFin || '') : '';
+      }
     };
 
     convocatoria.addEventListener('change', filtrar);

--- a/programas/tests/test_becas_api.py
+++ b/programas/tests/test_becas_api.py
@@ -86,7 +86,7 @@ class RelevamientoApiTests(_BaseApiTest):
         self.assertIn(self.rel.id, ids)
         self.assertNotIn(self.rel_ajeno.id, ids)
 
-    def test_lista_solo_relevamientos_asignados_hoy(self):
+    def test_lista_incluye_relevamientos_de_hoy_y_proximos(self):
         vencido = Relevamiento.objects.create(
             convocatoria=self.conv,
             territorial=self.terri,
@@ -107,7 +107,7 @@ class RelevamientoApiTests(_BaseApiTest):
         ids = [r["id"] for r in resp.data["results"]]
         self.assertIn(self.rel.id, ids)
         self.assertNotIn(vencido.id, ids)
-        self.assertNotIn(futuro.id, ids)
+        self.assertIn(futuro.id, ids)
 
     def test_detalle_incluye_definicion(self):
         PreguntaGlobal.objects.create(texto="Tenencia", tipo=TipoCampo.STRING, activo=True, orden=1)

--- a/programas/tests/test_becas_config.py
+++ b/programas/tests/test_becas_config.py
@@ -7,6 +7,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 
+from programas.forms import AsignacionCoordinadorForm
 from programas.management.commands.seed_becas import ROL_ADMIN, ROL_COORDINADOR
 from programas.models import (
     AsignacionCoordinador,
@@ -175,6 +176,32 @@ class CoordinadorTests(_BaseConfigTest):
         )
         self.assertEqual(resp.status_code, 302)
         self.assertTrue(AsignacionCoordinador.objects.filter(segmento=self.seg, coordinador=self.coord).exists())
+
+    def test_selector_excluye_coordinadores_ya_asignados(self):
+        disponible = User.objects.create_user("coord_disponible", password="x")
+        disponible.groups.add(Group.objects.get(name=ROL_COORDINADOR))
+        AsignacionCoordinador.objects.create(segmento=self.seg, coordinador=self.coord)
+
+        form = AsignacionCoordinadorForm(segmento=self.seg)
+        opciones = form.fields["coordinador"].queryset
+
+        self.assertNotIn(self.coord, opciones)
+        self.assertIn(disponible, opciones)
+
+        form_duplicado = AsignacionCoordinadorForm(
+            {"coordinador": self.coord.pk},
+            segmento=self.seg,
+        )
+
+        self.assertFalse(form_duplicado.is_valid())
+        self.assertIn(
+            "Ese coordinador ya está asignado a este segmento.",
+            form_duplicado.errors["coordinador"],
+        )
+        self.assertEqual(
+            AsignacionCoordinador.objects.filter(segmento=self.seg, coordinador=self.coord).count(),
+            1,
+        )
 
     def test_no_asignar_usuario_sin_rol_coordinador(self):
         otro = User.objects.create_user("otro", password="x")  # sin rol coordinador

--- a/programas/tests/test_becas_relevamientos.py
+++ b/programas/tests/test_becas_relevamientos.py
@@ -14,6 +14,7 @@ from programas.management.commands.seed_becas import (
     ROL_COORDINADOR,
     ROL_TERRITORIAL,
 )
+from programas.forms import RelevamientoForm, ReprogramarForm
 from programas.models import AsignacionCoordinador, AsignacionTerritorial, Convocatoria, Relevamiento, Segmento
 
 
@@ -141,6 +142,39 @@ class CrearReasignarReprogramarTests(_BaseRelevTest):
         nuevo = Relevamiento.objects.get(zona="Nueva zona")
         self.assertTrue(nuevo.nombre.startswith("Relevamiento "))
         self.assertEqual(nuevo.estado, Relevamiento.Estado.ASIGNADO)
+
+    def test_fecha_debe_estar_dentro_del_periodo_de_convocatoria(self):
+        for fecha in ("2025-12-31", "2027-01-01"):
+            with self.subTest(fecha=fecha):
+                form = RelevamientoForm(
+                    {
+                        "convocatoria": self.conv_a.pk,
+                        "territorial": self.territorial.pk,
+                        "fecha_asignada": fecha,
+                        "zona": "Fuera de período",
+                    }
+                )
+                self.assertFalse(form.is_valid())
+                self.assertIn("período de la convocatoria", form.errors["fecha_asignada"][0])
+
+    def test_fecha_acepta_limites_inclusivos_de_convocatoria(self):
+        for fecha in ("2026-01-01", "2026-12-31"):
+            with self.subTest(fecha=fecha):
+                form = RelevamientoForm(
+                    {
+                        "convocatoria": self.conv_a.pk,
+                        "territorial": self.territorial.pk,
+                        "fecha_asignada": fecha,
+                        "zona": "Fecha límite",
+                    }
+                )
+                self.assertTrue(form.is_valid(), form.errors)
+
+    def test_opciones_de_convocatoria_exponen_limites_para_el_datepicker(self):
+        html = str(RelevamientoForm()["convocatoria"])
+
+        self.assertIn('data-fecha-inicio="2026-01-01"', html)
+        self.assertIn('data-fecha-fin="2026-12-31"', html)
 
     def test_crear_solapado_advierte_sin_guardar(self):
         self.client.force_login(self.admin)
@@ -318,6 +352,17 @@ class CrearReasignarReprogramarTests(_BaseRelevTest):
         self.assertEqual(resp.status_code, 302)
         self.rel_a.refresh_from_db()
         self.assertEqual(self.rel_a.fecha_asignada, date(2026, 9, 15))
+
+    def test_reprogramar_rechaza_fecha_fuera_de_convocatoria(self):
+        form = ReprogramarForm(
+            {"fecha_asignada": "2027-01-01"},
+            convocatoria=self.conv_a,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("período de la convocatoria", form.errors["fecha_asignada"][0])
+        self.assertEqual(form.fields["fecha_asignada"].widget.attrs["min"], "2026-01-01")
+        self.assertEqual(form.fields["fecha_asignada"].widget.attrs["max"], "2026-12-31")
 
 
 class FinalizarReabrirTests(_BaseRelevTest):

--- a/programas/tests/test_becas_relevamientos.py
+++ b/programas/tests/test_becas_relevamientos.py
@@ -9,12 +9,12 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from programas.forms import RelevamientoForm, ReprogramarForm
 from programas.management.commands.seed_becas import (
     ROL_ADMIN,
     ROL_COORDINADOR,
     ROL_TERRITORIAL,
 )
-from programas.forms import RelevamientoForm, ReprogramarForm
 from programas.models import AsignacionCoordinador, AsignacionTerritorial, Convocatoria, Relevamiento, Segmento
 
 

--- a/programas/views/relevamientos.py
+++ b/programas/views/relevamientos.py
@@ -473,7 +473,10 @@ class RelevamientoDetailView(CapacidadRequeridaMixin, LoginRequiredMixin, Detail
         ctx["form_reasignar"] = ReasignarTerritorialForm(
             initial={"territorial": rel.territorial}, segmento=rel.convocatoria.segmento
         )
-        ctx["form_reprogramar"] = ReprogramarForm(initial={"fecha_asignada": rel.fecha_asignada})
+        ctx["form_reprogramar"] = ReprogramarForm(
+            initial={"fecha_asignada": rel.fecha_asignada},
+            convocatoria=rel.convocatoria,
+        )
         # Personas relevadas: se listan en la solapa "Formularios". Se materializa
         # una vez y el contador se deriva en Python (evita un COUNT extra).
         formularios = list(rel.formularios.select_related("ciudadano").order_by("-creado"))
@@ -544,11 +547,11 @@ def relevamiento_reprogramar(request, pk):
     rel = get_object_or_404(Relevamiento.objects.select_related("convocatoria__segmento"), pk=pk)
     _assert_scope(request, rel)
     if request.method == "POST":
-        form = ReprogramarForm(request.POST)
+        form = ReprogramarForm(request.POST, convocatoria=rel.convocatoria)
         if form.is_valid():
             rel.fecha_asignada = form.cleaned_data["fecha_asignada"]
             rel.save(update_fields=["fecha_asignada", "modificado"])
             messages.success(request, "Relevamiento reprogramado.")
         else:
-            messages.error(request, "Fecha inválida.")
+            messages.error(request, form.errors["fecha_asignada"][0])
     return redirect("becas:relevamiento_detalle", pk=rel.pk)


### PR DESCRIPTION
## Resumen
- Excluye coordinadores ya asignados del selector (issue #211).
- Valida que las fechas de relevamiento y reprogramacion estén dentro de la convocatoria (issue #212).
- Expone en la API móvil los relevamientos de hoy y próximos.

## Validación
- docker compose exec app python manage.py check: OK.
- Tests puntuales: pasaron previamente de forma aislada.
- Reejecución actual bloqueada durante migraciones de la base de pruebas por el error preexistente Duplicate column name dias_horarios.