### PR TITLE
Fix: ampliar client_uuid en MySQL

### DIFF
--- a/programas/migrations/0047_ampliar_formulario_client_uuid.py
+++ b/programas/migrations/0047_ampliar_formulario_client_uuid.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def ampliar_client_uuid_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE programas_formulario MODIFY client_uuid char(36) NULL"
+    )
+
+
+def restaurar_client_uuid_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE programas_formulario MODIFY client_uuid char(32) NULL"
+    )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("programas", "0046_relevamiento_franja_horaria"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            ampliar_client_uuid_mysql,
+            restaurar_client_uuid_mysql,
+        ),
+    ]


### PR DESCRIPTION
## Causa confirmada por logs

El POST falla durante el INSERT con:

`django.db.utils.DataError: (1406, "Data too long for column 'client_uuid' at row 1")`

La columna física `programas_formulario.client_uuid` admite 32 caracteres, mientras el MySQL/MariaDB del entorno recibe la representación UUID de 36 caracteres.

## Solución

Agrega la migración `0047_ampliar_formulario_client_uuid`, que amplía la columna a `char(36)` únicamente en MySQL. En SQLite es una operación neutra. Se conserva el índice único y no se modifica la lógica de la API.

## Validación

- `makemigrations --check --dry-run`: sin cambios pendientes.
- Tests específicos de creación y reintento idempotente: 2/2 OK.
- Rama basada en `development`; un único archivo de migración.

## Verificación posterior al deploy

Repetir el POST con el mismo UUID: debe responder 201 y luego 200 con el mismo ID.
