### PR TITLE
Formulario público de Becas — Fase 4: correo de confirmación y cierre (#296)

### DIFF
--- a/docs/internal/requerimientos.md
+++ b/docs/internal/requerimientos.md
@@ -181,6 +181,7 @@ Los campos que no apliquen se escriben como «No requiere» o «No aplica»; no 
 | 37 | Credenciales por correo: clave provisoria al alta y recupero desde el login | Transversal / usuarios | `#usuarios` `#correo` `#sesion` `#infra` | PM — definiciones del 14/08/2026 (análisis #236) y credenciales SMTP entregadas el 20/08/2026 | 14/08/2026 | 🟡 **Parcial — implementado; falta envío real y aprobación de textos** | `users.0022` |
 | 38 | Cerrar sesión da error 405 después de actualizar Django | Transversal / sesión | `#sesion` `#infra` `#ui` | PM — reportó el 405 al entrar a `/logout` | 20/08/2026 | 🟢 **Hecho** | No |
 | 39 | En el login aparece el logo de Nodo en lugar del del Chaco | Transversal / marca | `#ui` `#sesion` `#infra` | PM — vio la marca del proveedor en la pantalla de acceso | 21/08/2026 | 🟢 **Hecho** | No |
+| 40 | Formulario público de autocompletado: relevamientos con link de inscripción | Becas · Portal | `#relevamientos` `#datos` `#rbac` `#correo` `#ui` | Programa de Becas, vía PM — sesión de análisis del 21/08/2026 (análisis #289) | 21/08/2026 | 🟡 **Hecho — pendiente de merge y despliegue (PRs #301–#304)** | `programas.0049` + `programas.0050` |
 
 **Notas del índice**
 
@@ -3309,3 +3310,90 @@ La estructura de cada entrada nueva está definida en **[Plantilla obligatoria d
 4. Correr `scripts/requerimientos.py --check`: verifica que la entrada y el índice coincidan y que las etiquetas existan en el vocabulario. Tiene que dar OK.
 
 La regla, el motivo de cada campo y la mitad de lectura —qué consultar **antes** de escribir código— están en **[Regla de oro](#regla-de-oro)** y en **[Cómo leerlo sin leerlo entero](#cómo-leerlo-sin-leerlo-entero)**.
+
+
+---
+
+# Cambio 40 — Formulario público de autocompletado: relevamientos con link de inscripción
+
+🟡 **HECHO — 24/08/2026 — pendiente de merge y despliegue (PRs #301, #302, #303 y #304, apilados)**
+
+| | |
+|---|---|
+| **Programa / módulo** | Becas · Portal |
+| **Etiquetas** | `#relevamientos` `#datos` `#rbac` `#correo` `#ui` |
+| **Solicitante** | Programa de Becas, a través del PM — pedido relevado y cerrado en sesión de análisis del 21/08/2026 (con adiciones del 22/08 y 24/08) |
+| **Fecha del pedido** | 21/08/2026 |
+| **Issue / épica** | Épica #69 · Análisis #289 · Tasks #290–#296 y #299 |
+| **Partes afectadas** | Backoffice · Portal ciudadano (nueva superficie pública) · Servidor. **Mobile no se toca.** |
+| **Migración** | `programas.0049` (tipo, token, correo, territorial nullable) + `programas.0050` (padrón) |
+
+## Pedido original
+
+> «Desde el programa de Becas quieren que un público objetivo se autocomplete: pasar un link con un formulario y que esa data llegue como si fuera desde la aplicación a un relevamiento. Mi idea era sumar en la configuración del relevamiento si es territorial o formulario público; en base a eso genera un relevamiento en la app o un link público.» Después: «siempre el primer paso antes de ingresar al form es poner número de documento y sexo […] valida si ya fue relevado […] después valida contra la Gran Base / RENAPER y te completa la información». Y el 24/08: «cuando se configura el relevamiento público la opción se valida con un Excel de dos columnas, documento y sexo, para dejar pasar o no al siguiente paso; esa validación la podemos configurar».
+
+## Alcance acordado
+
+- Nuevo **tipo de relevamiento**: territorial (exactamente como hoy) o **formulario público**, que genera un link con token y no tiene territorial ni zona.
+- Flujo público en dos pasos: identificación (DNI + sexo, captcha) → formulario dinámico → comprobante. Lo enviado es un `Formulario` **ENVIADO** más, con su legajo ciudadano creado en el acto.
+- **Padrón de habilitados** opcional por relevamiento (Excel documento/sexo) como lista blanca del paso 1.
+- **Correo de confirmación configurable** por relevamiento.
+- **Lanzamiento gateado por RBAC**: toda la superficie backoffice detrás de la capacidad `becas.relevamiento.publico`.
+- **Afuera**: configurador de formularios propio, comunicar cupo o motivo de cierre, login del portal como requisito, avisos al backoffice por envío, editar el tipo de un relevamiento existente, pedir fecha de nacimiento en el paso 1.
+
+## Decisiones tomadas
+
+- **Sin form-builder: el público usa la misma definición dinámica que la app** (`definicion_formulario`: preguntas globales + requisitos heredados). Motivo: `Formulario.data` está keyed por pk de pregunta/requisito y la revisión renderiza contra eso; un form propio habría roto el «llega como si fuera de la app». Si hace falta acotar qué ve el público, el camino barato es un flag por pregunta (evolutivo aparte).
+- **La ingesta no pasa por la API DRF** (exige token de territorial): una vista pública reutiliza los mismos servicios (`resolver_ciudadano_offline`, cupo bajo `select_for_update`, `client_uuid` idempotente). Para el backoffice el formulario es indistinguible: la bandeja de revisión, SIS, cupos y exportación **no se tocaron**.
+- **Territorial pasa a nullable + constraint por tipo** en vez de un usuario sistema «Formulario público». Motivo: un usuario fantasma aparecería en filtros y reportes. Efecto colateral buscado: la API móvil filtra por territorial, así que los públicos desaparecen solos de la app (con test).
+- **El público nace En curso y se cierra solo** al pasar `fecha_hasta`, reutilizando el registro de vencimientos (`becas.relevamiento_publico` → FINALIZADO). La pausa existente lo saca de servicio a mano. Sin operador que lo inicie no había alternativa.
+- **Duplicado por convocatoria completa** (opción B del análisis), no por relevamiento: quien ya fue relevado en campo no puede volver a inscribirse por link. Se re-chequea dentro de la transacción del envío por si se coló otro entre paso 1 y envío.
+- **Sin match en RENAPER/Gran Base se deja pasar igual**, con `validado_renaper=False` (mismo tratamiento que una carga manual del territorial); FALLECIDO corta. Decisión del cliente.
+- **Los menores pueden inscribirse**; el paso 2 exige apoderado (RN-22, misma regla que la app; cumplir 18 hoy = mayor).
+- **Solo datos básicos en la respuesta** (nombre, apellido, fecha de nacimiento): nunca domicilio. El paso 1 es un oráculo público y se acotó lo que revela. Se decidió **no** pedir fecha de nacimiento como control extra «por ahora»: quien sabe DNI y sexo de un tercero puede inscribirlo; la revisión humana es la mitigación.
+- **Gateo por capacidad RBAC, no por variable de entorno.** Motivo: el pedido fue «que yo la configure y el cliente no la vea» en el mismo ambiente → per-usuario; encender es tildar la capacidad en Roles, sin deploy. El link en sí no se gatea (es público por diseño). El superusuario tiene bypass.
+- **Padrón: Excel parseado al subir a una tabla indexada**, nunca leído por request; chequeo **antes** de RENAPER (ahorra consultas de no habilitados); normalización en ambos sentidos (dígitos; F/M sin mayúsculas); **reemplazo total, no merge**; el mensaje «no estás habilitado» revela pertenencia y se asumió como parte del requerimiento (la persona tiene que saber por qué no entra), acotado por captcha y rate limit.
+- **Captcha aritmético autoalojado** en vez de reCAPTCHA/Turnstile o una dependencia nueva: los servicios externos exigirían salida a internet desde icore-srv y claves por ambiente. **Rate limiting sobre el cache de Django** (Redis en producción): cero infraestructura nueva.
+- **GPS best-effort**: si la persona niega la geolocalización del navegador, el envío se acepta sin coordenadas (en campo el territorial la garantiza; desde la casa no tiene sentido bloquear).
+- **El correo nunca rompe la inscripción**: cualquier falla de SMTP se loguea y el comprobante se muestra igual. Es exclusivo del flujo público (la API de campo no lo llama, con test).
+
+## Implementación
+
+- **Backoffice:** el modal de Nuevo relevamiento (listado, detalle de convocatoria y alta completa) tiene un selector de tipo visible solo con la capacidad; al elegir público se ocultan Territorial y Municipio/Localidad y aparecen Cupo, Padrón (archivo .xlsx) y el toggle de correo. El detalle muestra el link con botón copiar, la vigencia, el padrón cargado y la acción Cargar/Reemplazar padrón. Listados con badge de tipo; los públicos se ocultan a quien no tiene la capacidad y el POST con tipo público se rechaza server-side.
+- **Portal** (`/inscripcion/<token>/`): paso 1 con DNI, sexo y verificación; en orden captcha → rate limit → padrón → duplicado → Gran Base. Pantallas: «Ya estás inscripto», «Formulario no disponible» (única para vencido/pausado/cupo/cerrado, sin motivo), 404 para token inválido, «No estás habilitado» inline. Paso 2 con datos validados en solo lectura (o carga manual sin match), contacto, preguntas y requisitos de la convocatoria con los seis tipos de campo, archivos JPG/PNG/PDF hasta 5 MB, apoderado y GPS. Comprobante con número de formulario y, si aplica, aviso del correo enviado (email enmascarado).
+- **Ingesta:** `Formulario` ENVIADO con `datos_identificacion` en el contrato de la app, `validado_renaper` según origen, adjuntos como `AdjuntoFormulario`, legajo ciudadano creado o linkeado, `created_by` vacío.
+
+## Archivos
+
+`programas/models/__init__.py` · `programas/migrations/0049_*`, `0050_*` · `programas/forms.py` · `programas/views/relevamientos.py` · `programas/urls.py` · `programas/services/{vencimientos,padron,inscripcion_publica}.py` · `programas/api/views.py` · `programas/admin.py` · `programas/templates/programas/becas/relevamientos/*` · `core/rbac.py` · `portal/{urls,forms/inscripcion,services/inscripcion,views/inscripcion}.py` · `portal/templates/portal/inscripcion/*` · tests: `programas/tests/test_relevamiento_publico.py`, `test_padron.py`, `portal/tests/test_inscripcion*.py` · `docs/plans/2026-08-22-formulario-publico-becas-plan.md`.
+
+## Base de datos
+
+- `programas.0049`: `Relevamiento.tipo` (default TERRITORIAL), `token_publico` (UUID único, nulo en territoriales), `confirmar_por_email`, `territorial` nullable + `CheckConstraint` tipo↔territorial. **Segura sobre datos existentes**: todos los relevamientos previos quedan TERRITORIAL con su territorial intacto.
+- `programas.0050`: `Relevamiento.padron_archivo` + tabla `PadronHabilitado` (relevamiento, dni, sexo; único por relevamiento+dni). Aditiva.
+
+## Validación
+
+- **~75 pruebas automáticas nuevas** en verde en local: modelo/constraint/API móvil/vistas gateadas (fase 1), cierre por vencimiento, parser y servicio del padrón, paso 1 completo (captcha, rate limit, padrón, duplicado por ambos campos, FALLECIDO, caído, privacidad de la respuesta), form dinámico (obligatorios, ids ajenos, archivos, RN-22 con borde de 18), ingesta (validado, linkeo sin duplicar, manual, idempotencia, cupo, duplicado colado, vencido), vista y correo (toggle on/off, SMTP caído, la API de campo no manda).
+- Suites completas de Becas y Portal: solo los errores de entorno preexistentes (Python 3.14 renderizando plantillas), verificados contra `development` limpio en cada fase.
+- `manage.py check` OK · `makemigrations --check` sin faltantes · `design_audit.py --changed` 0 errores / 0 warnings en las cuatro fases · `compile_templates.py` 324 plantillas, 0 errores · `check_design_agent.py` OK.
+- **65 casos de QA** (`TC-290…299`) en los cuerpos de las tasks, a ejecutar por QA humano cuando los PRs mergeen.
+
+## Puesta en marcha en el servidor
+
+- Deploy estándar **con migración** (`manage.py migrate`; 0049 y 0050 son aditivas y de bajo riesgo).
+- Tras el deploy **el cliente no ve nada**: ningún rol tiene `becas.relevamiento.publico`. Encender = asignarla desde la pantalla de Roles, sin deploy. Probar el link end-to-end **en test, no en producción** (un envío de prueba aparecería en la bandeja de revisión del cliente).
+- El correo de confirmación depende del **Cambio 37 / #245 (SMTP)**; hasta entonces crear los públicos con el toggle apagado.
+- Sin cron nuevo: el cierre por vencimiento corre dentro del `procesar_vencimientos` existente.
+
+## Pendientes / a definir
+
+- **Merge y despliegue** de los cuatro PRs apilados (#301 → #302 → #303 → #304) y ejecución de los 65 casos de QA.
+- **Mockup desactualizado en dos detalles**: el modal del backoffice ya tiene el campo de padrón y «no estás habilitado» quedó como error inline del paso 1 (no pantalla propia).
+- **Flag «visible en formulario público» por pregunta/requisito** si el programa necesita acotar el formulario del público (evolutivo aparte, ~4–6 h).
+- Textos definitivos de pantallas y correo: se usaron los del mockup; los ajusta el programa cuando lo vea.
+- El control extra de fecha de nacimiento en el paso 1 quedó descartado «por ahora»; retomarlo si aparece abuso.
+
+## Reversión
+
+Revertir los PRs en orden inverso (#304 → #301). Las migraciones se retroceden a `programas.0048`: antes de hacerlo con datos reales hay que **exportar los relevamientos públicos, sus padrones y los formularios ingresados por link** —el rollback elimina `tipo`, `token_publico`, `confirmar_por_email`, `padron_archivo` y la tabla `PadronHabilitado`, y los relevamientos sin territorial violarían la columna no nula—. Los formularios ya creados y sus legajos ciudadanos son datos comunes y se conservan.

--- a/docs/plans/2026-08-22-formulario-publico-becas-plan.md
+++ b/docs/plans/2026-08-22-formulario-publico-becas-plan.md
@@ -14,6 +14,13 @@ La revisión, SIS, cupos y la app móvil **no se tocan**.
 capacidad nueva `becas.relevamiento.publico`. Se puede desplegar a producción sin que los
 usuarios del cliente vean nada; habilitarlo después es tildar la capacidad en Roles, sin deploy.
 
+## Estado (24/08/2026)
+
+Las cuatro fases están desarrolladas y en PRs apilados sobre `development`, cada uno con sus
+gates en verde: **#301** (Fase 1) → **#302** (Fase 2) → **#303** (Fase 3) → **#304** (Fase 4).
+Mergear en orden re-apuntando bases. Registro de cierre: `docs/internal/requerimientos.md`,
+Cambio 40. Queda para el PM: merge, ejecución de los 65 casos de QA y deploy a test.
+
 ## Fases de desarrollo
 
 Cuatro fases incrementales. Cada fase cierra con un **entregable demostrable**, sus tests en

--- a/portal/templates/portal/inscripcion/confirmacion.html
+++ b/portal/templates/portal/inscripcion/confirmacion.html
@@ -16,6 +16,9 @@
         <div class="mt-6 p-4 text-left" style="background: var(--bg-secondary); border: 1px solid var(--border-base); border-radius: var(--radius-xl);">
             <p class="text-xs font-bold uppercase tracking-wide" style="color: var(--text-body-subtle);">Comprobante</p>
             <p class="text-sm mt-1 font-semibold" style="color: var(--text-heading);">Formulario Nº {{ comprobante.numero }} · {{ convocatoria.nombre }}</p>
+            {% if comprobante.correo_enviado %}
+            <p class="text-xs mt-2" style="color: var(--text-body-subtle);">Te enviamos una copia a {{ comprobante.email }}.</p>
+            {% endif %}
         </div>
 
         <p class="mt-6 text-xs" style="color: var(--text-body-subtle);">Podés cerrar esta página. Ante cualquier consulta, comunicate al 0800-222-1133.</p>

--- a/portal/templates/portal/inscripcion/email/confirmacion_body.txt
+++ b/portal/templates/portal/inscripcion/email/confirmacion_body.txt
@@ -1,0 +1,9 @@
+Hola,
+
+Recibimos tu inscripción a {{ convocatoria }} ({{ segmento }}).
+
+Tu comprobante es el Formulario Nº {{ numero }}. Guardá este correo: el equipo del programa va a revisar tu formulario y, si hace falta, se va a comunicar con vos por los datos de contacto que dejaste.
+
+Este mensaje se envió automáticamente; no es necesario responderlo.
+
+DATAÑACH — Portal Ciudadano

--- a/portal/tests/test_inscripcion_correo.py
+++ b/portal/tests/test_inscripcion_correo.py
@@ -1,0 +1,112 @@
+"""Tests del correo de confirmación de la inscripción pública (#296, RN-P10)."""
+
+from unittest.mock import patch
+
+from django.core import mail
+from django.urls import reverse
+
+from portal.services.inscripcion import clave_sesion
+from portal.tests.test_inscripcion_envio import _BasePaso2Test, _identificacion
+from programas.models import Formulario, Relevamiento
+from programas.services.inscripcion_publica import enmascarar_email, enviar_confirmacion_inscripcion
+from programas.tests.test_becas_api import _BaseApiTest
+
+
+class EnviarConfirmacionTests(_BasePaso2Test):
+    def _formulario(self):
+        return Formulario.objects.create(
+            relevamiento=self.relevamiento,
+            celular="3624123456",
+            email_contacto="maria.gomez@correo.com",
+            datos_identificacion={"dni": "30123456"},
+        )
+
+    def test_toggle_activo_envia_comprobante(self):
+        self.relevamiento.confirmar_por_email = True
+        self.relevamiento.save(update_fields=["confirmar_por_email"])
+        formulario = self._formulario()
+        self.assertTrue(enviar_confirmacion_inscripcion(formulario))
+        self.assertEqual(len(mail.outbox), 1)
+        correo = mail.outbox[0]
+        self.assertEqual(correo.to, ["maria.gomez@correo.com"])
+        self.assertIn("Becas 2026", correo.subject)
+        self.assertIn(f"Formulario Nº {formulario.numero}", correo.body)
+        self.assertIn("Becas 2026", correo.body)
+
+    def test_toggle_apagado_no_envia(self):
+        formulario = self._formulario()
+        self.assertFalse(enviar_confirmacion_inscripcion(formulario))
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_falla_de_smtp_no_rompe(self):
+        self.relevamiento.confirmar_por_email = True
+        self.relevamiento.save(update_fields=["confirmar_por_email"])
+        formulario = self._formulario()
+        with patch("programas.services.inscripcion_publica.send_mail", side_effect=OSError("smtp caído")):
+            self.assertFalse(enviar_confirmacion_inscripcion(formulario))
+        self.assertTrue(Formulario.objects.filter(pk=formulario.pk).exists())
+
+    def test_enmascarar_email(self):
+        self.assertEqual(enmascarar_email("maria.gomez@correo.com"), "ma•••@correo.com")
+        self.assertEqual(enmascarar_email("a@x.com"), "a•••@x.com")
+        self.assertEqual(enmascarar_email(""), "")
+
+
+class CorreoEnLaVistaTests(_BasePaso2Test):
+    def _enviar(self):
+        session = self.client.session
+        session[clave_sesion(self.relevamiento)] = _identificacion()
+        session.save()
+        url = reverse("portal:inscripcion_paso2", kwargs={"token": self.relevamiento.token_publico})
+        return self.client.post(url, {**self._data(), **self._files()})
+
+    def test_envio_con_toggle_manda_correo_y_lo_marca_en_el_comprobante(self):
+        self.relevamiento.confirmar_por_email = True
+        self.relevamiento.save(update_fields=["confirmar_por_email"])
+        # El cuerpo del correo se renderiza con un template; bajo el test client
+        # de este entorno (Python 3.14 + Django 4.2) ese render rompe por el bug
+        # conocido de Context.__copy__, así que acá se fija el cuerpo y el
+        # template se cubre en EnviarConfirmacionTests (sin client).
+        with patch("programas.services.inscripcion_publica.render_to_string", return_value="Comprobante"):
+            resp = self._enviar()
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        comprobante = self.client.session[f"inscripcion_ok_{self.relevamiento.pk}"]
+        self.assertTrue(comprobante["correo_enviado"])
+        self.assertEqual(comprobante["email"], "ma•••@correo.com")
+
+    def test_envio_sin_toggle_no_manda(self):
+        resp = self._enviar()
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertFalse(self.client.session[f"inscripcion_ok_{self.relevamiento.pk}"]["correo_enviado"])
+
+    def test_smtp_caido_no_impide_la_inscripcion(self):
+        self.relevamiento.confirmar_por_email = True
+        self.relevamiento.save(update_fields=["confirmar_por_email"])
+        with patch("programas.services.inscripcion_publica.send_mail", side_effect=OSError("smtp caído")):
+            resp = self._enviar()
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(self.relevamiento.formularios.count(), 1)
+        self.assertFalse(self.client.session[f"inscripcion_ok_{self.relevamiento.pk}"]["correo_enviado"])
+
+
+class ElFlujoDeCampoNoMandaCorreoTests(_BaseApiTest):
+    def test_sync_desde_la_app_no_dispara_correo(self):
+        # Aunque el toggle estuviera encendido en un territorial (la UI no lo
+        # permite), la API de campo jamás manda el correo: es del flujo público.
+        self.rel.estado = Relevamiento.Estado.EN_CURSO
+        self.rel.confirmar_por_email = True
+        self.rel.save(update_fields=["estado", "confirmar_por_email"])
+        self.autenticar(self.terri)
+        resp = self.client.post(
+            reverse("becas_api:relevamiento-formularios", args=[self.rel.pk]),
+            {
+                "datos_identificacion": {"dni": "20111222", "nombre": "Ana", "apellido": "Paz", "fecha_nacimiento": "1990-01-01"},
+                "celular": "3624000000",
+                "email_contacto": "ana@correo.com",
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.data)
+        self.assertEqual(len(mail.outbox), 0)

--- a/portal/views/inscripcion.py
+++ b/portal/views/inscripcion.py
@@ -6,8 +6,9 @@ duplicado por convocatoria (RN-P5) → consulta a Gran Base/RENAPER (RN-P6).
 Con match se precargan **solo datos básicos** en la sesión (RN-P7); sin match
 se continúa igual y el formulario quedará no validado.
 
-Paso 2 (formulario dinámico) llega con #294: acá vive su guardia de sesión y
-un render provisorio.
+Paso 2 (#294): el mismo formulario dinámico que la app de campo; su envío crea
+el formulario y el legajo en el acto (#295) y, si el relevamiento lo tiene
+activo, manda el comprobante por correo (#296).
 """
 
 import logging
@@ -32,6 +33,8 @@ from programas.services.inscripcion_publica import (
     InscripcionDuplicada,
     InscripcionNoDisponible,
     crear_formulario_publico,
+    enmascarar_email,
+    enviar_confirmacion_inscripcion,
 )
 from programas.services.padron import esta_habilitado
 from programas.services.personas import consultar_persona
@@ -145,7 +148,7 @@ def inscripcion_paso2(request, token):
     )
     if request.method == "POST" and form.is_valid():
         try:
-            formulario, _creado = crear_formulario_publico(
+            formulario, creado = crear_formulario_publico(
                 relevamiento,
                 identificacion=identificacion,
                 form=form,
@@ -159,10 +162,15 @@ def inscripcion_paso2(request, token):
                 "portal/inscripcion/ya_inscripto.html",
                 {"relevamiento": relevamiento, "dni": identificacion["dni"]},
             )
+        # Correo de confirmación (#296): solo si el relevamiento lo tiene
+        # activo y solo en el envío que creó el formulario; su falla no
+        # rompe nada (queda logueada).
+        correo_enviado = bool(creado and enviar_confirmacion_inscripcion(formulario))
         request.session.pop(clave_sesion(relevamiento), None)
         request.session[f"inscripcion_ok_{relevamiento.pk}"] = {
             "numero": formulario.numero,
-            "email": formulario.email_contacto,
+            "email": enmascarar_email(formulario.email_contacto),
+            "correo_enviado": correo_enviado,
         }
         return redirect("portal:inscripcion_confirmacion", token=relevamiento.token_publico)
 

--- a/programas/services/inscripcion_publica.py
+++ b/programas/services/inscripcion_publica.py
@@ -15,8 +15,12 @@ Garantías dentro de la transacción (mismo patrón que la API de campo):
 
 from __future__ import annotations
 
+import logging
+
+from django.core.mail import send_mail
 from django.db import transaction
 from django.db.models import Q
+from django.template.loader import render_to_string
 from django.utils import timezone
 
 from programas.models import AdjuntoFormulario, Formulario, Relevamiento
@@ -112,3 +116,51 @@ def crear_formulario_publico(relevamiento, *, identificacion, form, client_uuid)
         resolver_ciudadano_offline(formulario)
         formulario.refresh_from_db()
     return formulario, True
+
+
+# --- Correo de confirmación (#296, RN-P10) ---------------------------------
+
+logger = logging.getLogger(__name__)
+
+
+def enmascarar_email(email):
+    """``maria.gomez@correo.com`` → ``ma•••@correo.com`` para el comprobante."""
+    usuario, _, dominio = (email or "").partition("@")
+    if not dominio:
+        return email or ""
+    visible = usuario[:2] if len(usuario) > 2 else usuario[:1]
+    return f"{visible}•••@{dominio}"
+
+
+def enviar_confirmacion_inscripcion(formulario):
+    """Manda el comprobante a ``email_contacto`` si el relevamiento tiene el
+    toggle activo. Exclusivo del flujo público: la API de campo no lo llama.
+
+    Nunca rompe la inscripción: cualquier falla de SMTP se loguea y devuelve
+    ``False`` (el formulario ya quedó creado y la persona ve su comprobante).
+    """
+    relevamiento = formulario.relevamiento
+    if not relevamiento.confirmar_por_email or not formulario.email_contacto:
+        return False
+    convocatoria = relevamiento.convocatoria
+    contexto = {
+        "numero": formulario.numero,
+        "convocatoria": convocatoria.nombre,
+        "segmento": convocatoria.segmento.nombre,
+    }
+    try:
+        send_mail(
+            subject=f"Comprobante de inscripción — {convocatoria.nombre}",
+            message=render_to_string("portal/inscripcion/email/confirmacion_body.txt", contexto),
+            from_email=None,
+            recipient_list=[formulario.email_contacto],
+            fail_silently=False,
+        )
+    except Exception:  # SMTP caído, mal configurado, rechazo del servidor…
+        logger.exception(
+            "No se pudo enviar el correo de confirmación del formulario %s (relevamiento %s)",
+            formulario.pk,
+            relevamiento.pk,
+        )
+        return False
+    return True


### PR DESCRIPTION
> **Apilado sobre #303 (Fase 3)** → #302 → #301. Mergear en orden y re-apuntar bases. Con este PR la funcionalidad del análisis #289 queda **completa y registrada**.

## Qué incluye

- **#296 — Correo de confirmación configurable (RN-P10):** `enviar_confirmacion_inscripcion` manda el comprobante (número de formulario + convocatoria) a `email_contacto` **solo** si el relevamiento tiene activado "Enviar confirmación por correo" y solo en el envío que creó el formulario (un reintento idempotente no re-envía). **Nunca rompe la inscripción**: cualquier falla de SMTP se loguea y el comprobante se muestra igual. Es exclusivo del flujo público — la API de campo no lo llama, con test que lo demuestra aunque el toggle estuviera encendido en un territorial. El comprobante en pantalla avisa "Te enviamos una copia a ma•••@correo.com" cuando salió.
- **Cierre (regla de oro):** entrada **Cambio 40** en `docs/internal/requerimientos.md` con la plantilla completa — pedido original, alcance, las 13 decisiones con su motivo, implementación, migraciones 0049/0050, validación, puesta en marcha (deploy con migración; el cliente no ve nada hasta asignar la capacidad; probar en test, no en prod; el correo depende de #245), pendientes y reversión. `scripts/requerimientos.py --check` OK (42 requerimientos). Plan de desarrollo actualizado con el estado final y los cuatro PRs.

## Validación

- 8 tests nuevos (`portal.tests.test_inscripcion_correo`): toggle activo envía con número y convocatoria; apagado no envía; SMTP caído devuelve `False` sin romper; enmascarado de email; vista con toggle marca `correo_enviado` en el comprobante; vista sin toggle no manda; SMTP caído en la vista igual crea el formulario y redirige; **el sync desde la app no dispara correo**. Los 54 tests de los módulos nuevos de las fases 2–4 en verde.
- Un test de vista fija el cuerpo del correo con `patch(render_to_string)` porque el test client de este entorno (Python 3.14 + Django 4.2) rompe al copiar el `Context` — bug de entorno documentado en fases anteriores; el template real se cubre en el test del servicio sin client.
- `manage.py check` OK · `makemigrations --check` sin faltantes · `design_audit.py --changed` **0 errores, 0 warnings** · `compile_templates.py` 324/0.

## Para el PM

Merge en orden #301 → #302 → #303 → #304, ejecución de los 65 casos `TC-*` y deploy a **test** con `manage.py migrate`. Encendido al cliente: asignar `becas.relevamiento.publico` desde Roles, sin deploy. El correo se verifica de verdad recién con #245 (SMTP).

Cadena: Épica #69 · Análisis #289 · Task #296 · Cambio 40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)