### PR TITLE
fix(becas): ampliar UUID de validación SIIS en MySQL

### DIFF
--- a/legajos/migrations/0007_ampliar_uuid_legajos.py
+++ b/legajos/migrations/0007_ampliar_uuid_legajos.py
@@ -1,0 +1,86 @@
+from django.db import migrations
+
+
+FK_ALERTA = "legajos_alertaciudad_legajo_id_82fefd0e_fk_legajos_l"
+FK_HISTORIAL = "legajos_historialcon_legajo_id_beafe3f5_fk_legajos_l"
+
+
+def _normalizar_uuid(schema_editor, tabla, columna, con_guiones):
+    if con_guiones:
+        valor = (
+            f"CONCAT(SUBSTRING({columna}, 1, 8), '-', "
+            f"SUBSTRING({columna}, 9, 4), '-', SUBSTRING({columna}, 13, 4), '-', "
+            f"SUBSTRING({columna}, 17, 4), '-', SUBSTRING({columna}, 21, 12))"
+        )
+        longitud = 32
+    else:
+        valor = f"REPLACE({columna}, '-', '')"
+        longitud = 36
+    schema_editor.execute(
+        f"UPDATE {tabla} SET {columna} = {valor} WHERE CHAR_LENGTH({columna}) = {longitud}"
+    )
+
+
+def _quitar_foreign_keys(schema_editor):
+    schema_editor.execute(
+        f"ALTER TABLE legajos_alertaciudadano DROP FOREIGN KEY {FK_ALERTA}"
+    )
+    schema_editor.execute(
+        f"ALTER TABLE legajos_historialcontacto DROP FOREIGN KEY {FK_HISTORIAL}"
+    )
+
+
+def _crear_foreign_keys(schema_editor):
+    schema_editor.execute(
+        f"ALTER TABLE legajos_alertaciudadano ADD CONSTRAINT {FK_ALERTA} "
+        "FOREIGN KEY (legajo_id) REFERENCES legajos_legajoatencion (id)"
+    )
+    schema_editor.execute(
+        f"ALTER TABLE legajos_historialcontacto ADD CONSTRAINT {FK_HISTORIAL} "
+        "FOREIGN KEY (legajo_id) REFERENCES legajos_legajoatencion (id)"
+    )
+
+
+def ampliar_uuid_legajos_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    _quitar_foreign_keys(schema_editor)
+    columnas = (
+        ("legajos_legajoatencion", "id", "NOT NULL"),
+        ("legajos_alertaciudadano", "legajo_id", "NULL"),
+        ("legajos_historialcontacto", "legajo_id", "NOT NULL"),
+        ("legajos_adjunto", "object_id", "NOT NULL"),
+    )
+    for tabla, columna, nulabilidad in columnas:
+        schema_editor.execute(f"ALTER TABLE {tabla} MODIFY {columna} char(36) {nulabilidad}")
+        # Solo MariaDB 10.7+ usa UUID nativo; MySQL conserva el formato hex de 32.
+        if schema_editor.connection.features.has_native_uuid_field:
+            _normalizar_uuid(schema_editor, tabla, columna, con_guiones=True)
+    _crear_foreign_keys(schema_editor)
+
+
+def restaurar_uuid_legajos_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    _quitar_foreign_keys(schema_editor)
+    columnas = (
+        ("legajos_adjunto", "object_id", "NOT NULL"),
+        ("legajos_historialcontacto", "legajo_id", "NOT NULL"),
+        ("legajos_alertaciudadano", "legajo_id", "NULL"),
+        ("legajos_legajoatencion", "id", "NOT NULL"),
+    )
+    for tabla, columna, nulabilidad in columnas:
+        if schema_editor.connection.features.has_native_uuid_field:
+            _normalizar_uuid(schema_editor, tabla, columna, con_guiones=False)
+        schema_editor.execute(f"ALTER TABLE {tabla} MODIFY {columna} char(32) {nulabilidad}")
+    _crear_foreign_keys(schema_editor)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [("legajos", "0006_desactivar_alertas_sin_red_familiar")]
+
+    operations = [
+        migrations.RunPython(ampliar_uuid_legajos_mysql, restaurar_uuid_legajos_mysql),
+    ]

--- a/programas/migrations/0048_ampliar_validacionsis_id_consulta.py
+++ b/programas/migrations/0048_ampliar_validacionsis_id_consulta.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def ampliar_id_consulta_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE programas_validacionsis MODIFY id_consulta char(36) NULL"
+    )
+
+
+def restaurar_id_consulta_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE programas_validacionsis MODIFY id_consulta char(32) NULL"
+    )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [("programas", "0047_ampliar_formulario_client_uuid")]
+
+    operations = [
+        migrations.RunPython(
+            ampliar_id_consulta_mysql,
+            restaurar_id_consulta_mysql,
+        ),
+    ]

--- a/programas/migrations/0048_ampliar_validacionsis_id_consulta.py
+++ b/programas/migrations/0048_ampliar_validacionsis_id_consulta.py
@@ -1,20 +1,47 @@
 from django.db import migrations
 
 
+COLUMNAS_UUID = (
+    ("programas_formulario", "client_uuid", "NULL"),
+    ("programas_validacionsis", "id_consulta", "NULL"),
+    ("programas_inscripcionprograma", "legajo_id", "NULL"),
+)
+
+
+def _normalizar_uuid(schema_editor, tabla, columna, con_guiones):
+    if con_guiones:
+        valor = (
+            f"CONCAT(SUBSTRING({columna}, 1, 8), '-', "
+            f"SUBSTRING({columna}, 9, 4), '-', SUBSTRING({columna}, 13, 4), '-', "
+            f"SUBSTRING({columna}, 17, 4), '-', SUBSTRING({columna}, 21, 12))"
+        )
+        condicion = f"CHAR_LENGTH({columna}) = 32"
+    else:
+        valor = f"REPLACE({columna}, '-', '')"
+        condicion = f"CHAR_LENGTH({columna}) = 36"
+    schema_editor.execute(
+        f"UPDATE {tabla} SET {columna} = {valor} WHERE {columna} IS NOT NULL AND {condicion}"
+    )
+
+
 def ampliar_id_consulta_mysql(apps, schema_editor):
     if schema_editor.connection.vendor != "mysql":
         return
-    schema_editor.execute(
-        "ALTER TABLE programas_validacionsis MODIFY id_consulta char(36) NULL"
-    )
+    for tabla, columna, nulabilidad in COLUMNAS_UUID:
+        schema_editor.execute(f"ALTER TABLE {tabla} MODIFY {columna} char(36) {nulabilidad}")
+        # MariaDB 10.7+ usa UUID nativo y Django envía valores con guiones.
+        # MySQL sigue serializando UUIDField como 32 caracteres hexadecimales.
+        if schema_editor.connection.features.has_native_uuid_field:
+            _normalizar_uuid(schema_editor, tabla, columna, con_guiones=True)
 
 
 def restaurar_id_consulta_mysql(apps, schema_editor):
     if schema_editor.connection.vendor != "mysql":
         return
-    schema_editor.execute(
-        "ALTER TABLE programas_validacionsis MODIFY id_consulta char(32) NULL"
-    )
+    for tabla, columna, nulabilidad in reversed(COLUMNAS_UUID):
+        if schema_editor.connection.features.has_native_uuid_field:
+            _normalizar_uuid(schema_editor, tabla, columna, con_guiones=False)
+        schema_editor.execute(f"ALTER TABLE {tabla} MODIFY {columna} char(32) {nulabilidad}")
 
 
 class Migration(migrations.Migration):

--- a/programas/tests/test_becas_models.py
+++ b/programas/tests/test_becas_models.py
@@ -42,6 +42,12 @@ class UUIDExternosMySQLTests(TestCase):
         columnas = (
             ("programas_formulario", "client_uuid"),
             ("programas_validacionsis", "id_consulta"),
+            ("programas_inscripcionprograma", "legajo_id"),
+            ("users_solicitudcambioemail", "token"),
+            ("legajos_legajoatencion", "id"),
+            ("legajos_alertaciudadano", "legajo_id"),
+            ("legajos_historialcontacto", "legajo_id"),
+            ("legajos_adjunto", "object_id"),
         )
         with connection.cursor() as cursor:
             for tabla, columna in columnas:

--- a/programas/tests/test_becas_models.py
+++ b/programas/tests/test_becas_models.py
@@ -6,6 +6,7 @@ from io import StringIO
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
+from django.db import connection
 from django.test import TestCase
 
 from legajos.models import Ciudadano
@@ -29,6 +30,34 @@ from programas.services.becas import (
     get_segmentos_coordinador,
     resolver_ciudadano_offline,
 )
+
+
+class UUIDExternosMySQLTests(TestCase):
+    """Los UUID recibidos por API deben admitir su representación con guiones."""
+
+    def test_columnas_uuid_externas_admiten_36_caracteres(self):
+        if connection.vendor != "mysql":
+            self.skipTest("La longitud física comprobada corresponde a MySQL.")
+
+        columnas = (
+            ("programas_formulario", "client_uuid"),
+            ("programas_validacionsis", "id_consulta"),
+        )
+        with connection.cursor() as cursor:
+            for tabla, columna in columnas:
+                cursor.execute(
+                    """
+                    SELECT CHARACTER_MAXIMUM_LENGTH
+                    FROM information_schema.COLUMNS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME = %s
+                      AND COLUMN_NAME = %s
+                    """,
+                    [tabla, columna],
+                )
+                fila = cursor.fetchone()
+                self.assertIsNotNone(fila, f"No existe {tabla}.{columna}")
+                self.assertGreaterEqual(fila[0], 36, f"{tabla}.{columna} no admite UUID con guiones")
 
 
 class SeedBecasCommandTests(TestCase):

--- a/programas/tests/test_becas_revision.py
+++ b/programas/tests/test_becas_revision.py
@@ -483,7 +483,11 @@ class AprobarRechazarTests(_BaseRevisionTest):
         self.validar_compatibilidad.return_value = {
             "success": True,
             "compatible": True,
-            "data": {"id_programa": 41, "validaciones": {}},
+            "data": {
+                "id_programa": 41,
+                "id_consulta": "8ef13bfb-529a-4438-a8b4-dca8b238039a",
+                "validaciones": {},
+            },
         }
         self.ciudadano = Ciudadano.objects.create(
             dni="24459123", nombre="Persona", apellido="Compatible", fecha_nacimiento=date(1975, 2, 20), genero="F"
@@ -604,6 +608,10 @@ class AprobarRechazarTests(_BaseRevisionTest):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self.form_a.validaciones_sis.count(), 2)
+        self.assertEqual(
+            str(self.form_a.validaciones_sis.first().id_consulta),
+            "8ef13bfb-529a-4438-a8b4-dca8b238039a",
+        )
 
     def test_coordinador_ve_boton_validar_siis(self):
         response = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))

--- a/users/migrations/0023_ampliar_solicitud_cambio_email_token.py
+++ b/users/migrations/0023_ampliar_solicitud_cambio_email_token.py
@@ -1,0 +1,45 @@
+from django.db import migrations
+
+
+def ampliar_token_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    schema_editor.execute(
+        "ALTER TABLE users_solicitudcambioemail MODIFY token char(36) NOT NULL"
+    )
+    # Solo MariaDB 10.7+ usa UUID nativo; MySQL conserva el formato hex de 32.
+    if schema_editor.connection.features.has_native_uuid_field:
+        schema_editor.execute(
+            """
+            UPDATE users_solicitudcambioemail
+            SET token = CONCAT(
+                SUBSTRING(token, 1, 8), '-', SUBSTRING(token, 9, 4), '-',
+                SUBSTRING(token, 13, 4), '-', SUBSTRING(token, 17, 4), '-',
+                SUBSTRING(token, 21, 12)
+            )
+            WHERE CHAR_LENGTH(token) = 32
+            """
+        )
+
+
+def restaurar_token_mysql(apps, schema_editor):
+    if schema_editor.connection.vendor != "mysql":
+        return
+    if schema_editor.connection.features.has_native_uuid_field:
+        schema_editor.execute(
+            "UPDATE users_solicitudcambioemail SET token = REPLACE(token, '-', '') "
+            "WHERE CHAR_LENGTH(token) = 36"
+        )
+    schema_editor.execute(
+        "ALTER TABLE users_solicitudcambioemail MODIFY token char(32) NOT NULL"
+    )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [("users", "0022_profile_debe_cambiar_contrasena")]
+
+    operations = [
+        migrations.RunPython(ampliar_token_mysql, restaurar_token_mysql),
+    ]


### PR DESCRIPTION
## Problema

La validación manual de SIIS respondía HTTP 500 al persistir el UUID de consulta en MySQL: la columna física tenía 32 caracteres y el entorno guarda la representación con guiones de 36 caracteres.

## Solución

- Amplía programas_validacionsis.id_consulta a char(36) mediante la migración 