### PR TITLE
Formulario público de Becas — Fase 3: formulario dinámico e ingesta end-to-end (#294 #295)

### DIFF
--- a/portal/forms/inscripcion.py
+++ b/portal/forms/inscripcion.py
@@ -1,8 +1,15 @@
-"""Formulario del paso 1 de la inscripción pública de Becas (#293)."""
+"""Formularios de la inscripción pública de Becas (#293 paso 1, #294 paso 2)."""
 
 from django import forms
+from django.utils.dateparse import parse_date
+
+from programas.services.becas import es_menor
 
 INPUT_CLASS = "nodo-field w-full"
+
+# Archivos del formulario público: upload anónimo, límites duros (análisis #289).
+ARCHIVO_EXTENSIONES = (".jpg", ".jpeg", ".png", ".pdf")
+ARCHIVO_MAX_BYTES = 5 * 1024 * 1024
 
 
 class InscripcionPaso1Form(forms.Form):
@@ -34,3 +41,188 @@ class InscripcionPaso1Form(forms.Form):
         if sexo not in ("F", "M"):
             raise forms.ValidationError("Seleccioná una opción.")
         return sexo
+
+
+def _validar_archivo(archivo):
+    nombre = (archivo.name or "").lower()
+    if not nombre.endswith(ARCHIVO_EXTENSIONES):
+        raise forms.ValidationError("Solo se aceptan archivos JPG, PNG o PDF.")
+    if archivo.size > ARCHIVO_MAX_BYTES:
+        raise forms.ValidationError("El archivo no puede superar los 5 MB.")
+
+
+def _field_para_campo(campo):
+    """Traduce un campo de ``definicion_formulario`` (la misma definición que
+    consume la app, RN-P12) a un field de Django. Tipos: ``TipoCampo``."""
+    etiqueta = campo["texto"]
+    requerido = bool(campo["obligatorio"])
+    tipo = campo["tipo"]
+    if tipo == "INT":
+        return forms.IntegerField(
+            label=etiqueta,
+            required=requerido,
+            widget=forms.NumberInput(attrs={"class": INPUT_CLASS, "inputmode": "numeric"}),
+        )
+    if tipo == "SELECTOR":
+        opciones = [("", "Elegí una opción")] + [(o, o) for o in campo["opciones"]]
+        return forms.ChoiceField(
+            label=etiqueta, required=requerido, choices=opciones, widget=forms.Select(attrs={"class": INPUT_CLASS})
+        )
+    if tipo == "SELECTOR_MULTIPLE":
+        opciones = [(o, o) for o in campo["opciones"]]
+        return forms.MultipleChoiceField(
+            label=etiqueta, required=requerido, choices=opciones, widget=forms.CheckboxSelectMultiple
+        )
+    if tipo == "DATE":
+        return forms.DateField(
+            label=etiqueta,
+            required=requerido,
+            widget=forms.DateInput(attrs={"class": INPUT_CLASS, "type": "date"}),
+        )
+    if tipo == "ARCHIVO":
+        return forms.FileField(
+            label=etiqueta,
+            required=requerido,
+            validators=[_validar_archivo],
+            widget=forms.ClearableFileInput(attrs={"class": INPUT_CLASS, "accept": ".jpg,.jpeg,.png,.pdf"}),
+        )
+    return forms.CharField(
+        label=etiqueta, required=requerido, max_length=500, widget=forms.TextInput(attrs={"class": INPUT_CLASS})
+    )
+
+
+class InscripcionPaso2Form(forms.Form):
+    """Paso 2 del link (#294): contacto + formulario dinámico + apoderado.
+
+    Se construye desde ``definicion_formulario(relevamiento)`` — misma fuente
+    que la app de campo, sin definiciones paralelas (RN-P12). Las preguntas
+    globales entran como ``g_<pk>`` y los requisitos como ``r_<pk>``; un POST
+    con ids ajenos a la definición se ignora (nunca llega a ``data``).
+    """
+
+    # Identidad manual (solo cuando el paso 1 no validó contra Gran Base).
+    nombre = forms.CharField(
+        label="Nombre", max_length=120, widget=forms.TextInput(attrs={"class": INPUT_CLASS})
+    )
+    apellido = forms.CharField(
+        label="Apellido", max_length=120, widget=forms.TextInput(attrs={"class": INPUT_CLASS})
+    )
+    fecha_nacimiento = forms.DateField(
+        label="Fecha de nacimiento",
+        widget=forms.DateInput(attrs={"class": INPUT_CLASS, "type": "date"}),
+    )
+
+    # Bloque C — contacto (obligatorio en el modelo).
+    celular = forms.CharField(
+        label="Celular",
+        max_length=20,
+        widget=forms.TextInput(attrs={"class": INPUT_CLASS, "inputmode": "tel", "placeholder": "Ej. 3624123456"}),
+    )
+    email_contacto = forms.EmailField(
+        label="Correo electrónico",
+        widget=forms.EmailInput(attrs={"class": INPUT_CLASS, "placeholder": "nombre@correo.com"}),
+    )
+
+    # Bloque D — apoderado (obligatorio solo para menores, RN-22/RN-P9).
+    apoderado_nombre = forms.CharField(
+        label="Nombre del apoderado", max_length=120, required=False, widget=forms.TextInput(attrs={"class": INPUT_CLASS})
+    )
+    apoderado_apellido = forms.CharField(
+        label="Apellido del apoderado", max_length=120, required=False, widget=forms.TextInput(attrs={"class": INPUT_CLASS})
+    )
+    apoderado_dni = forms.CharField(
+        label="DNI del apoderado", max_length=12, required=False, widget=forms.TextInput(attrs={"class": INPUT_CLASS, "inputmode": "numeric"})
+    )
+    apoderado_genero = forms.ChoiceField(
+        label="Sexo del apoderado",
+        required=False,
+        choices=(("", "Elegí una opción"), ("F", "Femenino"), ("M", "Masculino")),
+        widget=forms.Select(attrs={"class": INPUT_CLASS}),
+    )
+    apoderado_fecha_nacimiento = forms.DateField(
+        label="Fecha de nacimiento del apoderado",
+        required=False,
+        widget=forms.DateInput(attrs={"class": INPUT_CLASS, "type": "date"}),
+    )
+
+    # Geolocalización del navegador (best effort — asunción del análisis #289).
+    gps_lat = forms.DecimalField(required=False, max_digits=9, decimal_places=6, widget=forms.HiddenInput)
+    gps_lng = forms.DecimalField(required=False, max_digits=9, decimal_places=6, widget=forms.HiddenInput)
+
+    def __init__(self, *args, definicion, identificacion, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.definicion = definicion
+        self.identificacion = identificacion
+        self.es_manual = identificacion.get("origen") != "personas"
+        if not self.es_manual:
+            # La identidad ya vino validada del paso 1: no se pide ni se pisa.
+            del self.fields["nombre"], self.fields["apellido"], self.fields["fecha_nacimiento"]
+        self._campos_dinamicos = []
+        for prefijo, lista in (("g", definicion["globales"]), ("r", definicion["requisitos"])):
+            for campo in lista:
+                clave = f"{prefijo}_{campo['id']}"
+                self.fields[clave] = _field_para_campo(campo)
+                self._campos_dinamicos.append((clave, campo))
+
+    # --- Helpers que consume el template ---------------------------------
+    def campos_globales(self):
+        return [self[clave] for clave, campo in self._campos_dinamicos if clave.startswith("g_")]
+
+    def campos_requisitos(self):
+        return [self[clave] for clave, campo in self._campos_dinamicos if clave.startswith("r_")]
+
+    # --- RN-22: apoderado obligatorio para menores ------------------------
+    def fecha_nacimiento_efectiva(self):
+        if self.es_manual:
+            return self.cleaned_data.get("fecha_nacimiento")
+        datos = self.identificacion.get("datos") or {}
+        return parse_date(str(datos.get("fecha_nacimiento") or "")) or None
+
+    def clean(self):
+        cleaned = super().clean()
+        if es_menor(self.fecha_nacimiento_efectiva()):
+            campos = (
+                "apoderado_nombre",
+                "apoderado_apellido",
+                "apoderado_dni",
+                "apoderado_genero",
+                "apoderado_fecha_nacimiento",
+            )
+            for campo in campos:
+                if not cleaned.get(campo):
+                    self.add_error(campo, "Este dato es obligatorio cuando la persona que se inscribe es menor de edad.")
+            dni_apoderado = "".join(ch for ch in str(cleaned.get("apoderado_dni") or "") if ch.isdigit())
+            if cleaned.get("apoderado_dni") and len(dni_apoderado) not in (7, 8):
+                self.add_error("apoderado_dni", "Ingresá un DNI válido de 7 u 8 dígitos.")
+            cleaned["apoderado_dni"] = dni_apoderado
+        return cleaned
+
+    # --- Salidas hacia la ingesta (#295) ----------------------------------
+    def respuestas(self):
+        """``Formulario.data`` con el mismo contrato que la app: claves por pk
+        en string, bajo "globales" y "requisitos". Los ARCHIVO guardan el
+        nombre; el archivo real viaja aparte como ``AdjuntoFormulario``."""
+        data = {"globales": {}, "requisitos": {}}
+        for clave, campo in self._campos_dinamicos:
+            valor = self.cleaned_data.get(clave)
+            if valor in (None, "", []):
+                continue
+            if campo["tipo"] == "ARCHIVO":
+                valor = valor.name
+            elif hasattr(valor, "isoformat"):
+                valor = valor.isoformat()
+            destino = "globales" if clave.startswith("g_") else "requisitos"
+            data[destino][str(campo["id"])] = valor
+        return data
+
+    def archivos(self):
+        """Lista de ``(alcance, id_campo, archivo)`` para crear los adjuntos."""
+        subidos = []
+        for clave, campo in self._campos_dinamicos:
+            if campo["tipo"] != "ARCHIVO":
+                continue
+            archivo = self.cleaned_data.get(clave)
+            if archivo:
+                alcance = "global" if clave.startswith("g_") else "requisito"
+                subidos.append((alcance, campo["id"], archivo))
+        return subidos

--- a/portal/templates/portal/inscripcion/confirmacion.html
+++ b/portal/templates/portal/inscripcion/confirmacion.html
@@ -1,0 +1,24 @@
+{% extends 'portal/base.html' %}
+
+{% block title %}Inscripción enviada - Portal Ciudadano{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto text-center">
+    <div class="bg-white p-10 animate-fadeInUp" style="border-radius: var(--radius-2xl); box-shadow: var(--shadow-sm); border: 1px solid var(--border-base);">
+        <div class="inline-flex items-center justify-center w-16 h-16 mb-4" style="border-radius: var(--radius-full); background: var(--gradient-brand);">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color: #fff;">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path>
+            </svg>
+        </div>
+        <h1 class="text-2xl font-bold" style="color: var(--text-heading);">¡Inscripción enviada!</h1>
+        <p class="mt-3 text-sm" style="color: var(--text-body);">Tu formulario fue recibido y va a ser revisado por el equipo del programa.</p>
+
+        <div class="mt-6 p-4 text-left" style="background: var(--bg-secondary); border: 1px solid var(--border-base); border-radius: var(--radius-xl);">
+            <p class="text-xs font-bold uppercase tracking-wide" style="color: var(--text-body-subtle);">Comprobante</p>
+            <p class="text-sm mt-1 font-semibold" style="color: var(--text-heading);">Formulario Nº {{ comprobante.numero }} · {{ convocatoria.nombre }}</p>
+        </div>
+
+        <p class="mt-6 text-xs" style="color: var(--text-body-subtle);">Podés cerrar esta página. Ante cualquier consulta, comunicate al 0800-222-1133.</p>
+    </div>
+</div>
+{% endblock %}

--- a/portal/templates/portal/inscripcion/paso2.html
+++ b/portal/templates/portal/inscripcion/paso2.html
@@ -19,14 +19,118 @@
     {% else %}
     <div class="p-4 mb-4" style="background: var(--bg-secondary); border: 1px solid var(--border-base); border-radius: var(--radius-xl);">
         <p class="text-sm font-semibold" style="color: var(--text-heading);">DNI {{ identificacion.dni }}</p>
-        <p class="text-xs mt-1" style="color: var(--text-body-subtle);">No pudimos validar tus datos automáticamente: vas a completarlos a mano en el formulario.</p>
+        <p class="text-xs mt-1" style="color: var(--text-body-subtle);">No pudimos validar tus datos automáticamente: completalos a continuación.</p>
     </div>
     {% endif %}
 
-    {# El formulario dinámico (preguntas, requisitos, archivos y GPS) se renderiza acá — task 294 de la Fase 3. #}
-    <div class="bg-white p-10 text-center animate-fadeInUp" style="border-radius: var(--radius-2xl); box-shadow: var(--shadow-sm); border: 1px solid var(--border-base);">
-        <p class="text-sm" style="color: var(--text-body);">Estamos preparando el formulario de inscripción.</p>
-        <p class="text-xs mt-2" style="color: var(--text-body-subtle);">Volvé a intentarlo más tarde desde el mismo link.</p>
-    </div>
+    <form method="post" enctype="multipart/form-data" novalidate id="form-inscripcion"
+          class="bg-white p-8 animate-fadeInUp" style="border-radius: var(--radius-2xl); box-shadow: var(--shadow-sm); border: 1px solid var(--border-base);">
+        {% csrf_token %}
+        {{ form.gps_lat }}{{ form.gps_lng }}
+
+        {% if form.non_field_errors %}
+            <div class="mb-4 p-3 text-sm" style="background: var(--bg-danger-soft); border: 1px solid var(--border-danger-subtle); border-radius: var(--radius-lg); color: var(--text-fg-danger);" role="alert">
+                {% for error in form.non_field_errors %}<p class="m-0">{{ error }}</p>{% endfor %}
+            </div>
+        {% endif %}
+
+        {% if form.es_manual %}
+        <h2 class="text-sm font-bold uppercase tracking-wide mb-3" style="color: var(--text-body-subtle);">Tus datos</h2>
+        <div class="space-y-4 mb-6">
+            {% for campo in form %}{% if campo.name == "nombre" or campo.name == "apellido" or campo.name == "fecha_nacimiento" %}
+            <div>
+                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }} <span style="color: var(--text-fg-danger);">*</span></label>
+                {{ campo }}
+                {% for error in campo.errors %}<p class="text-xs mt-1" style="color: var(--text-fg-danger);">{{ error }}</p>{% endfor %}
+            </div>
+            {% endif %}{% endfor %}
+        </div>
+        {% endif %}
+
+        <h2 class="text-sm font-bold uppercase tracking-wide mb-3" style="color: var(--text-body-subtle);">Datos de contacto</h2>
+        <div class="space-y-4 mb-6">
+            {% for campo in form %}{% if campo.name == "celular" or campo.name == "email_contacto" %}
+            <div>
+                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }} <span style="color: var(--text-fg-danger);">*</span></label>
+                {{ campo }}
+                {% for error in campo.errors %}<p class="text-xs mt-1" style="color: var(--text-fg-danger);">{{ error }}</p>{% endfor %}
+            </div>
+            {% endif %}{% endfor %}
+        </div>
+
+        {% if form.campos_globales %}
+        <h2 class="text-sm font-bold uppercase tracking-wide mb-3" style="color: var(--text-body-subtle);">Sobre vos</h2>
+        <div class="space-y-4 mb-6">
+            {% for campo in form.campos_globales %}
+            <div>
+                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }}{% if campo.field.required %} <span style="color: var(--text-fg-danger);">*</span>{% endif %}</label>
+                {{ campo }}
+                {% for error in campo.errors %}<p class="text-xs mt-1" style="color: var(--text-fg-danger);">{{ error }}</p>{% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {% if form.campos_requisitos %}
+        <h2 class="text-sm font-bold uppercase tracking-wide mb-3" style="color: var(--text-body-subtle);">Requisitos</h2>
+        <div class="space-y-4 mb-6">
+            {% for campo in form.campos_requisitos %}
+            <div>
+                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }}{% if campo.field.required %} <span style="color: var(--text-fg-danger);">*</span>{% endif %}</label>
+                {{ campo }}
+                {% if campo.field.widget.input_type == "file" %}<p class="text-xs mt-1" style="color: var(--text-body-subtle);">JPG, PNG o PDF, hasta 5 MB.</p>{% endif %}
+                {% for error in campo.errors %}<p class="text-xs mt-1" style="color: var(--text-fg-danger);">{{ error }}</p>{% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <h2 class="text-sm font-bold uppercase tracking-wide mb-1" style="color: var(--text-body-subtle);">Apoderado</h2>
+        <p class="text-xs mb-3" style="color: var(--text-body-subtle);">Completalo solo si la persona que se inscribe es menor de 18 años.</p>
+        <div class="space-y-4 mb-6">
+            {% for campo in form %}{% if campo.name == "apoderado_nombre" or campo.name == "apoderado_apellido" or campo.name == "apoderado_dni" or campo.name == "apoderado_genero" or campo.name == "apoderado_fecha_nacimiento" %}
+            <div>
+                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }}</label>
+                {{ campo }}
+                {% for error in campo.errors %}<p class="text-xs mt-1" style="color: var(--text-fg-danger);">{{ error }}</p>{% endfor %}
+            </div>
+            {% endif %}{% endfor %}
+        </div>
+
+        {% if requiere_gps %}
+        <div class="p-3 mb-6 flex items-start gap-2 text-xs" style="background: var(--bg-brand-tint); border-radius: var(--radius-lg); color: var(--text-heading);">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="flex-shrink:0; margin-top:1px;">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"></path>
+            </svg>
+            <span>Al enviar vamos a solicitar tu ubicación para georreferenciar la inscripción. Si preferís no compartirla, el envío se realiza igual.</span>
+        </div>
+        {% endif %}
+
+        <button type="submit" class="btn-nodo btn-brand btn-lg w-full">
+            Enviar formulario
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"></path>
+            </svg>
+        </button>
+    </form>
+
+    <p class="text-xs mt-4" style="color: var(--text-body-subtle);">Tus datos se usan únicamente para esta inscripción (Ley 25.326).</p>
 </div>
+
+{% if requiere_gps %}
+<script>
+// Geolocalización best-effort (asunción del análisis 289): se pide al cargar y
+// completa los campos ocultos; si la persona la niega, el envío sigue igual.
+(function () {
+  if (!navigator.geolocation) return;
+  navigator.geolocation.getCurrentPosition(function (pos) {
+    var lat = document.getElementById('id_gps_lat');
+    var lng = document.getElementById('id_gps_lng');
+    if (lat) lat.value = pos.coords.latitude.toFixed(6);
+    if (lng) lng.value = pos.coords.longitude.toFixed(6);
+  }, function () { /* denegada: best effort */ }, { timeout: 8000 });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/portal/tests/test_inscripcion_envio.py
+++ b/portal/tests/test_inscripcion_envio.py
@@ -1,0 +1,306 @@
+"""Tests del paso 2 y la ingesta del formulario público (#294/#295, análisis #289)."""
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from legajos.models import Ciudadano
+from portal.forms.inscripcion import InscripcionPaso2Form
+from portal.services.inscripcion import clave_sesion
+from programas.models import (
+    AdjuntoFormulario,
+    Convocatoria,
+    Formulario,
+    PreguntaGlobal,
+    Relevamiento,
+    RequisitoNativo,
+    Segmento,
+)
+from programas.services.becas import definicion_formulario
+from programas.services.inscripcion_publica import (
+    InscripcionDuplicada,
+    InscripcionNoDisponible,
+    crear_formulario_publico,
+)
+
+def _identificacion(dni="30123456", origen="personas", **extra):
+    base = {
+        "dni": dni,
+        "sexo": "F",
+        "datos": {"nombre": "María Luján", "apellido": "Gómez", "fecha_nacimiento": "1991-03-14"}
+        if origen == "personas"
+        else None,
+        "origen": origen,
+        "client_uuid": str(uuid4()),
+    }
+    base.update(extra)
+    return base
+
+
+class _BasePaso2Test(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.segmento = Segmento.objects.create(nombre="Seg", cupo_maximo=100)
+        self.convocatoria = Convocatoria.objects.create(
+            nombre="Becas 2026",
+            segmento=self.segmento,
+            fecha_inicio=date(2026, 1, 1),
+            fecha_fin=date(2026, 12, 31),
+        )
+        self.pregunta = PreguntaGlobal.objects.create(
+            texto="¿Asistís a una institución educativa?",
+            tipo="SELECTOR",
+            opciones=["Sí", "No"],
+            obligatorio=True,
+            orden=1,
+        )
+        self.requisito = RequisitoNativo.objects.create(
+            texto="Certificado de alumno regular",
+            tipo="ARCHIVO",
+            segmento=self.segmento,
+            obligatorio=True,
+            orden=1,
+        )
+        self.relevamiento = Relevamiento.objects.create(
+            convocatoria=self.convocatoria,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now() - timedelta(days=1),
+            fecha_hasta=timezone.now() + timedelta(days=10),
+        )
+        self.definicion = definicion_formulario(self.relevamiento)
+
+    def _data(self, **extra):
+        data = {
+            "celular": "3624123456",
+            "email_contacto": "maria@correo.com",
+            f"g_{self.pregunta.pk}": "Sí",
+        }
+        data.update(extra)
+        return data
+
+    def _files(self, **extra):
+        files = {f"r_{self.requisito.pk}": SimpleUploadedFile("cert.png", b"\x89PNG fake", content_type="image/png")}
+        files.update(extra)
+        return files
+
+    def _form(self, identificacion=None, data=None, files=None):
+        return InscripcionPaso2Form(
+            data if data is not None else self._data(),
+            files if files is not None else self._files(),
+            definicion=self.definicion,
+            identificacion=identificacion or _identificacion(),
+        )
+
+
+class Paso2FormTests(_BasePaso2Test):
+    def test_construye_los_campos_de_la_definicion(self):
+        form = self._form()
+        self.assertIn(f"g_{self.pregunta.pk}", form.fields)
+        self.assertIn(f"r_{self.requisito.pk}", form.fields)
+        self.assertNotIn("nombre", form.fields)  # identidad validada: no se pide
+
+    def test_origen_manual_pide_identidad(self):
+        form = self._form(
+            identificacion=_identificacion(origen="manual"),
+            data=self._data(nombre="Juan", apellido="Pérez", fecha_nacimiento="1990-01-01"),
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_obligatorios_dinamicos_se_exigen(self):
+        data = self._data()
+        data.pop(f"g_{self.pregunta.pk}")
+        form = self._form(data=data, files={})
+        self.assertFalse(form.is_valid())
+        self.assertIn(f"g_{self.pregunta.pk}", form.errors)
+        self.assertIn(f"r_{self.requisito.pk}", form.errors)
+
+    def test_opcion_invalida_de_selector_se_rechaza(self):
+        form = self._form(data=self._data(**{f"g_{self.pregunta.pk}": "Otra cosa"}))
+        self.assertFalse(form.is_valid())
+        self.assertIn(f"g_{self.pregunta.pk}", form.errors)
+
+    def test_respuestas_ignoran_ids_ajenos_a_la_definicion(self):
+        form = self._form(data=self._data(g_99999="hack", r_99999="hack"))
+        self.assertTrue(form.is_valid(), form.errors)
+        data = form.respuestas()
+        self.assertNotIn("99999", data["globales"])
+        self.assertNotIn("99999", data["requisitos"])
+        self.assertEqual(data["globales"][str(self.pregunta.pk)], "Sí")
+        self.assertEqual(data["requisitos"][str(self.requisito.pk)], "cert.png")
+
+    def test_archivo_invalido_se_rechaza(self):
+        exe = SimpleUploadedFile("virus.exe", b"MZ", content_type="application/octet-stream")
+        form = self._form(files={f"r_{self.requisito.pk}": exe})
+        self.assertFalse(form.is_valid())
+        self.assertIn(f"r_{self.requisito.pk}", form.errors)
+        gigante = SimpleUploadedFile("foto.png", b"0" * (5 * 1024 * 1024 + 1), content_type="image/png")
+        form = self._form(files={f"r_{self.requisito.pk}": gigante})
+        self.assertFalse(form.is_valid())
+
+    def test_menor_exige_apoderado_y_mayor_no(self):
+        hoy = timezone.localdate()
+        menor = _identificacion()
+        menor["datos"]["fecha_nacimiento"] = (hoy - timedelta(days=17 * 365)).isoformat()
+        form = self._form(identificacion=menor)
+        self.assertFalse(form.is_valid())
+        self.assertIn("apoderado_dni", form.errors)
+        # Cumple 18 exactamente hoy: se trata como mayor (RN-22).
+        cumple_hoy = _identificacion()
+        cumple_hoy["datos"]["fecha_nacimiento"] = hoy.replace(year=hoy.year - 18).isoformat()
+        form = self._form(identificacion=cumple_hoy)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_menor_con_apoderado_completo_pasa(self):
+        hoy = timezone.localdate()
+        menor = _identificacion()
+        menor["datos"]["fecha_nacimiento"] = (hoy - timedelta(days=17 * 365)).isoformat()
+        form = self._form(
+            identificacion=menor,
+            data=self._data(
+                apoderado_nombre="Ana",
+                apoderado_apellido="Gómez",
+                apoderado_dni="20.111.222",
+                apoderado_genero="F",
+                apoderado_fecha_nacimiento="1980-05-05",
+            ),
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["apoderado_dni"], "20111222")
+
+
+class IngestaPublicaTests(_BasePaso2Test):
+    def _form_valido(self, identificacion=None):
+        form = self._form(identificacion=identificacion)
+        assert form.is_valid(), form.errors
+        return form
+
+    def test_envio_crea_formulario_y_legajo_validado(self):
+        ident = _identificacion()
+        formulario, creado = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+        )
+        self.assertTrue(creado)
+        self.assertEqual(formulario.estado, Formulario.Estado.ENVIADO)
+        self.assertEqual(formulario.numero, 1)
+        self.assertTrue(formulario.validado_renaper)
+        self.assertIsNone(formulario.created_by)
+        ciudadano = Ciudadano.objects.get(dni="30123456")
+        self.assertEqual(ciudadano.nombre, "María Luján")
+        self.assertEqual(formulario.ciudadano, ciudadano)
+        self.assertEqual(formulario.data["globales"][str(self.pregunta.pk)], "Sí")
+        adjunto = AdjuntoFormulario.objects.get(formulario=formulario)
+        self.assertEqual(adjunto.requisito_nativo_id, self.requisito.pk)
+
+    def test_dni_existente_se_linkea_sin_duplicar(self):
+        existente = Ciudadano.objects.create(dni="30123456", nombre="María", apellido="Gómez")
+        ident = _identificacion()
+        formulario, _ = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+        )
+        self.assertEqual(formulario.ciudadano, existente)
+        self.assertEqual(Ciudadano.objects.filter(dni="30123456").count(), 1)
+
+    def test_origen_manual_queda_no_validado(self):
+        ident = _identificacion(origen="manual")
+        form = self._form(
+            identificacion=ident,
+            data=self._data(nombre="Juan", apellido="Pérez", fecha_nacimiento="1990-01-01"),
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        formulario, _ = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=form, client_uuid=ident["client_uuid"]
+        )
+        self.assertFalse(formulario.validado_renaper)
+        self.assertEqual(formulario.ciudadano.nombre, "Juan")
+
+    def test_doble_submit_es_idempotente(self):
+        ident = _identificacion()
+        primero, creado1 = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+        )
+        segundo, creado2 = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+        )
+        self.assertTrue(creado1)
+        self.assertFalse(creado2)
+        self.assertEqual(primero.pk, segundo.pk)
+        self.assertEqual(self.relevamiento.formularios.count(), 1)
+
+    def test_cupo_lleno_no_crea(self):
+        self.relevamiento.cupo_maximo = 1
+        self.relevamiento.save(update_fields=["cupo_maximo"])
+        Formulario.objects.create(
+            relevamiento=self.relevamiento, celular="1", email_contacto="a@a.com", datos_identificacion={"dni": "1"}
+        )
+        ident = _identificacion(dni="28111222")
+        with self.assertRaises(InscripcionNoDisponible):
+            crear_formulario_publico(
+                self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+            )
+        self.assertEqual(self.relevamiento.formularios.count(), 1)
+
+    def test_duplicado_colado_entre_pasos_se_rechaza(self):
+        Formulario.objects.create(
+            relevamiento=self.relevamiento,
+            celular="1",
+            email_contacto="a@a.com",
+            datos_identificacion={"dni": "30123456"},
+        )
+        ident = _identificacion()
+        with self.assertRaises(InscripcionDuplicada):
+            crear_formulario_publico(
+                self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+            )
+
+    def test_vencido_al_enviar_no_crea(self):
+        self.relevamiento.fecha_hasta = timezone.now() - timedelta(hours=1)
+        self.relevamiento.save(update_fields=["fecha_hasta"])
+        ident = _identificacion()
+        with self.assertRaises(InscripcionNoDisponible):
+            crear_formulario_publico(
+                self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=ident["client_uuid"]
+            )
+
+
+class Paso2VistaTests(_BasePaso2Test):
+    def _sembrar_sesion(self, ident):
+        session = self.client.session
+        session[clave_sesion(self.relevamiento)] = ident
+        session.save()
+
+    def _url(self):
+        return reverse("portal:inscripcion_paso2", kwargs={"token": self.relevamiento.token_publico})
+
+    def test_post_valido_crea_y_redirige_a_confirmacion(self):
+        ident = _identificacion()
+        self._sembrar_sesion(ident)
+        resp = self.client.post(self._url(), {**self._data(), **{k: v for k, v in self._files().items()}})
+        self.assertRedirects(
+            resp,
+            reverse("portal:inscripcion_confirmacion", kwargs={"token": self.relevamiento.token_publico}),
+            fetch_redirect_response=False,
+        )
+        self.assertEqual(self.relevamiento.formularios.count(), 1)
+        # La identificación se limpia y el comprobante queda para la pantalla.
+        self.assertNotIn(clave_sesion(self.relevamiento), self.client.session)
+        self.assertEqual(self.client.session[f"inscripcion_ok_{self.relevamiento.pk}"]["numero"], 1)
+
+    def test_confirmacion_sin_envio_redirige_al_paso1(self):
+        resp = self.client.get(reverse("portal:inscripcion_confirmacion", kwargs={"token": self.relevamiento.token_publico}))
+        self.assertEqual(resp.status_code, 302)
+
+    def test_reenvio_tras_confirmar_no_duplica(self):
+        ident = _identificacion()
+        self._sembrar_sesion(ident)
+        datos_post = {**self._data(), **self._files()}
+        self.client.post(self._url(), datos_post)
+        # Segundo POST: la sesión ya no tiene identificación → vuelve al paso 1.
+        resp = self.client.post(self._url(), datos_post)
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(reverse("portal:inscripcion_paso1", kwargs={"token": self.relevamiento.token_publico}), resp.url)
+        self.assertEqual(self.relevamiento.formularios.count(), 1)

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -21,7 +21,7 @@ from .views.ciudadano import (
     ciudadano_nueva_consulta,
     ciudadano_programa_detalle,
 )
-from .views.inscripcion import inscripcion_paso1, inscripcion_paso2
+from .views.inscripcion import inscripcion_confirmacion, inscripcion_paso1, inscripcion_paso2
 from .views.public import (
     PortalHomeView,
 )
@@ -33,6 +33,7 @@ urlpatterns = [
     # Formulario público de Becas (#293) — superficie sin login, por token.
     path("inscripcion/<uuid:token>/", inscripcion_paso1, name="inscripcion_paso1"),
     path("inscripcion/<uuid:token>/formulario/", inscripcion_paso2, name="inscripcion_paso2"),
+    path("inscripcion/<uuid:token>/confirmacion/", inscripcion_confirmacion, name="inscripcion_confirmacion"),
     # Portal ciudadano
     path("mi-perfil/login/", CiudadanoLoginView.as_view(), name="ciudadano_login"),
     path("mi-perfil/logout/", CiudadanoLogoutView.as_view(), name="ciudadano_logout"),

--- a/portal/views/inscripcion.py
+++ b/portal/views/inscripcion.py
@@ -11,10 +11,11 @@ un render provisorio.
 """
 
 import logging
+import uuid
 
 from django.shortcuts import get_object_or_404, redirect, render
 
-from portal.forms.inscripcion import InscripcionPaso1Form
+from portal.forms.inscripcion import InscripcionPaso1Form, InscripcionPaso2Form
 from portal.services.inscripcion import (
     captcha_valido,
     clave_sesion,
@@ -26,6 +27,12 @@ from portal.services.inscripcion import (
     relevamiento_disponible,
 )
 from programas.models import Relevamiento
+from programas.services.becas import definicion_formulario
+from programas.services.inscripcion_publica import (
+    InscripcionDuplicada,
+    InscripcionNoDisponible,
+    crear_formulario_publico,
+)
 from programas.services.padron import esta_habilitado
 from programas.services.personas import consultar_persona
 
@@ -113,17 +120,52 @@ def inscripcion_paso1(request, token):
 
 
 def inscripcion_paso2(request, token):
-    """Guardia del paso 2: exige la identificación del paso 1 en la sesión.
-
-    El formulario dinámico se renderiza acá a partir de #294; mientras tanto
-    la pantalla confirma la identificación y anuncia el paso siguiente.
-    """
+    """Paso 2 (#294): el mismo formulario dinámico que la app de campo, más
+    contacto, apoderado para menores y GPS best-effort. El envío crea el
+    formulario y el legajo en el acto (#295) y redirige al comprobante."""
     relevamiento = _get_relevamiento(token)
     if not relevamiento_disponible(relevamiento):
         return _no_disponible(request, relevamiento)
     identificacion = request.session.get(clave_sesion(relevamiento))
     if not identificacion:
         return redirect("portal:inscripcion_paso1", token=relevamiento.token_publico)
+
+    # Idempotencia del doble submit: un client_uuid por identificación, igual
+    # que las capturas de la app (RN de #295).
+    if not identificacion.get("client_uuid"):
+        identificacion["client_uuid"] = str(uuid.uuid4())
+        request.session[clave_sesion(relevamiento)] = identificacion
+
+    definicion = definicion_formulario(relevamiento)
+    form = InscripcionPaso2Form(
+        request.POST or None,
+        request.FILES or None,
+        definicion=definicion,
+        identificacion=identificacion,
+    )
+    if request.method == "POST" and form.is_valid():
+        try:
+            formulario, _creado = crear_formulario_publico(
+                relevamiento,
+                identificacion=identificacion,
+                form=form,
+                client_uuid=identificacion["client_uuid"],
+            )
+        except InscripcionNoDisponible:
+            return _no_disponible(request, relevamiento)
+        except InscripcionDuplicada:
+            return render(
+                request,
+                "portal/inscripcion/ya_inscripto.html",
+                {"relevamiento": relevamiento, "dni": identificacion["dni"]},
+            )
+        request.session.pop(clave_sesion(relevamiento), None)
+        request.session[f"inscripcion_ok_{relevamiento.pk}"] = {
+            "numero": formulario.numero,
+            "email": formulario.email_contacto,
+        }
+        return redirect("portal:inscripcion_confirmacion", token=relevamiento.token_publico)
+
     return render(
         request,
         "portal/inscripcion/paso2.html",
@@ -131,5 +173,25 @@ def inscripcion_paso2(request, token):
             "relevamiento": relevamiento,
             "convocatoria": relevamiento.convocatoria,
             "identificacion": identificacion,
+            "form": form,
+            "requiere_gps": definicion["requiere_gps"],
+        },
+    )
+
+
+def inscripcion_confirmacion(request, token):
+    """Comprobante del envío. Se alimenta de la sesión para tolerar el refresh
+    sin duplicar nada; sin envío previo, vuelve al paso 1."""
+    relevamiento = _get_relevamiento(token)
+    comprobante = request.session.get(f"inscripcion_ok_{relevamiento.pk}")
+    if not comprobante:
+        return redirect("portal:inscripcion_paso1", token=relevamiento.token_publico)
+    return render(
+        request,
+        "portal/inscripcion/confirmacion.html",
+        {
+            "relevamiento": relevamiento,
+            "convocatoria": relevamiento.convocatoria,
+            "comprobante": comprobante,
         },
     )

--- a/programas/services/inscripcion_publica.py
+++ b/programas/services/inscripcion_publica.py
@@ -1,0 +1,114 @@
+"""Ingesta del formulario público de Becas (#295, análisis #289).
+
+El envío del paso 2 del link crea exactamente lo mismo que un sync de la app
+de campo: un ``Formulario`` ENVIADO dentro del relevamiento **y el legajo
+ciudadano en el acto** (RN-P8, vía ``resolver_ciudadano_offline``). Para el
+backoffice el resultado es indistinguible: entra a la bandeja de revisión sin
+ningún cambio en ella.
+
+Garantías dentro de la transacción (mismo patrón que la API de campo):
+- cupo bajo ``select_for_update`` (dos envíos al último lugar → entra uno);
+- idempotencia por ``client_uuid`` (doble submit devuelve el mismo formulario);
+- re-chequeo del duplicado por convocatoria (RN-P5) — entre el paso 1 y el
+  envío pudo inscribirse otro con el mismo DNI.
+"""
+
+from __future__ import annotations
+
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from programas.models import AdjuntoFormulario, Formulario, Relevamiento
+from programas.services.becas import resolver_ciudadano_offline
+
+
+class InscripcionNoDisponible(Exception):
+    """El relevamiento dejó de aceptar envíos (vencido, pausado, cupo, cerrado)."""
+
+
+class InscripcionDuplicada(Exception):
+    """El DNI ya está inscripto en la convocatoria (RN-P5)."""
+
+
+def _dni_en_convocatoria(convocatoria, dni):
+    return (
+        Formulario.objects.filter(relevamiento__convocatoria=convocatoria)
+        .filter(Q(ciudadano__dni=dni) | Q(datos_identificacion__dni=dni))
+        .exists()
+    )
+
+
+def crear_formulario_publico(relevamiento, *, identificacion, form, client_uuid):
+    """Crea el formulario de una inscripción pública validada.
+
+    ``identificacion`` es el dict del paso 1 (dni, sexo, datos básicos, origen)
+    y ``form`` un ``InscripcionPaso2Form`` válido. Devuelve ``(formulario,
+    creado)``: con ``creado=False`` el ``client_uuid`` ya había ingresado
+    (doble submit) y se devuelve el formulario original.
+    """
+    dni = identificacion["dni"]
+    datos_basicos = identificacion.get("datos") or {}
+    es_validado = identificacion.get("origen") == "personas"
+    cleaned = form.cleaned_data
+
+    with transaction.atomic():
+        rel = Relevamiento.objects.select_for_update().get(pk=relevamiento.pk)
+        if client_uuid:
+            existente = rel.formularios.filter(client_uuid=client_uuid).first()
+            if existente:
+                return existente, False
+        if rel.estado != Relevamiento.Estado.EN_CURSO or not rel.habilitado_en(timezone.now()):
+            raise InscripcionNoDisponible()
+        if rel.formularios.count() >= rel.cupo_maximo:
+            raise InscripcionNoDisponible()
+        if _dni_en_convocatoria(rel.convocatoria, dni):
+            raise InscripcionDuplicada()
+
+        if es_validado:
+            nombre = datos_basicos.get("nombre", "")
+            apellido = datos_basicos.get("apellido", "")
+            fecha_nacimiento = datos_basicos.get("fecha_nacimiento", "")
+        else:
+            nombre = cleaned.get("nombre", "")
+            apellido = cleaned.get("apellido", "")
+            fecha = cleaned.get("fecha_nacimiento")
+            fecha_nacimiento = fecha.isoformat() if fecha else ""
+
+        formulario = Formulario.objects.create(
+            relevamiento=rel,
+            celular=cleaned["celular"],
+            email_contacto=cleaned["email_contacto"],
+            apoderado_nombre=cleaned.get("apoderado_nombre", ""),
+            apoderado_apellido=cleaned.get("apoderado_apellido", ""),
+            apoderado_dni=cleaned.get("apoderado_dni", ""),
+            apoderado_genero=cleaned.get("apoderado_genero", ""),
+            apoderado_fecha_nacimiento=cleaned.get("apoderado_fecha_nacimiento"),
+            gps_lat=cleaned.get("gps_lat"),
+            gps_lng=cleaned.get("gps_lng"),
+            data=form.respuestas(),
+            # Mismo contrato que el sync offline de la app: el origen
+            # "personas" acredita identidad (validado_renaper); "manual" no.
+            datos_identificacion={
+                "dni": dni,
+                "sexo": identificacion.get("sexo", ""),
+                "nombre": nombre,
+                "apellido": apellido,
+                "fecha_nacimiento": fecha_nacimiento,
+                "origen": "personas" if es_validado else "manual",
+            },
+            client_uuid=client_uuid,
+            capturado_en=timezone.now(),
+            created_by=None,
+            validado_renaper=bool(es_validado and nombre and apellido),
+        )
+        for alcance, campo_id, archivo in form.archivos():
+            AdjuntoFormulario.objects.create(
+                formulario=formulario,
+                pregunta_global_id=campo_id if alcance == "global" else None,
+                requisito_nativo_id=campo_id if alcance == "requisito" else None,
+                archivo=archivo,
+            )
+        resolver_ciudadano_offline(formulario)
+        formulario.refresh_from_db()
+    return formulario, True


### PR DESCRIPTION
> **Apilado sobre #302 (Fase 2)**, que a su vez apila sobre #301 (Fase 1). Mergear en orden y re-apuntar bases.

## Qué incluye (Fase 3 del análisis #289 — la funcionalidad queda completa de punta a punta)

- **#294 — Paso 2, formulario dinámico:** `InscripcionPaso2Form` se construye desde `definicion_formulario(relevamiento)` — la misma fuente que consume la app de campo (RN-P12), sin definiciones paralelas. Soporta los seis tipos de campo (`STRING/INT/SELECTOR/SELECTOR_MULTIPLE/DATE/ARCHIVO`) como `g_<pk>`/`r_<pk>`; un POST con ids ajenos a la definición se ignora y nunca llega a `data`. Contacto obligatorio; identidad manual solo cuando el paso 1 no validó; **apoderado exigido para menores** (RN-22 — quien cumple 18 hoy es mayor, con test); archivos JPG/PNG/PDF hasta 5 MB; **GPS best-effort** del navegador (hidden + geolocation; si se niega, el envío sigue — asunción registrada en el análisis).
- **#295 — Ingesta:** `crear_formulario_publico` replica las garantías de la API de campo dentro de una transacción: cupo bajo `select_for_update`, **idempotencia por `client_uuid`** de sesión (doble submit devuelve el mismo formulario), re-chequeo del **duplicado por convocatoria** (RN-P5) por si se coló otro entre paso 1 y envío, y disponibilidad re-verificada (vencido/cupo al momento del POST → pantallas de no disponible / ya inscripto). Crea el `Formulario` **ENVIADO** con `datos_identificacion` en el mismo contrato que el sync offline de la app, marca `validado_renaper` según el origen del paso 1, crea los `AdjuntoFormulario` y **resuelve el legajo ciudadano en el acto** (RN-P8, `resolver_ciudadano_offline`: crea o linkea sin duplicar). `Formulario.data` usa claves string-pk — la bandeja de revisión lo renderiza idéntico a uno de campo, sin ningún cambio en ella.
- Pantalla de **comprobante** (`Formulario Nº …`) alimentada por sesión: el refresh no duplica y el reenvío tras confirmar vuelve al paso 1 sin crear nada.

## Validación

- **18 tests nuevos** (`portal.tests.test_inscripcion_envio`): form dinámico (obligatorios, selector inválido, ids ajenos, archivos, RN-22 con borde de 18 años), servicio (creación validada, linkeo sin duplicar, manual no validado, idempotencia, cupo, duplicado colado, vencido) y vista (redirect a confirmación, sesión limpia, reenvío no duplica) — **todos en verde en local**.
- Suites completas de `portal` + Becas: 171 tests, con solo los errores de entorno preexistentes (verificado contra `development` limpio: los 11 de `portal.tests` ya estaban; los 6 de Fase 1 ya documentados).
- `manage.py check` OK · `makemigrations --check` sin faltantes (esta fase no migra) · `design_audit.py --changed` **0 errores, 0 warnings** · `compile_templates.py` 324/0 · `check_design_agent.py` OK.

Cadena: Épica #69 · Análisis #289 · Tasks #294, #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)