### PR TITLE
Fix: relevamientos y flujos de Becas

### DIFF
--- a/programas/api/views.py
+++ b/programas/api/views.py
@@ -170,10 +170,9 @@ class RelevamientoViewSet(viewsets.ReadOnlyModelViewSet):
         )
         if self.action == "list":
             ahora = timezone.now()
-            queryset = queryset.filter(
-                fecha_asignada__lte=ahora,
-                fecha_hasta__gte=ahora,
-            ).order_by("fecha_asignada", "nombre")
+            # La agenda del territorial incluye lo vigente y lo próximo. Las
+            # acciones operativas siguen validando que ya haya comenzado.
+            queryset = queryset.filter(fecha_hasta__gte=ahora).order_by("fecha_asignada", "nombre")
         return queryset
 
     def get_serializer_class(self):

--- a/programas/forms.py
+++ b/programas/forms.py
@@ -1,5 +1,6 @@
 """Formularios del backoffice de Programas."""
 
+import unicodedata
 from calendar import monthrange
 from collections import OrderedDict
 from datetime import datetime, time
@@ -46,7 +47,12 @@ CHECKBOX_CLASS = "h-4 w-4 rounded border-base text-fg-brand focus:ring-brand"
 
 
 def _catalogo_choices(items, empty_label):
-    return [("", empty_label)] + [(str(item["id"]), item["nombre"]) for item in items]
+    def clave_alfabetica(item):
+        nombre = str(item.get("nombre") or "")
+        return unicodedata.normalize("NFKD", nombre).encode("ascii", "ignore").decode().casefold()
+
+    items_ordenados = sorted(items, key=clave_alfabetica)
+    return [("", empty_label)] + [(str(item["id"]), item["nombre"]) for item in items_ordenados]
 
 
 def _cargar_catalogo(loader):

--- a/programas/models/__init__.py
+++ b/programas/models/__init__.py
@@ -1579,14 +1579,21 @@ class Relevamiento(PausableMixin, TimeStamped):
             raise ValidationError(errores)
 
     @classmethod
-    def proximo_nombre(cls):
+    def proximo_nombre(cls, convocatoria=None):
         """Nombre autogenerado del próximo relevamiento.
 
-        Usa ``Max(id)`` en vez de ``count()`` (evita el full scan y la carrera
+        Usa ``Max(numero)`` en vez de ``count()`` (evita el full scan y la carrera
         de dos altas simultáneas con el mismo número).
         """
-        siguiente = cls.proximo_numero()
-        return f"Relevamiento {siguiente:03d}"
+        siguiente = cls.proximo_numero(convocatoria)
+        return cls.nombre_para(convocatoria, siguiente)
+
+    @classmethod
+    def nombre_para(cls, convocatoria, numero):
+        nombre = f"Relevamiento {numero:03d}"
+        if convocatoria is not None:
+            nombre = f"{nombre} · {convocatoria.nombre}"
+        return nombre[: cls._meta.get_field("nombre").max_length]
 
     @classmethod
     def proximo_numero(cls, convocatoria=None):
@@ -1604,10 +1611,10 @@ class Relevamiento(PausableMixin, TimeStamped):
             with transaction.atomic():
                 Convocatoria.objects.select_for_update().get(pk=self.convocatoria_id)
                 self.numero = self.proximo_numero(self.convocatoria_id)
-                self.nombre = f"Relevamiento {self.numero:03d}"
+                self.nombre = self.nombre_para(self.convocatoria, self.numero)
                 return super().save(*args, **kwargs)
         if not self.nombre:
-            self.nombre = f"Relevamiento {self.numero:03d}"
+            self.nombre = self.nombre_para(self.convocatoria, self.numero)
         return super().save(*args, **kwargs)
 
     @classmethod

--- a/programas/templates/programas/becas/relevamientos/_filtro_territorial.html
+++ b/programas/templates/programas/becas/relevamientos/_filtro_territorial.html
@@ -23,12 +23,12 @@ La regla dura vive en RelevamientoForm.clean(); esto es solo UX.
         if (!visible && opt.selected) opt.selected = false;
       });
       if (fechaAsignada) {
-        fechaAsignada.min = opcion ? (opcion.dataset.fechaInicio || '') : '';
-        fechaAsignada.max = opcion ? (opcion.dataset.fechaFin || '') : '';
+        fechaAsignada.min = opcion && opcion.dataset.fechaInicio ? `${opcion.dataset.fechaInicio}T00:00` : '';
+        fechaAsignada.max = opcion && opcion.dataset.fechaFin ? `${opcion.dataset.fechaFin}T23:59` : '';
       }
       if (fechaHasta) {
-        fechaHasta.min = opcion ? (opcion.dataset.fechaInicio || '') : '';
-        fechaHasta.max = opcion ? (opcion.dataset.fechaFin || '') : '';
+        fechaHasta.min = opcion && opcion.dataset.fechaInicio ? `${opcion.dataset.fechaInicio}T00:00` : '';
+        fechaHasta.max = opcion && opcion.dataset.fechaFin ? `${opcion.dataset.fechaFin}T23:59` : '';
       }
     };
 

--- a/programas/templates/programas/becas/relevamientos/relevamiento_form.html
+++ b/programas/templates/programas/becas/relevamientos/relevamiento_form.html
@@ -5,7 +5,7 @@
 {% block main-content %}
 <div class="">
   <h1 class="text-3xl font-extrabold text-heading tracking-tight mb-1">Nuevo relevamiento</h1>
-  <p class="text-sm text-body-subtle mb-6">El nombre se genera automáticamente (Relevamiento NNN).</p>
+  <p class="text-sm text-body-subtle mb-6">El nombre se genera automáticamente con su número y convocatoria.</p>
   <form method="post" class="bg-white rounded-xl border border-base shadow-sm p-6">
     {% csrf_token %}
     {% if advertencia_solapamiento %}

--- a/programas/tests/test_becas_api.py
+++ b/programas/tests/test_becas_api.py
@@ -117,7 +117,7 @@ class RelevamientoApiTests(_BaseApiTest):
         propio = next(item for item in resp.data["results"] if item["id"] == self.rel.id)
         self.assertEqual(propio["localidad"], "Localidad Norte")
 
-    def test_lista_incluye_solo_relevamientos_vigentes_ahora(self):
+    def test_lista_incluye_relevamientos_vigentes_y_futuros(self):
         vencido = Relevamiento.objects.create(
             convocatoria=self.conv,
             territorial=self.terri,
@@ -138,7 +138,7 @@ class RelevamientoApiTests(_BaseApiTest):
         ids = [r["id"] for r in resp.data["results"]]
         self.assertIn(self.rel.id, ids)
         self.assertNotIn(vencido.id, ids)
-        self.assertNotIn(futuro.id, ids)
+        self.assertIn(futuro.id, ids)
 
         propio = next(item for item in resp.data["results"] if item["id"] == self.rel.id)
         self.assertIn("T", propio["fecha_asignada"])

--- a/programas/tests/test_becas_config.py
+++ b/programas/tests/test_becas_config.py
@@ -133,6 +133,22 @@ class ProgramaSiisConfigTests(_BaseConfigTest):
         # El nombre se toma tal cual del catálogo.
         self.assertEqual(programa.nombre, "Producción")
 
+    def test_modal_nuevo_programa_ordena_catalogo_alfabeticamente(self):
+        self.programas_siis.stop()
+        self.addCleanup(self.programas_siis.start)
+        with patch(
+            "programas.forms.listar_programas",
+            return_value=[
+                {"id": 3, "nombre": "Zoonosis", "estado": "ACTIVO"},
+                {"id": 1, "nombre": "Ángeles", "estado": "ACTIVO"},
+                {"id": 2, "nombre": "becas", "estado": "ACTIVO"},
+            ],
+        ):
+            resp = self.client.get(reverse("becas:programas"))
+
+        choices = list(resp.context["form_programa"].fields["siis_programa_id"].choices)
+        self.assertEqual([label for _, label in choices[1:]], ["Ángeles", "becas", "Zoonosis"])
+
     def test_detalle_del_programa(self):
         programa = ProgramaSiis.objects.create(nombre="Producción", siis_programa_id=38)
         Segmento.objects.create(programa=programa, nombre="Seg A", cupo_maximo=10)

--- a/programas/tests/test_becas_models.py
+++ b/programas/tests/test_becas_models.py
@@ -157,7 +157,7 @@ class RelevamientoTests(TestCase):
             fecha_asignada=date(2026, 6, 1),
             zona="Centro",
         )
-        self.assertEqual(rel.nombre, "Relevamiento 001")
+        self.assertEqual(rel.nombre, "Relevamiento 001 · Conv")
         self.assertEqual(rel.numero, 1)
         self.assertEqual(rel.estado, Relevamiento.Estado.ASIGNADO)
 
@@ -178,6 +178,9 @@ class RelevamientoTests(TestCase):
             convocatoria=otra_conv, territorial=self.territorial, fecha_asignada=date(2026, 6, 1), zona="C"
         )
         self.assertEqual((primero.numero, segundo.numero, primero_otra.numero), (1, 2, 1))
+        self.assertEqual(primero.nombre, "Relevamiento 001 · Conv")
+        self.assertEqual(segundo.nombre, "Relevamiento 002 · Conv")
+        self.assertEqual(primero_otra.nombre, "Relevamiento 001 · Otra")
 
 
 class CamposFormularioTests(TestCase):

--- a/programas/tests/test_becas_relevamientos.py
+++ b/programas/tests/test_becas_relevamientos.py
@@ -155,7 +155,7 @@ class CrearReasignarReprogramarTests(_BaseRelevTest):
         )
         self.assertEqual(resp.status_code, 302)
         nuevo = Relevamiento.objects.get(zona=self.localidad.nombre)
-        self.assertTrue(nuevo.nombre.startswith("Relevamiento "))
+        self.assertEqual(nuevo.nombre, "Relevamiento 002 · Conv A")
         self.assertEqual(nuevo.estado, Relevamiento.Estado.ASIGNADO)
 
     def test_fecha_debe_estar_dentro_del_periodo_de_convocatoria(self):
@@ -186,6 +186,21 @@ class CrearReasignarReprogramarTests(_BaseRelevTest):
                     }
                 )
                 self.assertTrue(form.is_valid(), form.errors)
+
+    def test_fecha_hasta_debe_estar_dentro_del_periodo_de_convocatoria(self):
+        form = RelevamientoForm(
+            {
+                "convocatoria": self.conv_a.pk,
+                "territorial": self.territorial.pk,
+                "fecha_asignada": "2026-12-31T08:00",
+                "fecha_hasta": "2027-01-01T08:00",
+                "municipio": self.municipio.pk,
+                "zona": self.localidad.pk,
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("período de la convocatoria", form.errors["fecha_hasta"][0])
 
     def test_opciones_de_convocatoria_exponen_limites_para_el_datepicker(self):
         html = str(RelevamientoForm()["convocatoria"])

--- a/users/tests/test_credenciales.py
+++ b/users/tests/test_credenciales.py
@@ -89,6 +89,7 @@ class CambioObligatorioPrimerLoginTests(TestCase):
         respuesta = self.client.get(self.destino)
 
         self.assertEqual(respuesta.status_code, 200)
+        self.assertContains(respuesta, f'method="post" action="{reverse("users:logout")}"')
 
     def test_al_cambiarla_se_libera_el_acceso_y_no_se_pierde_la_sesion(self):
         self.client.force_login(self.user)
@@ -106,3 +107,14 @@ class CambioObligatorioPrimerLoginTests(TestCase):
         # o BackofficeSingleSessionMiddleware expulsa al usuario en el próximo request.
         self.assertEqual(self.user.profile.backoffice_session_key, self.client.session.session_key)
         self.assertEqual(self.client.get(reverse("core:inicio")).status_code, 200)
+
+
+class LogoutTests(TestCase):
+    def test_logout_por_post_cierra_la_sesion(self):
+        user = User.objects.create_user(username="operador.logout", password="clave-segura")
+        self.client.force_login(user)
+
+        respuesta = self.client.post(reverse("users:logout"))
+
+        self.assertEqual(respuesta.status_code, 302)
+        self.assertNotIn("_auth_user_id", self.client.session)


### PR DESCRIPTION
## Resumen
- ordena alfabeticamente catalogos consumidos desde SIIS
- corrige logout por POST con CSRF
- genera nombres de relevamientos por convocatoria y limita fechas a su vigencia
- incluye relevamientos vigentes y proximos en la API territorial
- ajusta filtros y pruebas relacionadas

## Validacion
- docker compose exec app python manage.py check: OK
- 162/165 pruebas seleccionadas: OK
- LogoutTests: OK
- 3 errores preexistentes en CambioObligatorioPrimerLoginTests: el setUp espera User.profile automatico, pero origin/development no registra ese signal en este entorno
- git diff --check: OK