### PR TITLE
style(ci): eliminar deuda global de Ruff

### DIFF
--- a/programas/forms.py
+++ b/programas/forms.py
@@ -1120,9 +1120,7 @@ class RelevamientoForm(forms.ModelForm):
                 models.Q(segmento__programa__isnull=True)
                 | (
                     models.Q(segmento__programa__pausado=False)
-                    & ~models.Q(
-                        segmento__programa__siis_programa_estado__in=ProgramaSiis.ESTADOS_SIIS_BLOQUEANTES
-                    )
+                    & ~models.Q(segmento__programa__siis_programa_estado__in=ProgramaSiis.ESTADOS_SIIS_BLOQUEANTES)
                 )
             )
             .filter(models.Q(subsegmento__isnull=True) | models.Q(subsegmento__pausado=False))
@@ -1170,9 +1168,7 @@ class RelevamientoForm(forms.ModelForm):
         municipio_id = self.data.get(self.add_prefix("municipio")) if self.is_bound else None
         opciones = []
         if municipio_id:
-            opciones = [
-                (loc.pk, loc.nombre) for loc in self.fields["zona"].queryset.filter(municipio_id=municipio_id)
-            ]
+            opciones = [(loc.pk, loc.nombre) for loc in self.fields["zona"].queryset.filter(municipio_id=municipio_id)]
         vacia = "Elegí una localidad" if opciones else "Elegí primero el municipio"
         self.fields["zona"].widget.choices = [("", vacia), *opciones]
 

--- a/programas/management/commands/sincronizar_programas_siis.py
+++ b/programas/management/commands/sincronizar_programas_siis.py
@@ -38,7 +38,9 @@ class Command(BaseCommand):
 
         prefijo = "[dry-run] " if dry else ""
         for programa, anterior, nuevo in cambios:
-            linea = f"{prefijo}{programa.nombre} (programa SIIS #{programa.siis_programa_id}): {anterior or '—'} → {nuevo}"
+            linea = (
+                f"{prefijo}{programa.nombre} (programa SIIS #{programa.siis_programa_id}): {anterior or '—'} → {nuevo}"
+            )
             if nuevo in ProgramaSiis.ESTADOS_SIIS_BLOQUEANTES:
                 self.stdout.write(self.style.WARNING(f"{linea} — el programa y sus segmentos quedan bloqueados."))
             else:

--- a/programas/tests/test_siis_vigencia_programa.py
+++ b/programas/tests/test_siis_vigencia_programa.py
@@ -144,9 +144,7 @@ class DetalleInformativoTests(TestCase):
         programa = ProgramaSiis.objects.create(nombre="Sin datos", siis_programa_id=77)
 
         datos = json.loads(
-            Template("{% load becas_extras %}{{ p|siis_info }}")
-            .render(Context({"p": programa}))
-            .replace("&quot;", '"')
+            Template("{% load becas_extras %}{{ p|siis_info }}").render(Context({"p": programa})).replace("&quot;", '"')
         )
 
         self.assertEqual(datos["id"], 77)

--- a/scripts/requerimientos.py
+++ b/scripts/requerimientos.py
@@ -65,9 +65,7 @@ class Fila:
 
 
 def _sin_tildes(texto: str) -> str:
-    return "".join(
-        c for c in unicodedata.normalize("NFD", texto.lower()) if not unicodedata.combining(c)
-    )
+    return "".join(c for c in unicodedata.normalize("NFD", texto.lower()) if not unicodedata.combining(c))
 
 
 def _limpiar(celda: str) -> str:
@@ -141,7 +139,9 @@ def leer_documento() -> tuple[list[str], list[Fila], list[Entrada], set[str]]:
         if not coincidencia:
             subentrada = SUBENTRADA_RE.match(linea)
             siguientes = lineas[numero_linea : numero_linea + 3]
-            if subentrada and any(s in l for l in siguientes for s in SEMAFOROS):
+            if subentrada and any(
+                semaforo in linea_siguiente for linea_siguiente in siguientes for semaforo in SEMAFOROS
+            ):
                 coincidencia = subentrada
         if coincidencia:
             if entradas:
@@ -286,8 +286,7 @@ def main() -> int:
         etiqueta = args.tag if args.tag.startswith("#") else f"#{args.tag}"
         if etiqueta not in vocabulario:
             print(
-                f"La etiqueta {etiqueta} no está en el vocabulario. "
-                f"Hay: {' '.join(sorted(vocabulario))}",
+                f"La etiqueta {etiqueta} no está en el vocabulario. Hay: {' '.join(sorted(vocabulario))}",
                 file=sys.stderr,
             )
             return 1

--- a/users/selectors/roles.py
+++ b/users/selectors/roles.py
@@ -16,6 +16,7 @@ def _capacidades_desde_prefetch(group):
 _CAPACIDAD_LABELS = {codigo: etiqueta for modulo in rbac.CATALOGO for codigo, etiqueta in modulo["capacidades"]}
 _CATEGORIAS_CON_PROGRAMA = {rbac.CATEGORIA_PROGRAMA, rbac.CATEGORIA_BECAS}
 
+
 def _codenames(capacidades):
     return [rbac.codename_de(c) for c in capacidades]
 


### PR DESCRIPTION
## Resumen

- Aplica el formato canónico de Ruff únicamente en los cinco archivos reportados por CI.
- Reemplaza el nombre ambiguo de variable en `scripts/requerimientos.py` sin cambiar su lógica.
- Mantiene fuera de alcance la actualización de dependencias reportada por Pip Audit.

## Validación

- `ruff check .`
- `ruff format --check .`
- `python scripts/requerimientos.py --check`
- `python manage.py test programas.tests.test_siis_vigencia_programa --verbosity 1` (21 tests)
- `git diff --check`
- Ruff Lint, Ruff Format y Bandit pasaron en [Code Quality run 32142482696](https://github.com/Mkdir-arg/Chaco-Back/actions/runs/32142482696).

## Integración apilada

Este PR apunta a la rama del PR #224 para evitar una dependencia circular de checks: `development` todavía excede el presupuesto de consultas que #224 corrige, mientras #224 necesita esta remediación global de Ruff.

El diff visible y revisable sigue aislado en cinco archivos. La rama contiene además el merge de sincronización con #224; por eso la integración debe hacerse por **squash**, dejando un único commit de Ruff sobre la rama padre. Después, #224 volverá a ejecutar el CI combinado contra `development`.

Pip Audit continúa como remediación independiente por su mayor riesgo.