### PR TITLE
perf(legajos,programas): eliminar lecturas repetidas y bajar los presupuestos medidos

### DIFF
--- a/legajos/selectors/ciudadanos.py
+++ b/legajos/selectors/ciudadanos.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 from django.core.cache import cache
-from django.db.models import Q
+from django.db.models import Count, Q
 
 from programas.models import DerivacionPrograma, InscripcionPrograma, Programa
 
@@ -64,10 +64,16 @@ def get_ciudadanos_queryset(search=""):
 
 
 def _build_ciudadanos_dashboard_metrics(total_ciudadanos=None):
-    total_inscripciones_activas = InscripcionPrograma.objects.filter(
-        estado__in=[InscripcionPrograma.Estado.ACTIVO, InscripcionPrograma.Estado.EN_SEGUIMIENTO]
-    ).count()
-    total_inscripciones = InscripcionPrograma.objects.count()
+    totales_inscripciones = InscripcionPrograma.objects.aggregate(
+        total=Count("id"),
+        activas=Count(
+            "id",
+            filter=Q(estado__in=[InscripcionPrograma.Estado.ACTIVO, InscripcionPrograma.Estado.EN_SEGUIMIENTO]),
+        ),
+        hoy=Count("id", filter=Q(fecha_inscripcion=date.today())),
+    )
+    total_inscripciones_activas = totales_inscripciones["activas"]
+    total_inscripciones = totales_inscripciones["total"]
     tasa_adherencia = round((total_inscripciones_activas / total_inscripciones * 100) if total_inscripciones > 0 else 0)
 
     return {
@@ -76,7 +82,7 @@ def _build_ciudadanos_dashboard_metrics(total_ciudadanos=None):
         ),
         "legajos_activos": total_inscripciones_activas,
         "alertas_criticas": AlertaCiudadano.objects.filter(activa=True).count(),
-        "seguimientos_hoy": InscripcionPrograma.objects.filter(fecha_inscripcion=date.today()).count(),
+        "seguimientos_hoy": totales_inscripciones["hoy"],
         "tasa_adherencia": tasa_adherencia,
         "casos_alto_riesgo": DerivacionPrograma.objects.filter(
             estado=DerivacionPrograma.Estado.PENDIENTE,
@@ -115,7 +121,8 @@ def build_ciudadano_detail_context(ciudadano, user=None):
         .order_by("-fecha_inscripcion")
     )
 
-    todas_las_solapas = SolapasService.obtener_solapas_ciudadano(ciudadano)
+    resumen_becas = SolapasService.obtener_resumen_becas_ciudadano(ciudadano)
+    todas_las_solapas = SolapasService.obtener_solapas_ciudadano(ciudadano, resumen_becas=resumen_becas)
     solapas = [
         solapa for solapa in todas_las_solapas if solapa["id"] != "legajos" and "ACOMPANAMIENTO" not in solapa["id"]
     ]
@@ -133,7 +140,6 @@ def build_ciudadano_detail_context(ciudadano, user=None):
 
     # --- Becas (issue #80): tab embebida, contenido con prefijo para evitar colisiones ---
     if any(solapa["id"] == "becas" for solapa in context["solapas_programas"]):
-        resumen_becas = SolapasService.obtener_resumen_becas_ciudadano(ciudadano)
         context["becas_formularios"] = resumen_becas["formularios"]
         context["becas_estado_texto"] = resumen_becas["estado_texto"]
         context["becas_estado_color"] = resumen_becas["estado_color"]
@@ -166,9 +172,12 @@ def build_ciudadano_detail_context(ciudadano, user=None):
         context["conversaciones_ciudadano"] = []
 
     # --- Derivaciones ---
-    context["derivaciones_ciudadano"] = ciudadano.derivaciones_programas.select_related(
-        "programa_origen", "programa_destino", "derivado_por"
-    ).order_by("-creado")[:20]
+    derivaciones_ciudadano = list(
+        ciudadano.derivaciones_programas.select_related("programa_origen", "programa_destino", "derivado_por").order_by(
+            "-creado"
+        )[:20]
+    )
+    context["derivaciones_ciudadano"] = derivaciones_ciudadano
 
     # --- Alertas ---
     context["alertas_ciudadano"] = ciudadano.alertas.filter(activa=True).order_by("prioridad", "-creado")
@@ -191,7 +200,7 @@ def build_ciudadano_detail_context(ciudadano, user=None):
             }
         )
 
-    for deriv in ciudadano.derivaciones_programas.select_related("programa_destino").order_by("-creado")[:10]:
+    for deriv in derivaciones_ciudadano[:10]:
         linea.append(
             {
                 "fecha": deriv.creado.date() if hasattr(deriv.creado, "date") else deriv.creado,

--- a/legajos/tests/test_ciudadano_detail_context_derivaciones.py
+++ b/legajos/tests/test_ciudadano_detail_context_derivaciones.py
@@ -1,0 +1,63 @@
+from datetime import timedelta
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from legajos.models import Ciudadano
+from legajos.selectors.ciudadanos import build_ciudadano_detail_context
+from programas.models import DerivacionPrograma, Programa
+
+
+class CiudadanoDetailContextDerivacionesTests(TestCase):
+    def test_conserva_derivaciones_y_limita_linea_de_tiempo_sin_n_plus_one(self):
+        ciudadano = Ciudadano.objects.create(dni="39000201", nombre="Ana", apellido="Derivaciones")
+        derivaciones = []
+        for indice in range(12):
+            programa = Programa.objects.create(
+                codigo=f"DERIVACION-{indice}",
+                nombre=f"Programa destino {indice}",
+            )
+            derivaciones.append(
+                DerivacionPrograma.objects.create(
+                    ciudadano=ciudadano,
+                    programa_destino=programa,
+                    motivo=f"Motivo {indice}",
+                    estado=DerivacionPrograma.Estado.PENDIENTE,
+                )
+            )
+            DerivacionPrograma.objects.filter(pk=derivaciones[-1].pk).update(
+                creado=timezone.now() + timedelta(minutes=indice)
+            )
+
+        with CaptureQueriesContext(connection) as queries:
+            context = build_ciudadano_detail_context(ciudadano)
+
+        derivaciones_esperadas = list(reversed(derivaciones))
+        self.assertEqual(context["derivaciones_ciudadano"], derivaciones_esperadas)
+        self.assertEqual(len(context["derivaciones_ciudadano"]), 12)
+
+        derivaciones_en_linea = [entrada for entrada in context["linea_tiempo"] if entrada["icono"] == "share-nodes"]
+        self.assertEqual(len(derivaciones_en_linea), 10)
+        self.assertEqual(
+            [entrada["titulo"] for entrada in derivaciones_en_linea],
+            [f"Derivación a {deriv.programa_destino.nombre}" for deriv in derivaciones_esperadas[:10]],
+        )
+        self.assertEqual(
+            [(entrada["descripcion"], entrada["color_hex"]) for entrada in derivaciones_en_linea],
+            [("Pendiente", "#F97316")] * 10,
+        )
+
+        consultas_programa_destino = [
+            query["sql"] for query in queries.captured_queries if 'FROM "programas_programa"' in query["sql"]
+        ]
+        self.assertEqual(consultas_programa_destino, [])
+
+    def test_sin_derivaciones_no_agrega_entradas_a_la_linea_de_tiempo(self):
+        ciudadano = Ciudadano.objects.create(dni="39000202", nombre="Bruno", apellido="Sin derivaciones")
+
+        context = build_ciudadano_detail_context(ciudadano)
+
+        self.assertEqual(context["derivaciones_ciudadano"], [])
+        self.assertFalse(any(entrada["icono"] == "share-nodes" for entrada in context["linea_tiempo"]))

--- a/legajos/tests/test_ciudadanos_selectors.py
+++ b/legajos/tests/test_ciudadanos_selectors.py
@@ -1,0 +1,48 @@
+from datetime import date, timedelta
+
+from django.test import TestCase
+
+from legajos.models import Ciudadano
+from legajos.selectors.ciudadanos import _build_ciudadanos_dashboard_metrics
+from programas.models import InscripcionPrograma, Programa
+
+
+class CiudadanosDashboardMetricsTests(TestCase):
+    def test_consolida_metricas_de_inscripciones_sin_cambiar_valores(self):
+        ciudadano = Ciudadano.objects.create(dni="39000200", nombre="Ana", apellido="Métricas")
+        inscripciones = []
+        for indice, estado in enumerate(
+            [
+                InscripcionPrograma.Estado.ACTIVO,
+                InscripcionPrograma.Estado.EN_SEGUIMIENTO,
+                InscripcionPrograma.Estado.CERRADO,
+            ]
+        ):
+            programa = Programa.objects.create(codigo=f"METRICAS-{indice}", nombre=f"Métricas {indice}")
+            inscripciones.append(
+                InscripcionPrograma.objects.create(ciudadano=ciudadano, programa=programa, estado=estado)
+            )
+
+        InscripcionPrograma.objects.filter(pk=inscripciones[1].pk).update(fecha_inscripcion=date.today() - timedelta(1))
+
+        with self.assertNumQueries(3):
+            metricas = _build_ciudadanos_dashboard_metrics(total_ciudadanos=17)
+
+        self.assertEqual(
+            metricas,
+            {
+                "total_ciudadanos": 17,
+                "legajos_activos": 2,
+                "alertas_criticas": 0,
+                "seguimientos_hoy": 2,
+                "tasa_adherencia": 67,
+                "casos_alto_riesgo": 0,
+            },
+        )
+
+    def test_sin_inscripciones_la_tasa_de_adherencia_es_cero(self):
+        metricas = _build_ciudadanos_dashboard_metrics(total_ciudadanos=0)
+
+        self.assertEqual(metricas["legajos_activos"], 0)
+        self.assertEqual(metricas["seguimientos_hoy"], 0)
+        self.assertEqual(metricas["tasa_adherencia"], 0)

--- a/programas/services/solapas.py
+++ b/programas/services/solapas.py
@@ -27,7 +27,7 @@ class SolapasService:
     ]
 
     @classmethod
-    def obtener_solapas_ciudadano(cls, ciudadano):
+    def obtener_solapas_ciudadano(cls, ciudadano, resumen_becas=None):
         solapas = [dict(s) for s in cls.SOLAPAS_ESTATICAS]
 
         inscripciones_activas = (
@@ -79,7 +79,7 @@ class SolapasService:
                 s = {**s, "badge": badges[s["id"]]}
             solapas_final.append(s)
 
-        solapa_becas = cls._obtener_solapa_becas(ciudadano)
+        solapa_becas = cls._obtener_solapa_becas(ciudadano, resumen_becas=resumen_becas)
         if solapa_becas:
             solapas_final.append(solapa_becas)
 
@@ -213,23 +213,28 @@ class SolapasService:
         return ascii_valor or "PROGRAMA"
 
     @classmethod
-    def _obtener_solapa_becas(cls, ciudadano):
+    def _obtener_solapa_becas(cls, ciudadano, resumen_becas=None):
         """Genera la solapa dinámica 'Becas' si el ciudadano tiene formularios (issue #80).
 
         Sin 'url': se renderiza embebida en el legajo (tab-becas), igual que Resumen
         o Conversaciones, en vez de redirigir a la página standalone.
         """
-        from programas.models import Formulario, ListaEspera
-        from programas.services.cupo import estado_relevante_becas
+        if resumen_becas is None:
+            from programas.models import Formulario, ListaEspera
+            from programas.services.cupo import estado_relevante_becas
 
-        formularios_qs = Formulario.objects.filter(ciudadano=ciudadano)
-        estados = set(formularios_qs.values_list("estado", flat=True))
-        if not estados:
-            return None
+            formularios_qs = Formulario.objects.filter(ciudadano=ciudadano)
+            estados = set(formularios_qs.values_list("estado", flat=True))
+            if not estados:
+                return None
 
-        en_espera = ListaEspera.objects.filter(formulario__ciudadano=ciudadano, promovido=False).exists()
-
-        texto, color = estado_relevante_becas(estados, en_espera)
+            en_espera = ListaEspera.objects.filter(formulario__ciudadano=ciudadano, promovido=False).exists()
+            texto, color = estado_relevante_becas(estados, en_espera)
+        else:
+            if not resumen_becas["formularios"]:
+                return None
+            texto = resumen_becas["estado_texto"]
+            color = resumen_becas["estado_color"]
         color_hex = {
             "success": "var(--text-fg-success)",
             "warning": "var(--text-fg-warning)",

--- a/programas/tests/test_solapa_becas.py
+++ b/programas/tests/test_solapa_becas.py
@@ -1,0 +1,59 @@
+from datetime import date
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from legajos.models import Ciudadano
+from programas.models import Convocatoria, Formulario, ListaEspera, ProgramaSiis, Relevamiento, Segmento
+from programas.services.solapas import SolapasService
+
+
+class SolapaBecasTests(TestCase):
+    def test_resumen_sin_formularios_ejecuta_una_sola_query(self):
+        ciudadano = Ciudadano.objects.create(dni="39000202", nombre="Cora", apellido="Sin becas")
+
+        with self.assertNumQueries(1):
+            resumen = SolapasService.obtener_resumen_becas_ciudadano(ciudadano)
+
+        self.assertEqual(resumen["formularios"], [])
+
+    def test_resumen_opcional_conserva_solapa_y_badge(self):
+        territorial = User.objects.create_user(username="territorial-solapa-becas")
+        ciudadano = Ciudadano.objects.create(dni="39000201", nombre="Beto", apellido="Becas")
+        programa = ProgramaSiis.objects.create(nombre="Programa becas", siis_programa_id=902)
+        segmento = Segmento.objects.create(programa=programa, nombre="Segmento becas", cupo_maximo=10)
+        convocatoria = Convocatoria.objects.create(
+            nombre="Convocatoria becas",
+            segmento=segmento,
+            fecha_inicio=date(2026, 1, 1),
+            fecha_fin=date(2026, 12, 31),
+        )
+        relevamiento = Relevamiento.objects.create(
+            convocatoria=convocatoria,
+            territorial=territorial,
+            fecha_asignada=date(2026, 6, 1),
+            fecha_hasta=date(2026, 6, 30),
+            zona="Zona becas",
+        )
+        formulario = Formulario.objects.create(
+            relevamiento=relevamiento,
+            ciudadano=ciudadano,
+            celular="3624000000",
+            email_contacto="solapa@example.com",
+        )
+        ListaEspera.objects.create(formulario=formulario, segmento=segmento, posicion=1)
+
+        solapas_sin_resumen = SolapasService.obtener_solapas_ciudadano(ciudadano)
+        resumen = SolapasService.obtener_resumen_becas_ciudadano(ciudadano)
+        solapas_con_resumen = SolapasService.obtener_solapas_ciudadano(ciudadano, resumen_becas=resumen)
+
+        self.assertEqual(solapas_sin_resumen, solapas_con_resumen)
+        solapa_becas = next(solapa for solapa in solapas_con_resumen if solapa["id"] == "becas")
+        self.assertEqual(
+            solapa_becas["badge"],
+            {
+                "tipo": "punto",
+                "color_hex": "var(--text-fg-warning)",
+                "title": "Lista de espera",
+            },
+        )

--- a/scripts/perf_budgets.json
+++ b/scripts/perf_budgets.json
@@ -7,7 +7,10 @@
     "maintenance": "Subir un max_queries requiere editar este archivo en el mismo PR que introduce la necesidad, con justificacion visible para review.",
     "adjustments": {
       "becas_relevamiento_detalle": "14→15: consulta fija del control de sesión única de Backoffice; el N+1 detectado en legajo_detalle fue eliminado sin ampliar su presupuesto.",
-      "becas_consulta_duplicada": "El baseline determinista actual tiene dos consultas normalizadas repetidas en cuatro rutas Becas; la nueva guarda bloquea cualquier incremento hasta que exista una optimización medida."
+      "becas_consulta_duplicada": "2→1 (#261): la repetición medida es 1, no 2. Las dos consultas no son redundantes: programa_becas() lee Programa codigo=BECAS y programa_dispositivos() lee codigo=DISPOSITIVOS desde el tag de sidebar. normalize_sql y sql_fingerprint reemplazan el literal por ?, así que agrupan dos lecturas distintas. Se baja el techo al valor medido; llegar a 0 exigiría eliminar una lectura de negocio diferente.",
+      "conversaciones_consulta_duplicada": "Se mantiene en 1 (#261): chats_no_atendidos cuenta estado=activa y el badge del sidebar cuenta estado=pendiente. Misma forma de SQL, parámetros distintos. Unificarlas exigiría fusionar dos caches de clave y TTL distintos, fuera del cuello medido.",
+      "optimizacion_261": "Medido con seed_perf scale 200 + perf_audit (SQLite, request fría): legajos_lista 14→12 unificando tres COUNT de InscripcionPrograma en un aggregate; legajo_detalle 23→20 calculando el resumen de Becas una sola vez por request y reutilizando las derivaciones ya leídas en la línea de tiempo. inicio queda en 19 medidas: sus lecturas restantes viven en módulos con cache e invalidación propias (dashboard.utils) y unificarlas excede el cuello medido.",
+      "presupuestos_261": "Cada ruta tocada queda en el valor medido + 1. Ese margen absorbe el UPDATE del control de sesión única de Backoffice, que la guarda le cobra a la primera ruta autenticada del recorrido y por lo tanto depende del orden de este archivo."
     },
     "timing": {
       "reference_total_ms": 220.92,
@@ -18,20 +21,20 @@
   },
   "budgets": {
     "login": {"route": "users:login", "max_queries": 0, "max_duplicate_queries": 0},
-    "inicio": {"route": "core:inicio", "max_queries": 21, "max_duplicate_queries": 0},
+    "inicio": {"route": "core:inicio", "max_queries": 20, "max_duplicate_queries": 0},
     "dashboard_redirect": {"route": "core:dashboard", "max_queries": 4, "max_duplicate_queries": 0},
     "dashboard_metricas": {"route": "dashboard:api_metricas", "max_queries": 10, "max_duplicate_queries": 0},
-    "legajos_lista": {"route": "legajos:ciudadanos", "max_queries": 16, "max_duplicate_queries": 0},
-    "legajo_detalle": {"route": "legajos:ciudadano_detalle", "max_queries": 27, "max_duplicate_queries": 0},
-    "conversaciones_lista": {"route": "conversaciones:lista", "max_queries": 16, "max_duplicate_queries": 1},
+    "legajos_lista": {"route": "legajos:ciudadanos", "max_queries": 13, "max_duplicate_queries": 0},
+    "legajo_detalle": {"route": "legajos:ciudadano_detalle", "max_queries": 21, "max_duplicate_queries": 0},
+    "conversaciones_lista": {"route": "conversaciones:lista", "max_queries": 15, "max_duplicate_queries": 1},
     "conversacion_detalle": {"route": "conversaciones:detalle", "max_queries": 14, "max_duplicate_queries": 0},
     "portal_home": {"route": "portal:home", "max_queries": 4, "max_duplicate_queries": 0},
     "portal_perfil": {"route": "portal:ciudadano_mi_perfil", "max_queries": 12, "max_duplicate_queries": 0},
     "portal_programas": {"route": "portal:ciudadano_mis_programas", "max_queries": 11, "max_duplicate_queries": 0},
     "portal_consultas": {"route": "portal:ciudadano_mis_consultas", "max_queries": 10, "max_duplicate_queries": 0},
-    "becas_segmentos": {"route": "becas:segmentos", "max_queries": 15, "max_duplicate_queries": 2},
-    "becas_convocatorias": {"route": "becas:convocatorias", "max_queries": 14, "max_duplicate_queries": 2},
-    "becas_relevamientos": {"route": "becas:relevamientos", "max_queries": 16, "max_duplicate_queries": 2},
-    "becas_relevamiento_detalle": {"route": "becas:relevamiento_detalle", "max_queries": 15, "max_duplicate_queries": 2}
+    "becas_segmentos": {"route": "becas:segmentos", "max_queries": 15, "max_duplicate_queries": 1},
+    "becas_convocatorias": {"route": "becas:convocatorias", "max_queries": 12, "max_duplicate_queries": 1},
+    "becas_relevamientos": {"route": "becas:relevamientos", "max_queries": 16, "max_duplicate_queries": 1},
+    "becas_relevamiento_detalle": {"route": "becas:relevamiento_detalle", "max_queries": 15, "max_duplicate_queries": 1}
   }
 }


### PR DESCRIPTION
Closes #261. Épica #222 · Análisis de origen #259.

## Qué hace

Elimina lecturas repetidas evitables en las dos rutas más caras y baja los presupuestos
versionados en el mismo PR, para que la guarda de CI proteja el nivel nuevo.

Ningún presupuesto sube.

## Medición determinista antes/después

`manage.py seed_perf --scale 200` + `scripts/perf_audit.py` (SQLite in-memory, request fría con
cache limpia). Los conteos son reproducibles: tres corridas dieron valores idénticos.

| Ruta | Queries antes | Queries después | Dup antes | Dup después | `max_queries` | `max_duplicate_queries` |
|---|---:|---:|---:|---:|---|---|
| `login` | 0 | 0 | 0 | 0 | 0 | 0 |
| `inicio` | 19 | 19 | 0 | 0 | **21 → 20** | 0 |
| `dashboard_redirect` | 4 | 4 | 0 | 0 | 4 | 0 |
| `dashboard_metricas` | 9 | 9 | 0 | 0 | 10 | 0 |
| `legajos_lista` | 14 | **12** | 0 | 0 | **16 → 13** | 0 |
| `legajo_detalle` | 23 | **20** | 0 | 0 | **27 → 21** | 0 |
| `conversaciones_lista` | 14 | 14 | 1 | 1 | **16 → 15** | 1 |
| `conversacion_detalle` | 12 | 12 | 0 | 0 | 14 | 0 |
| `portal_home` | 3 | 3 | 0 | 0 | 4 | 0 |
| `portal_perfil` | 11 | 11 | 0 | 0 | 12 | 0 |
| `portal_programas` | 9 | 9 | 0 | 0 | 11 | 0 |
| `portal_consultas` | 8 | 8 | 0 | 0 | 10 | 0 |
| `becas_segmentos` | 14 | 14 | 1 | 1 | 15 | **2 → 1** |
| `becas_convocatorias` | 11 | 11 | 1 | 1 | **14 → 12** | **2 → 1** |
| `becas_relevamientos` | 15 | 15 | 1 | 1 | 16 | **2 → 1** |
| `becas_relevamiento_detalle` | 14 | 14 | 1 | 1 | 15 | **2 → 1** |

El job `ephemeral-stack-contract` mide por `QueryCountMiddleware`, que es el middleware más
interno y por eso subcuenta. Simulado localmente, también baja:

| Ruta | Middleware antes | Middleware después |
|---|---:|---:|
| `inicio` | 14 | 14 |
| `legajos_lista` | 10 | **8** |
| `legajo_detalle` | 19 | **16** |

El resto de las rutas queda igual en ambos caminos.

## Optimizaciones aplicadas

**1. `legajos_lista` 14 → 12** — `_build_ciudadanos_dashboard_metrics` hacía tres `COUNT`
separados sobre `InscripcionPrograma` (activas, total, del día). Quedan unificados en un
`aggregate` con `Count` condicional. Mismo dict de retorno, misma clave y TTL de cache.

**2. `legajo_detalle` 23 → 21** — la solapa de Becas y su resumen leían lo mismo dos veces:
`_obtener_solapa_becas` consultaba `Formulario` + `ListaEspera` sólo para calcular el badge, y
`obtener_resumen_becas_ciudadano` volvía a consultarlos y recalculaba el mismo
`estado_relevante_becas`. Ahora el resumen se calcula una vez por request y el badge se deriva
de él, vía un parámetro opcional `resumen_becas`. Con el default `None` el camino es idéntico
al actual para los otros dos callers (`legajos/views/solapas.py`).

**3. `legajo_detalle` 21 → 20** — la línea de tiempo repetía la consulta de derivaciones que el
contexto ya traía con un `select_related` superset, mismo filtro y mismo orden. Se materializa
una vez y la línea de tiempo reutiliza sus primeros 10.

## Duplicadas: por qué no llegan a 0

Las cinco duplicadas toleradas **no son consultas redundantes**: son dos consultas de negocio
distintas que colapsan en el mismo fingerprint porque tanto `normalize_sql` (auditoría) como
`sql_fingerprint` (middleware) reemplazan el literal por `?`.

| Ruta | Consulta A | Consulta B |
|---|---|---|
| `becas_*` (4) | `programa_becas()` → `Programa WHERE codigo='BECAS'` | `programa_dispositivos()` → `Programa WHERE codigo='DISPOSITIVOS'`, desde el tag de sidebar |
| `conversaciones_lista` | `chats_no_atendidos` → `estado='activa'` | badge de sidebar → `estado='pendiente'` |

Son filas y contadores distintos: llevarlas a 0 exigiría eliminar una lectura de negocio o
fusionar dos caches con clave y TTL distintos (global vs por usuario), lo que excede el cuello
medido y cambiaría semántica de invalidación.

Lo que sí se hizo: **bajar el techo al valor medido**. La repetición real es 1, no 2, medida por
dos caminos independientes (auditoría SQLite y simulación del fingerprint del middleware), así
que las cuatro rutas Becas pasan de `max_duplicate_queries` 2 a 1.

## `inicio` no baja: evidencia

Sus 19 consultas son 8 agregados independientes más el render. Las tres sobre
`InscripcionPrograma` (`contar_legajos`, `registros_mes`, `contar_seguimientos_hoy`) sí podrían
unificarse, pero viven en `dashboard/utils.py`, las comparte `dashboard/views/home.py` y cada una
tiene su propia clave de cache e invalidación por señales (`legajos/signals/core.py` borra
`stats_legajos`). Unificarlas es un cambio de caching compartido, no el cuello medido de esta
task. Su presupuesto igual baja de 21 a 20.

## Validación

Corrida:
- `manage.py test --tag performance` con los presupuestos nuevos: **verde**.
- `scripts/check_perf_timing.py`: sin failure. En régimen da 1.21x–1.31x (warning >1.5x).
- 25 tests focalizados de `legajos` y solapas de `programas`: verdes.
- `manage.py check`: sin issues.
- `ruff check .` y `ruff format --check`: limpios.
- `perf_audit` antes y después: los `response_bytes` de las 16 rutas son idénticos byte a byte,
  evidencia de que no cambió el contenido renderizado.

No corrida localmente, verde en este PR:
- `ephemeral-stack-contract` (MySQL 8 + Redis), que necesita `PERFORMANCE_CI=1` y una base
  llamada exactamente `chaco_perf_ci`: localmente sólo se simuló su conteo. **En CI pasó**, lo
  que confirma que MySQL cuenta las duplicadas igual que la simulación y que el nuevo techo de 1
  se sostiene.
- Suite completa (`Tests & Coverage`): **verde en CI**.

## Riesgos

- Bajar `max_duplicate_queries` a 1 deja las cuatro rutas Becas sin margen: cualquier lectura
  nueva que comparta fingerprint con `Programa WHERE codigo = ?` rompe la guarda. El riesgo de
  que MySQL contara distinto que SQLite quedó descartado (el job efímero pasó), pero el margen
  cero es intencional y hace la guarda estricta.
- Los presupuestos que bajan quedan en medido + 1. Ese margen absorbe el `UPDATE` del control de
  sesión única de Backoffice, que la guarda le cobra a la primera ruta autenticada del recorrido
  y por lo tanto depende del orden de `perf_budgets.json`. Queda anotado en `_meta`.
- El smoke de tiempo es ruido en esta máquina: no muestra mejora medible. La reducción de
  consultas es el resultado real; el tiempo no se usa como evidencia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
