### PR TITLE
Formulario público de Becas — Fase 5: correcciones de la revisión de código

### DIFF
--- a/core/services/throttle.py
+++ b/core/services/throttle.py
@@ -4,9 +4,12 @@ from django.core.cache import cache
 
 
 def _ip_cliente(request):
+    real_ip = request.META.get("HTTP_X_REAL_IP", "").strip()
+    if real_ip:
+        return real_ip
     forwarded = request.META.get("HTTP_X_FORWARDED_FOR", "")
     if forwarded:
-        return forwarded.split(",")[0].strip()
+        return forwarded.split(",")[-1].strip()
     return request.META.get("REMOTE_ADDR", "desconocida")
 
 

--- a/docs/client/financiero/detalle-tareas.md
+++ b/docs/client/financiero/detalle-tareas.md
@@ -391,7 +391,10 @@
 !!! note "Restauración de horas (23/08/2026)"
     Un ajuste del 21/08 había reducido en **88 h** el registro de Juani Portilla: el desarrollo frontend de Dispositivos del 03 al 14/08 (−76 h) y los entregables de observabilidad y actualización de Django del 17–18/08 (−12 h). Por decisión del PM esas horas se **restauraron a sus valores originales**, y se **conservaron** las filas de desarrollo backend de Dispositivos agregadas en aquel ajuste (4 h).
 
-### :material-package-variant-closed: Consumo del 20 al 23 de agosto — por entregable
+### :material-package-variant-closed: Consumo del 20 al 24 de agosto — por entregable
+
+!!! info "Regla desde el 24/08"
+    Se incorpora una **reunión de seguimiento diaria** de las cuatro personas del equipo (1 h por persona) y el **armado del informe diario** por parte del PM (30 min). Ambas se registran cada día hábil.
 
 | Período | Persona | Programa | Entregable | Qué incluye | Horas | Equiv. |
 |---|---|---|---|---|---:|---:|
@@ -435,16 +438,25 @@
 | 23/08 | Matías Fariña | Becas | Documentación de la funcionalidad | Documentación del diseño y las decisiones de la funcionalidad de publicación de formularios. | 1 h | — |
 | 23/08 | Matías Fariña | Transversal | Auditoría y reconstrucción del registro de horas | Detección y reversión de un recorte no validado de 88 h en el registro, y reconstrucción del consumo del 20 al 23 por entregable a partir del repositorio. | 3 h | — |
 | 23/08 | Matías Fariña | Transversal | Gestión del tablero del Project | Carga del campo Proyecto en los 137 items del tablero, con verificación. | 1 h | — |
-| | | | **Total 20 al 23/08** | | **107 h** | **73 h** |
+| 24/08 | Matías Fariña | Becas | Formulario público — Fase 1: modelo, backoffice y ciclo de vida | Modelo de relevamiento público con tipo, token, correo y capacidad RBAC; alta y gestión en el backoffice gateada por permiso; ciclo de vida con cierre por vencimiento; cobertura de pruebas (#290, #291, #292 — PR #301). | 3 h | 16 h |
+| 24/08 | Matías Fariña | Becas | Formulario público — Fase 2: padrón por Excel y paso 1 del portal | Padrón de habilitados cargado por Excel y primera pantalla pública de identificación por DNI y sexo contra RENAPER (#299, #293 — PR #302). | 3 h | 12 h |
+| 24/08 | Matías Fariña | Becas | Formulario público — Fase 3: formulario dinámico e ingesta | Paso 2 del portal con el formulario dinámico y la ingesta de punta a punta que crea el Formulario y el legajo ciudadano (#294, #295 — PR #303). | 3 h | 15 h |
+| 24/08 | Matías Fariña | Transversal | Reunión de seguimiento diaria | Reunión diaria de seguimiento del equipo. | 1 h | — |
+| 24/08 | Matías Fariña | Transversal | Armado del informe diario | Informe diario de avance del equipo. | 0,5 h | — |
+| 24/08 | Juani Portilla | Transversal | Redirección de /dashboard/ al inicio | Corrección de la ruta heredada que mandaba al login en vez del inicio, con pruebas (#285 — PR #300). | 1 h | 2 h |
+| 24/08 | Juani Portilla | Transversal | Reunión de seguimiento diaria | Reunión diaria de seguimiento del equipo. | 1 h | — |
+| 24/08 | Pablo Cao | Transversal | Reunión de seguimiento diaria | Reunión diaria de seguimiento del equipo. | 1 h | — |
+| 24/08 | Matías Abate | Transversal | Reunión de seguimiento diaria | Reunión diaria de seguimiento del equipo. | 1 h | — |
+| | | | **Total 20 al 24/08** | | **121,5 h** | **118 h** |
 
 ### :material-briefcase-outline: Consumo de agosto por programa
 
 | Programa | Horas agosto |
 |---|---:|
-| Becas | 305 h 00 min |
+| Becas | 314 h 00 min |
 | Dispositivos | 124 h 30 min |
-| Transversal | 121 h 30 min |
-| **Total agosto 2026 (al 23/08)** | **551 h 00 min** |
+| Transversal | 127 h 00 min |
+| **Total agosto 2026 (al 24/08)** | **565 h 30 min** |
 
 ---
 
@@ -474,9 +486,9 @@
 
 
 
-    **93.012 minutos** (1.550 h 12 min)
+    **93.882 minutos** (1.564 h 42 min)
 
-    Junio 499 h 12 min + julio 500 h 00 min + agosto 551 h 00 min (al 23/08).
+    Junio 499 h 12 min + julio 500 h 00 min + agosto 565 h 30 min (al 24/08).
 
 
 

--- a/docs/client/financiero/index.md
+++ b/docs/client/financiero/index.md
@@ -14,9 +14,9 @@
     ---
 
     :material-wallet-outline: Presupuesto: **700 horas**<br>
-    :material-clock-check-outline: Consumido: **551 h 0 min** (79%) — al 23/08<br>
-    :material-check-circle-outline: Saldo: **149 h 0 min** disponibles<br>
-    :material-briefcase-outline: Becas: **305 h**
+    :material-clock-check-outline: Consumido: **565 h 30 min** (81%) — al 24/08<br>
+    :material-check-circle-outline: Saldo: **134 h 30 min** disponibles<br>
+    :material-briefcase-outline: Becas: **314 h**
 
     **Estado:** :material-circle:{ style="color: #3b82f6" } En curso
 

--- a/docs/client/financiero/mes-2026-08.md
+++ b/docs/client/financiero/mes-2026-08.md
@@ -1,7 +1,7 @@
 # :material-cash-multiple: Agosto 2026 — Mes en curso
 
 !!! info "Mes en curso"
-    Agosto 2026 está en ejecución. Al **23/08** se llevan **551 h consumidas** sobre un presupuesto de **700 horas** (79%). Esta página se actualiza a medida que se registran horas.
+    Agosto 2026 está en ejecución. Al **24/08** se llevan **565 h 30 min consumidas** sobre un presupuesto de **700 horas** (81%). Esta página se actualiza a medida que se registran horas.
 
 !!! note "Dos cambios respecto de los meses anteriores"
     **Presupuesto:** junio y julio se ejecutaron sobre 500 h mensuales. Agosto 2026 se ejecuta sobre **700 h**.
@@ -26,15 +26,15 @@
 
     ---
 
-    **551 h 00 min** (79%)
+    **565 h 30 min** (81%)
 
-    Horas consumidas al 23/08
+    Horas consumidas al 24/08
 
 -   :material-check-circle-outline: **Saldo**
 
     ---
 
-    **149 h 00 min**
+    **134 h 30 min**
 
     Disponibles para el resto del mes
 
@@ -46,10 +46,10 @@
 
 | Programa | Horas | % del consumo |
 |---|---:|---:|
-| [Programa Becas](../funcionalidades/programa-becas.md) | 305.0 | 55% |
-| [Programa Dispositivos](../funcionalidades/programa-dispositivos.md) | 124.5 | 23% |
-| Transversal | 121.5 | 22% |
-| **Total agosto 2026 (al 23/08)** | **551.0** | **100%** |
+| [Programa Becas](../funcionalidades/programa-becas.md) | 314.0 | 56% |
+| [Programa Dispositivos](../funcionalidades/programa-dispositivos.md) | 124.5 | 22% |
+| Transversal | 127.0 | 22% |
+| **Total agosto 2026 (al 24/08)** | **565.5** | **100%** |
 
 ---
 
@@ -57,11 +57,11 @@
 
 | Persona | Foco principal | Horas | % del consumo |
 |---|---|---:|---:|
-| Pablo Cao | Desarrollo de Becas: cambios solicitados, nivel Programa, reportes, análisis y app de campo | 162.0 | 29% |
-| Matías Fariña | Análisis funcional, diseño, despliegue, documentación y gestión | 155.0 | 28% |
-| Juani Portilla | Desarrollo de Dispositivos, performance y optimización de UX | 141.0 | 26% |
-| Matías Abate | Pruebas funcionales, casos de prueba y documentación de procesos | 93.0 | 17% |
-| **Total agosto 2026 (al 23/08)** | | **551.0** | **100%** |
+| Pablo Cao | Desarrollo de Becas: cambios solicitados, nivel Programa, reportes, análisis y app de campo | 163.0 | 29% |
+| Matías Fariña | Análisis funcional, diseño, desarrollo del formulario público, despliegue, documentación y gestión | 165.5 | 29% |
+| Juani Portilla | Desarrollo de Dispositivos, performance y optimización de UX | 143.0 | 25% |
+| Matías Abate | Pruebas funcionales, casos de prueba y documentación de procesos | 94.0 | 17% |
+| **Total agosto 2026 (al 24/08)** | | **565.5** | **100%** |
 
 [:material-table-arrow-right: Ver detalle de consumo día por día](detalle-tareas.md){ .md-button }
 
@@ -79,7 +79,7 @@
 - **Franja horaria del relevamiento:** el relevamiento pasa a tener franja horaria, con impacto en la app de campo.
 - **Recuperación de contraseña:** flujo de recuperación autogestionada en el acceso al backoffice.
 - **Calidad y performance:** línea de base de observabilidad de performance en el pipeline, actualización del ecosistema Django y restauración de los controles de calidad.
-- **Formulario público:** análisis funcional publicado con sus tareas derivadas, reunión de definición y plan de desarrollo de la épica.
+- **Formulario público:** análisis funcional publicado con sus tareas derivadas, reunión de definición, plan de desarrollo y arranque de la implementación: modelo y backoffice gateado, padrón por Excel, identificación por DNI, formulario dinámico e ingesta de punta a punta.
 - **Sincronización de la app de campo:** diagnóstico y corrección de los errores de sincronización de formularios en el entorno del organismo.
 - **Círculo de credenciales por correo:** implementación del envío de credenciales, cambio de contraseña obligatorio en el primer acceso y herramienta de diagnóstico de correo.
 - **Optimización de la experiencia y el rendimiento:** menos conexiones en vivo redundantes, recursos compilados localmente, interfaz móvil unificada y pruebas de estrés posteriores.

--- a/docs/internal/requerimientos.md
+++ b/docs/internal/requerimientos.md
@@ -3411,4 +3411,16 @@ Revertir los PRs en orden inverso (#304 → #301). Las migraciones se retroceden
 - **Duplicado por convocatoria**: se lockea la convocatoria antes del chequeo (dos envíos simultáneos por relevamientos distintos podían pasar ambos) y RN-P5 quedó en una sola función compartida por portal e ingesta.
 - Un relevamiento cambiado a público desde el admin quedaba **sin token** → se genera en `save()` siempre que falte.
 
+**25/08/2026 - Fase 6 - segunda revision.** Se implementaron las correcciones de la segunda revision:
+
+- El rate limit del paso 1 deja de confiar en el primer `X-Forwarded-For`: usa `X-Real-IP`, luego el ultimo forwarded, y el portal delega en el throttle central.
+- El captcha del paso 1 se consume apenas valida correctamente, aun cuando despues el flujo vuelva con error.
+- La idempotencia por `client_uuid` del formulario publico usa el helper tolerante a UUID texto/sin guiones compartido con la API.
+- `formulario_revalidar_renaper` vuelve a pasar por `_assert_scope_formulario` antes de mutar datos del ciudadano.
+- Si Gran Base valida identidad pero no entrega fecha normalizable, el paso 2 pide fecha de nacimiento y RN-22 vuelve a exigir apoderado para menores.
+- El DNI del apoderado se normaliza y valida siempre que venga cargado, tambien en formularios de adultos.
+- La creacion de relevamientos publicos con padron queda atomica: si falla la carga del padron no queda link abierto.
+- Los listados de revision y pendientes RENAPER excluyen formularios publicos cuando el usuario no tiene `becas.relevamiento.publico`.
+- Beneficiarios de convocatoria y su CSV aplican el mismo recorte de formularios publicos que los relevamientos visibles.
+- El admin deja `tipo` como solo lectura al editar un relevamiento; la conversion territorial/publico queda bloqueada.
 **Decisión pendiente detectada:** los formularios **RECHAZADO/BAJA** cuentan como «ya inscripto» y bloquean la reinscripción por link (mismo criterio que la app de campo). Quedó así por omisión; confirmar con el programa si el rechazo debe liberar el DNI.

--- a/docs/internal/requerimientos.md
+++ b/docs/internal/requerimientos.md
@@ -3397,3 +3397,18 @@ La regla, el motivo de cada campo y la mitad de lectura —qué consultar **ante
 ## Reversión
 
 Revertir los PRs en orden inverso (#304 → #301). Las migraciones se retroceden a `programas.0048`: antes de hacerlo con datos reales hay que **exportar los relevamientos públicos, sus padrones y los formularios ingresados por link** —el rollback elimina `tipo`, `token_publico`, `confirmar_por_email`, `padron_archivo` y la tabla `PadronHabilitado`, y los relevamientos sin territorial violarían la columna no nula—. Los formularios ya creados y sus legajos ciudadanos son datos comunes y se conservan.
+
+## Historial
+
+**24/08/2026 — Revisión de código de las cuatro fases (PR de correcciones, Fase 5).** Antes de mergear se revisó el diff completo y se corrigieron diez hallazgos; cinco eran errores 500 o salteos de reglas que los tests no cubrían:
+
+- El reporte **Producción territorial** se caía con un solo relevamiento público (territorial nulo) → se excluyen del agrupado.
+- El **rate limit** del paso 1 devolvía 500 en vez del mensaje (`add_error` sobre un form sin `cleaned_data`); un `except AttributeError` de los tests, puesto para tolerar el bug de render del entorno, lo tapaba → se corrigió el form y los tests ahora re-lanzan cualquier error que no sea ese bug conocido.
+- **Pendientes RENAPER** generaba una opción `None` de territorial y rompía al filtrar → se excluyen públicos del selector y se validan los filtros GET.
+- **Fecha de nacimiento no ISO** de Gran Base (`15/03/2010`) salteaba RN-22 (no exigía apoderado a un menor) y rompía el alta del ciudadano → `fecha_iso()` normaliza en `normalizar_persona`.
+- El **gate RBAC** protegía listados y detalle pero no las vistas mutantes (finalizar, reabrir, reprogramar, cupo, pausa, revisión) → el chequeo vive ahora en `_assert_scope*` y en pausas.
+- **Padrón**: los DNIs como float del Excel (`30123456.0`) quedaban con un cero de más y nadie matcheaba → cast numérico y rechazo de filas que no dan 7-8 dígitos. Y el padrón ahora **se re-verifica al enviar**, dentro de la transacción (un reemplazo entre paso 1 y envío ya no deja pasar).
+- **Duplicado por convocatoria**: se lockea la convocatoria antes del chequeo (dos envíos simultáneos por relevamientos distintos podían pasar ambos) y RN-P5 quedó en una sola función compartida por portal e ingesta.
+- Un relevamiento cambiado a público desde el admin quedaba **sin token** → se genera en `save()` siempre que falte.
+
+**Decisión pendiente detectada:** los formularios **RECHAZADO/BAJA** cuentan como «ya inscripto» y bloquean la reinscripción por link (mismo criterio que la app de campo). Quedó así por omisión; confirmar con el programa si el rechazo debe liberar el DNI.

--- a/docs/plans/2026-08-22-formulario-publico-becas-plan.md
+++ b/docs/plans/2026-08-22-formulario-publico-becas-plan.md
@@ -18,7 +18,7 @@ usuarios del cliente vean nada; habilitarlo después es tildar la capacidad en R
 
 Las cuatro fases están desarrolladas y en PRs apilados sobre `development`, cada uno con sus
 gates en verde: **#301** (Fase 1) → **#302** (Fase 2) → **#303** (Fase 3) → **#304** (Fase 4) →
-**#305** (Fase 5: correcciones de la revisión de código, ver Historial del Cambio 40).
+**#305** (Fase 5: correcciones de la revision de codigo) -> **PR pendiente** (Fase 6: segunda revision, ver Historial del Cambio 40).
 Mergear en orden re-apuntando bases. Registro de cierre: `docs/internal/requerimientos.md`,
 Cambio 40. Queda para el PM: merge, ejecución de los 65 casos de QA y deploy a test.
 

--- a/docs/plans/2026-08-22-formulario-publico-becas-plan.md
+++ b/docs/plans/2026-08-22-formulario-publico-becas-plan.md
@@ -17,7 +17,8 @@ usuarios del cliente vean nada; habilitarlo después es tildar la capacidad en R
 ## Estado (24/08/2026)
 
 Las cuatro fases están desarrolladas y en PRs apilados sobre `development`, cada uno con sus
-gates en verde: **#301** (Fase 1) → **#302** (Fase 2) → **#303** (Fase 3) → **#304** (Fase 4).
+gates en verde: **#301** (Fase 1) → **#302** (Fase 2) → **#303** (Fase 3) → **#304** (Fase 4) →
+**#305** (Fase 5: correcciones de la revisión de código, ver Historial del Cambio 40).
 Mergear en orden re-apuntando bases. Registro de cierre: `docs/internal/requerimientos.md`,
 Cambio 40. Queda para el PM: merge, ejecución de los 65 casos de QA y deploy a test.
 

--- a/docs/plans/2026-08-24-formulario-publico-fase-6-correcciones.md
+++ b/docs/plans/2026-08-24-formulario-publico-fase-6-correcciones.md
@@ -1,0 +1,131 @@
+# Formulario público de Becas — Fase 6: correcciones de la segunda revisión
+
+**Para quien ejecuta (Codex u otro agente):** este documento es autosuficiente. Cada punto trae
+*dónde está el error, por qué es un error y exactamente qué hacer*. No hace falta releer las
+fases anteriores; sí hay que leer `CLAUDE.md` y `AGENTS.md` (convenciones del repo) antes de tocar código.
+
+| | |
+|---|---|
+| **Rama base** | `feature/relevamiento-publico-fase-5-correcciones` (PR #305). Crear `feature/relevamiento-publico-fase-6-correcciones` desde ahí y abrir el PR **contra la rama de Fase 5**. |
+| **Cadena** | Épica #69 · Análisis #289 · registro `docs/internal/requerimientos.md` **Cambio 40** |
+| **Origen** | Segunda revisión de código del diff `development…fase-5` (24/08/2026): 10 hallazgos, 4 de seguridad/producción |
+| **Estimación** | ~4 h |
+| **Entorno** | Siempre el venv del repo: `$env:PY_VENV = "$PWD\.venv\Scripts\python.exe"; $env:DJANGO_SECRET_KEY = "test-key"`. Python 3.14 local rompe el render de templates bajo el test client (`AttributeError: 'super' object has no attribute 'dicts'`): **ese error es de entorno y ya está en `development`**; cualquier otro error es real. |
+
+## Reglas de trabajo para esta fase
+
+1. **Un commit por hallazgo** (título `fix(becas): …` o `fix(portal): …`), en el orden de abajo.
+2. **Cada hallazgo lleva su test** en `portal/tests/test_correcciones_review_2.py` (crear) o en el módulo de tests existente que corresponda. Los tests tienen que **fallar antes del fix y pasar después**; si un test necesita renderizar bajo el test client, usar el helper `_tolerar_render_local` de `portal/tests/test_inscripcion.py` (solo tolera el bug conocido `dicts`, re-lanza el resto).
+3. **Reutilizar lo que existe** — es el motivo de varios de estos bugs. Los helpers a reutilizar están nombrados en cada punto.
+4. **No mover issues del Project ni tocar `main`** (solo el PM mueve tareas).
+5. **Gates de cierre** (todos deben quedar en cero/OK): `manage.py check` · `makemigrations --check --dry-run` (esta fase **no** migra) · `scripts\design_audit.py --changed` 0 errores · `scripts\compile_templates.py` 0 errores · `scripts\requerimientos.py --check` OK · suites `portal.tests` y `programas.tests.test_relevamiento_publico test_padron test_becas_api test_becas_vencimientos test_becas_revision` sin fallos nuevos (los errores `dicts` preexistentes son 6 en `test_relevamiento_publico` y 14 en `test_becas_revision`, más 11 en `portal.tests` de módulos ajenos; verificarlo contra `development` si hay dudas).
+6. **Al terminar**, agregar al **Historial del Cambio 40** en `docs/internal/requerimientos.md` una entrada fechada «Fase 6 — segunda revisión» que liste los 10 arreglos en una línea cada uno (mismo estilo que la entrada de la Fase 5 que ya está ahí) y actualizar la línea de PRs en `docs/plans/2026-08-22-formulario-publico-becas-plan.md` (sección *Estado*) sumando el PR nuevo.
+
+---
+
+## Críticos
+
+### C1 · El rate limit del paso 1 se saltea con el header `X-Forwarded-For`
+
+- **Archivos:** `portal/services/inscripcion.py` (`_ip_de`, `intentos_excedidos`, `registrar_intento`, líneas ~45-70) · `core/services/throttle.py` (`_ip_cliente`).
+- **Error:** la IP se toma del **primer** valor de `X-Forwarded-For`. nginx (`nginx.conf:46`) usa `$proxy_add_x_forwarded_for`, que **agrega** al final lo que ya traía el cliente; el primer valor lo controla el atacante. Rotando el header, cada request cae en un bucket nuevo y el paso 1 queda como oráculo ilimitado de Gran Base/RENAPER y de «quién está inscripto». Además `portal/services/inscripcion.py` **reimplementa** `core/services/throttle.py`, que tiene el mismo defecto.
+- **Solución:**
+  1. En `core/services/throttle.py`, cambiar `_ip_cliente` para preferir `HTTP_X_REAL_IP` (nginx lo fija con `$remote_addr`, `nginx.conf:45`), luego el **último** valor de `X-Forwarded-For`, luego `REMOTE_ADDR`. Esto arregla también a los otros consumidores del throttle.
+  2. En `portal/services/inscripcion.py`, **borrar** `_ip_de`, `intentos_excedidos` y `registrar_intento`, y exponer una sola función `paso1_excedido(request)` que delegue en `rate_limit_excedido(request, "inscripcion_paso1", MAX_INTENTOS_IP, VENTANA_SEGUNDOS)`. Conservar las constantes `MAX_INTENTOS_IP` / `VENTANA_SEGUNDOS` (con sus `getattr(settings, …)`).
+  3. En `portal/views/inscripcion.py` (`inscripcion_paso1`), reemplazar el par «`intentos_excedidos` al inicio + `registrar_intento` en cada rama» por **una** llamada a `paso1_excedido(request)` al comienzo del POST: `rate_limit_excedido` cuenta y decide en el mismo paso. Si excede → `form.is_valid(); form.add_error(None, MENSAJE_DEMASIADOS_INTENTOS)` sin consultar nada más (mantener ese comportamiento).
+  4. Ajustar `portal/tests/test_inscripcion.py`: el test del rate limit hoy parchea `portal.views.inscripcion.intentos_excedidos`; pasar a parchear `portal.views.inscripcion.paso1_excedido`. El test unitario de ventana (`RateLimitTests`) pasa a usar `rate_limit_excedido` directamente.
+- **Test nuevo:** con `RequestFactory`, dos requests con `HTTP_X_FORWARDED_FOR` distintos pero el mismo `HTTP_X_REAL_IP` comparten el contador; y un request con `X-Real-IP` ignora un `X-Forwarded-For` falso.
+
+### C2 · El captcha se resuelve una vez y se reutiliza infinitamente
+
+- **Archivo:** `portal/views/inscripcion.py`, `inscripcion_paso1`, rama de éxito (~línea 107-115: se guarda la sesión y se hace `redirect` al paso 2).
+- **Error:** la respuesta del captcha queda en `request.session[SESSION_KEY_CAPTCHA]` después del POST exitoso; solo se regenera en el camino que vuelve a renderizar. Un bot resuelve `a+b` una vez y loopea POSTs con distintos DNIs: `captcha_valido` sigue dando `True` y cada request consulta Gran Base.
+- **Solución:** en `portal/services/inscripcion.py` agregar `consumir_captcha(request)` que haga `request.session.pop(SESSION_KEY_CAPTCHA, None)` y `pop(SESSION_KEY_CAPTCHA_PREGUNTA, None)`. Llamarla en la vista **inmediatamente después** de que `captcha_valido(...)` devuelva `True` (antes de seguir con padrón/duplicado/consulta), de modo que **cualquier** POST con captcha correcto lo consuma, avance o no. El render posterior ya llama a `nuevo_captcha(request)` en POST, así que el formulario que vuelve con error trae desafío nuevo.
+- **Test nuevo:** POST exitoso (con `consultar_persona` mockeado) → segundo POST con la misma respuesta de captcha y otro DNI **no** avanza (no redirect, `consultar_persona` llamado una sola vez).
+
+### C3 · La idempotencia por `client_uuid` no funciona en el MySQL de producción
+
+- **Archivo:** `programas/services/inscripcion_publica.py`, `crear_formulario_publico` (~línea 75: `rel.formularios.filter(client_uuid=client_uuid).first()`).
+- **Error:** el lookup nativo de `UUIDField` falla o no matchea en el esquema productivo, que guarda los UUID **como texto sin guiones**. El equipo ya lo sufrió en la sincronización móvil y lo resolvió con `_formulario_por_client_uuid` en `programas/api/views.py:57` (anota `Replace(Cast("client_uuid", CharField()), "-", "")` y compara con `client_uuid.hex`). Al no reusarlo, en producción el doble submit del paso 2 crea dos formularios o da 500, aunque en SQLite (tests) funcione.
+- **Solución:**
+  1. Mover `_formulario_por_client_uuid` a `programas/services/becas.py` como `formulario_por_client_uuid(relevamiento, client_uuid)` (misma implementación). En `programas/api/views.py` dejar `_formulario_por_client_uuid = formulario_por_client_uuid` (import) para no tocar sus llamadas ni sus tests.
+  2. En `crear_formulario_publico`, convertir el `client_uuid` de sesión (es `str`) con `uuid.UUID(client_uuid)` y usar `formulario_por_client_uuid(rel, ...)`. Si el string no es un UUID válido (`ValueError`), tratarlo como ausente (no idempotencia) — no puede romper el envío.
+- **Test nuevo:** el test existente `test_doble_submit_es_idempotente` (`portal/tests/test_inscripcion_envio.py`) debe seguir pasando; agregar uno que llame al servicio con `client_uuid` como **string con guiones** y verifique que el segundo envío devuelve `creado=False`. (La diferencia real solo se ve en MySQL; el objetivo del test es asegurar que se usa el helper tolerante y la conversión a `uuid.UUID`.)
+
+### C4 · `formulario_revalidar_renaper` no pasa por el scope ni por el gate RN-P13
+
+- **Archivo:** `programas/views/revision.py:563-566`.
+- **Error:** es la única vista mutante de formularios que no llama a `_assert_scope_formulario(request, formulario)`. Un usuario con `becas.programa.administrar` pero sin `becas.relevamiento.publico` (o fuera del segmento) puede POSTear `/becas/formularios/<pk>/revalidar-renaper/` sobre un formulario del link y pisar nombre/apellido/género/fecha del ciudadano, aunque el detalle le dé 403.
+- **Solución:** agregar `_assert_scope_formulario(request, formulario)` inmediatamente después del `get_object_or_404` (antes del chequeo de método), igual que hacen `formulario_detalle` y las demás vistas del módulo.
+- **Test nuevo:** con `RequestFactory` + `patch` de `puede` en `programas.views.revision` devolviendo `False` para `CAP_RELEVAMIENTO_PUBLICO`, la vista sobre un formulario de relevamiento público lanza `PermissionDenied` (o responde 403 vía client).
+
+---
+
+## Altos
+
+### A5 · RN-22 se saltea si la fecha de Gran Base no se pudo normalizar
+
+- **Archivo:** `portal/forms/inscripcion.py`, `InscripcionPaso2Form.__init__` (~línea 158-160) y `fecha_nacimiento_efectiva` (~línea 176-184).
+- **Error:** con `origen == "personas"` se **borran** los campos `nombre/apellido/fecha_nacimiento`. Si `fecha_iso()` devolvió `""` (formato desconocido del proveedor), `fecha_nacimiento_efectiva()` es `None`, `es_menor(None)` es `None` y `clean()` nunca exige apoderado: un menor se inscribe sin apoderado, con `datos_identificacion.fecha_nacimiento=""` y `validado_renaper=True`, y no tiene dónde cargar la fecha.
+- **Solución:** en `__init__`, cuando `origen == "personas"` borrar solo `nombre` y `apellido`; **conservar `fecha_nacimiento` únicamente si la fecha validada está vacía** (`not fecha_iso(datos.get("fecha_nacimiento"))`), como campo obligatorio; si la fecha validada existe, borrarlo como hoy. En `fecha_nacimiento_efectiva`, si no es manual y el campo `fecha_nacimiento` está presente en `self.fields`, devolver `cleaned_data.get("fecha_nacimiento")`. En `programas/services/inscripcion_publica.py`, al armar `datos_identificacion` para `es_validado`, usar la fecha del form si la del proveedor vino vacía. La identidad sigue contando como validada (nombre y apellido vienen del proveedor). Actualizar el template `paso2.html`: el bloque «Tus datos» hoy solo se muestra con `form.es_manual`; mostrar también el campo `fecha_nacimiento` cuando exista en el form (`{% if "fecha_nacimiento" in form.fields %}`) con el texto «No pudimos obtener tu fecha de nacimiento: completala».
+- **Test nuevo:** identificación `personas` con `datos.fecha_nacimiento = "texto raro"` → el form **exige** `fecha_nacimiento`; completándola con una fecha de menor, exige apoderado.
+
+### A6 · El DNI del apoderado solo se valida cuando la persona es menor
+
+- **Archivo:** `portal/forms/inscripcion.py`, `clean()` (~línea 190-205).
+- **Error:** el bloque de apoderado se renderiza siempre (`paso2.html`), pero la normalización/validación de `apoderado_dni` vive dentro del `if es_menor(...)`. Un adulto que escribe `30.123.456` o `abc` hace que `resolver_ciudadano_offline` cree un `Ciudadano` con ese DNI malformado (`programas/services/becas.py:165`).
+- **Solución:** sacar la normalización fuera de la rama de menor: si `cleaned.get("apoderado_dni")` viene cargado, siempre reducirlo a dígitos, exigir 7-8 dígitos (`add_error` si no) y guardar el valor normalizado. Dentro de la rama de menor solo queda la obligatoriedad de los cinco campos. Mismo criterio para `apoderado_genero` si viene cargado (ya es `ChoiceField`, no hace falta más).
+- **Test nuevo:** adulto con `apoderado_dni="30.123.456"` → `cleaned_data["apoderado_dni"] == "30123456"`; adulto con `apoderado_dni="abc"` → error en el campo.
+
+### A7 · Si falla la carga del padrón, el link queda abierto (fail-open)
+
+- **Archivos:** `programas/forms.py`, `RelevamientoForm.save()` (~línea 1250) · `programas/views/relevamientos.py`, `RelevamientoCreateView.form_valid` (~línea 553).
+- **Error:** `super().save()` commitea el relevamiento (token, EN_CURSO) y **después** `cargar_padron` corre en su propia transacción. Si falla (`bulk_create`, storage del archivo), el request da 500 pero el público queda vivo con cero filas de padrón, y `esta_habilitado` interpreta «sin padrón = abierto». No hay `ATOMIC_REQUESTS`.
+- **Solución:** envolver el cuerpo de `RelevamientoForm.save()` en `with transaction.atomic():` (alta + `cargar_padron` en la misma transacción; `cargar_padron` ya es `@transaction.atomic`, anida bien). Alternativa equivalente: decorar `form_valid` con `transaction.atomic`. Elegir el form: así también protege el alta de página completa.
+- **Test nuevo:** con `patch("programas.services.padron.PadronHabilitado.objects.bulk_create", side_effect=RuntimeError)`, `form.save()` lanza y **no existe** ningún `Relevamiento` nuevo.
+
+### A8 · Dos listados de revisión muestran formularios públicos a quien no tiene la capacidad
+
+- **Archivo:** `programas/views/revision.py`, `RevisionPersonasListView` y `RenaperPendientesListView` (`get_queryset`, ~líneas 130-180).
+- **Error:** el gate RN-P13 se aplica en los detalles (`_assert_scope_formulario`) pero no en estos dos listados: un coordinador sin `becas.relevamiento.publico` ve filas de inscriptos por link (territorial vacío), cuenta `pendientes_renaper` con ellos, y cada «Abrir» da 403. En `relevamientos.py` el invariante ya existe: `_sin_publicos_si_no_puede(qs, user)`.
+- **Solución:** en ambos `get_queryset` (y en el `base` de `get_context_data` de pendientes RENAPER, y en el contador `pendientes_renaper` del contexto si lo hay), excluir `relevamiento__tipo=Relevamiento.Tipo.PUBLICO` cuando `not puede(self.request.user, CAP_RELEVAMIENTO_PUBLICO)`. Crear un helper local `_sin_formularios_publicos_si_no_puede(qs, user)` en `revision.py` (espejo del de relevamientos, filtrando por `relevamiento__tipo`). Mientras se está ahí: en `renaper_pendientes.html:37`, mostrar «Formulario público» cuando `formulario.relevamiento.territorial` es nulo (hoy queda vacío).
+- **Test nuevo:** con la capacidad parcheada en `False`, `RevisionPersonasListView().get_queryset()` no incluye el formulario del público; con `True`, sí.
+
+### A9 · Beneficiarios y su export incluyen formularios públicos que el usuario no puede abrir
+
+- **Archivo:** `programas/views/relevamientos.py`, `ConvocatoriaDetailView.get_context_data` (~línea 177: `beneficiarios`, `n_beneficiarios`, `n_aprobados`) y `convocatoria_export_beneficiarios`.
+- **Error:** los relevamientos se filtran con `_sin_publicos_si_no_puede`, pero los formularios de la solapa Beneficiarios y su CSV se calculan sobre **todos** los `Formulario` de la convocatoria. El usuario sin capacidad ve `n_relevamientos=1` y 50 beneficiarios, cada uno con link a un detalle que da 403; `convocatoria_export_relevamientos` sí filtra, así que los dos exports se contradicen.
+- **Solución:** aplicar a esos querysets de `Formulario` la misma exclusión (`exclude(relevamiento__tipo=PUBLICO)` cuando no `_puede_publico(user)`). Crear `_sin_formularios_publicos_si_no_puede(qs, user)` en `relevamientos.py` y usarlo en el contexto y en el export.
+- **Test nuevo:** convocatoria con un territorial (1 formulario aprobado) y un público (1 aprobado); usuario sin capacidad → `n_beneficiarios == 1` y el CSV tiene una sola fila de datos; con capacidad → 2.
+
+---
+
+## Medio
+
+### M10 · Un relevamiento convertido a público desde el admin queda ASIGNADO para siempre
+
+- **Archivos:** `programas/models/__init__.py`, `Relevamiento.save()` (~línea 1681-1686) · `programas/admin.py`, `RelevamientoAdmin`.
+- **Error:** la Fase 5 hizo que el token se genere en cualquier `save()` (para que la conversión por admin tenga link), pero la promoción `ASIGNADO → EN_CURSO` sigue gateada en `_state.adding`. Convertido por admin, el link existe y siempre responde «no disponible» porque `relevamiento_disponible()` exige EN_CURSO y los únicos caminos a ese estado necesitan territorial.
+- **Solución (la más simple y sana):** en `RelevamientoAdmin` hacer `tipo` **read-only en edición** (`get_readonly_fields`: agregar `"tipo"` cuando `obj is not None`). El tipo se define al crear y no se cambia (RN-P1 del análisis #289). Con eso, la generación de token en `save()` puede volver a ser solo en el alta, o quedarse como está (inofensiva). Registrar en el Historial del Cambio 40 que la conversión de tipo por admin quedó bloqueada.
+- **Test nuevo:** `RelevamientoAdmin(Relevamiento, site).get_readonly_fields(request, obj=rel)` contiene `"tipo"` y no lo contiene con `obj=None`.
+
+---
+
+## Menores (hacer si sobra tiempo, en el mismo PR)
+
+- `renaper_pendientes.html:37`: celda de territorial vacía para públicos → «Formulario público» (cubierto en A8).
+- `portal/views/inscripcion.py`: en el camino de doble submit concurrente (`creado=False`) el comprobante guarda `correo_enviado=False`; es cosmético.
+- `programas/views/relevamientos.py`, `relevamiento_reemplazar_padron`: parsea `request.FILES["padron"]` a mano. Convención de `CLAUDE.md` («usar Django Forms para el backoffice»): crear un `PadronReemplazoForm(forms.Form)` con el mismo `FileField` y `clean_padron` que `RelevamientoForm` (extraer la validación a una función compartida en `programas/forms.py`) y usarlo en la vista.
+
+---
+
+## Checklist de entrega
+
+- [ ] 10 commits (C1…M10) con su test cada uno, en verde.
+- [ ] Gates del punto 5 de *Reglas de trabajo* en cero/OK.
+- [ ] Historial del Cambio 40 y *Estado* del plan actualizados.
+- [ ] PR contra `feature/relevamiento-publico-fase-5-correcciones` con título
+      `Formulario público de Becas — Fase 6: correcciones de la segunda revisión`, cuerpo con la
+      tabla error → fix por hallazgo y la nota de que los errores `dicts` son de entorno (Python 3.14),
+      verificados contra `development`.
+- [ ] Reportar al PM: la pila queda #301 → #302 → #303 → #304 → #305 → #306 (o el número que salga).

--- a/portal/forms/inscripcion.py
+++ b/portal/forms/inscripcion.py
@@ -4,6 +4,7 @@ from django import forms
 from django.utils.dateparse import parse_date
 
 from programas.services.becas import es_menor
+from programas.services.personas import fecha_iso
 
 INPUT_CLASS = "nodo-field w-full"
 
@@ -176,7 +177,7 @@ class InscripcionPaso2Form(forms.Form):
         if self.es_manual:
             return self.cleaned_data.get("fecha_nacimiento")
         datos = self.identificacion.get("datos") or {}
-        return parse_date(str(datos.get("fecha_nacimiento") or "")) or None
+        return parse_date(fecha_iso(datos.get("fecha_nacimiento")) or "") or None
 
     def clean(self):
         cleaned = super().clean()

--- a/portal/forms/inscripcion.py
+++ b/portal/forms/inscripcion.py
@@ -157,7 +157,12 @@ class InscripcionPaso2Form(forms.Form):
         self.es_manual = identificacion.get("origen") != "personas"
         if not self.es_manual:
             # La identidad ya vino validada del paso 1: no se pide ni se pisa.
-            del self.fields["nombre"], self.fields["apellido"], self.fields["fecha_nacimiento"]
+            del self.fields["nombre"], self.fields["apellido"]
+            datos = self.identificacion.get("datos") or {}
+            if fecha_iso(datos.get("fecha_nacimiento")):
+                del self.fields["fecha_nacimiento"]
+            else:
+                self.fields["fecha_nacimiento"].label = "No pudimos obtener tu fecha de nacimiento: completala"
         self._campos_dinamicos = []
         for prefijo, lista in (("g", definicion["globales"]), ("r", definicion["requisitos"])):
             for campo in lista:
@@ -176,11 +181,18 @@ class InscripcionPaso2Form(forms.Form):
     def fecha_nacimiento_efectiva(self):
         if self.es_manual:
             return self.cleaned_data.get("fecha_nacimiento")
+        if "fecha_nacimiento" in self.fields:
+            return self.cleaned_data.get("fecha_nacimiento")
         datos = self.identificacion.get("datos") or {}
         return parse_date(fecha_iso(datos.get("fecha_nacimiento")) or "") or None
 
     def clean(self):
         cleaned = super().clean()
+        dni_apoderado_original = cleaned.get("apoderado_dni")
+        dni_apoderado = "".join(ch for ch in str(dni_apoderado_original or "") if ch.isdigit())
+        if dni_apoderado_original and len(dni_apoderado) not in (7, 8):
+            self.add_error("apoderado_dni", "Ingresa un DNI valido de 7 u 8 digitos.")
+        cleaned["apoderado_dni"] = dni_apoderado
         if es_menor(self.fecha_nacimiento_efectiva()):
             campos = (
                 "apoderado_nombre",
@@ -192,10 +204,6 @@ class InscripcionPaso2Form(forms.Form):
             for campo in campos:
                 if not cleaned.get(campo):
                     self.add_error(campo, "Este dato es obligatorio cuando la persona que se inscribe es menor de edad.")
-            dni_apoderado = "".join(ch for ch in str(cleaned.get("apoderado_dni") or "") if ch.isdigit())
-            if cleaned.get("apoderado_dni") and len(dni_apoderado) not in (7, 8):
-                self.add_error("apoderado_dni", "Ingresá un DNI válido de 7 u 8 dígitos.")
-            cleaned["apoderado_dni"] = dni_apoderado
         return cleaned
 
     # --- Salidas hacia la ingesta (#295) ----------------------------------

--- a/portal/services/inscripcion.py
+++ b/portal/services/inscripcion.py
@@ -1,8 +1,8 @@
-"""Servicios del formulario público de inscripción de Becas (#293, análisis #289).
+"""Servicios del formulario publico de inscripcion de Becas (#293, analisis #289).
 
 Reglas del paso 1 del link: disponibilidad del relevamiento, control de
 duplicados por convocatoria completa (RN-P5), rate limiting por IP (RN-P11) y
-el desafío anti-bot. El padrón (RN-P14) vive en ``programas.services.padron``
+el desafio anti-bot. El padron (RN-P14) vive en ``programas.services.padron``
 y la consulta de identidad en ``programas.services.personas``.
 """
 
@@ -11,14 +11,14 @@ from __future__ import annotations
 import random
 
 from django.conf import settings
-from django.core.cache import cache
 from django.utils import timezone
 
+from core.services.throttle import rate_limit_excedido
 from programas.models import Relevamiento
 from programas.services.inscripcion_publica import dni_en_convocatoria
 
 # Rate limit del paso 1 (RN-P11): intentos por IP dentro de la ventana. Los
-# rechazos por límite o captcha nunca llegan a consultar RENAPER/Gran Base.
+# rechazos por limite o captcha nunca llegan a consultar RENAPER/Gran Base.
 MAX_INTENTOS_IP = getattr(settings, "INSCRIPCION_MAX_INTENTOS_IP", 10)
 VENTANA_SEGUNDOS = getattr(settings, "INSCRIPCION_VENTANA_SEGUNDOS", 600)
 
@@ -27,8 +27,7 @@ SESSION_KEY_CAPTCHA_PREGUNTA = "inscripcion_captcha_pregunta"
 
 
 def relevamiento_disponible(relevamiento):
-    """¿El link acepta envíos? Una sola respuesta para vencido, pausado, cupo
-    lleno o cerrado: la pantalla pública no revela el motivo (RN-P4)."""
+    """El link acepta envios cuando esta publico, vigente, en curso y con cupo."""
     return bool(
         relevamiento.es_publico
         and relevamiento.estado == Relevamiento.Estado.EN_CURSO
@@ -37,36 +36,16 @@ def relevamiento_disponible(relevamiento):
     )
 
 
-# RN-P5 vive en una sola función (la ingesta la re-chequea en su transacción).
+# RN-P5 vive en una sola funcion (la ingesta la re-chequea en su transaccion).
 dni_ya_inscripto = dni_en_convocatoria
 
 
-def _ip_de(request):
-    reenviada = request.META.get("HTTP_X_FORWARDED_FOR", "")
-    if reenviada:
-        return reenviada.split(",")[0].strip()
-    return request.META.get("REMOTE_ADDR", "")
-
-
-def intentos_excedidos(request):
-    clave = f"inscripcion:intentos:{_ip_de(request)}"
-    return (cache.get(clave) or 0) >= MAX_INTENTOS_IP
-
-
-def registrar_intento(request):
-    clave = f"inscripcion:intentos:{_ip_de(request)}"
-    if cache.add(clave, 1, VENTANA_SEGUNDOS):
-        return 1
-    try:
-        return cache.incr(clave)
-    except ValueError:  # la clave expiró entre el add y el incr
-        cache.set(clave, 1, VENTANA_SEGUNDOS)
-        return 1
+def paso1_excedido(request):
+    return rate_limit_excedido(request, "inscripcion_paso1", MAX_INTENTOS_IP, VENTANA_SEGUNDOS)
 
 
 def nuevo_captcha(request):
-    """Desafío aritmético anti-bot del paso 1 (decisión del plan: autoalojado,
-    sin servicio externo ni dependencia nueva). Se regenera en cada render."""
+    """Desafio aritmetico anti-bot del paso 1."""
     a, b = random.randint(2, 9), random.randint(2, 9)
     request.session[SESSION_KEY_CAPTCHA] = a + b
     request.session[SESSION_KEY_CAPTCHA_PREGUNTA] = f"¿Cuánto es {a} + {b}?"
@@ -85,6 +64,11 @@ def captcha_valido(request, respuesta):
         return False
 
 
+def consumir_captcha(request):
+    request.session.pop(SESSION_KEY_CAPTCHA, None)
+    request.session.pop(SESSION_KEY_CAPTCHA_PREGUNTA, None)
+
+
 def clave_sesion(relevamiento):
-    """La identificación del paso 1 vive en la sesión, por relevamiento."""
+    """La identificacion del paso 1 vive en la sesion, por relevamiento."""
     return f"inscripcion_{relevamiento.pk}"

--- a/portal/services/inscripcion.py
+++ b/portal/services/inscripcion.py
@@ -12,10 +12,10 @@ import random
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db.models import Q
 from django.utils import timezone
 
-from programas.models import Formulario, Relevamiento
+from programas.models import Relevamiento
+from programas.services.inscripcion_publica import dni_en_convocatoria
 
 # Rate limit del paso 1 (RN-P11): intentos por IP dentro de la ventana. Los
 # rechazos por límite o captcha nunca llegan a consultar RENAPER/Gran Base.
@@ -37,14 +37,8 @@ def relevamiento_disponible(relevamiento):
     )
 
 
-def dni_ya_inscripto(convocatoria, dni):
-    """Duplicado por convocatoria completa (RN-P5): cualquier relevamiento, de
-    campo o público, por ciudadano resuelto o identificación offline."""
-    return (
-        Formulario.objects.filter(relevamiento__convocatoria=convocatoria)
-        .filter(Q(ciudadano__dni=dni) | Q(datos_identificacion__dni=dni))
-        .exists()
-    )
+# RN-P5 vive en una sola función (la ingesta la re-chequea en su transacción).
+dni_ya_inscripto = dni_en_convocatoria
 
 
 def _ip_de(request):

--- a/portal/templates/portal/inscripcion/paso2.html
+++ b/portal/templates/portal/inscripcion/paso2.html
@@ -34,8 +34,9 @@
             </div>
         {% endif %}
 
-        {% if form.es_manual %}
+        {% if form.es_manual or "fecha_nacimiento" in form.fields %}
         <h2 class="text-sm font-bold uppercase tracking-wide mb-3" style="color: var(--text-body-subtle);">Tus datos</h2>
+        {% if not form.es_manual %}<p class="text-xs mb-3" style="color: var(--text-body-subtle);">No pudimos obtener tu fecha de nacimiento: completala.</p>{% endif %}
         <div class="space-y-4 mb-6">
             {% for campo in form %}{% if campo.name == "nombre" or campo.name == "apellido" or campo.name == "fecha_nacimiento" %}
             <div>

--- a/portal/tests/test_correcciones_review.py
+++ b/portal/tests/test_correcciones_review.py
@@ -1,0 +1,185 @@
+"""Tests de las correcciones de la revisión de código del formulario público
+(Fase 5, Historial del Cambio 40). Cada test reproduce el bug que se corrigió."""
+
+from datetime import date, timedelta
+from io import BytesIO
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from portal.forms.inscripcion import InscripcionPaso2Form
+from portal.tests.test_inscripcion import _BaseInscripcionTest, _tolerar_render_local
+from portal.tests.test_inscripcion_envio import _BasePaso2Test, _identificacion
+from programas.models import Convocatoria, Formulario, Relevamiento, Segmento
+from programas.services import reportes_becas
+from programas.services.inscripcion_publica import InscripcionNoHabilitada, crear_formulario_publico
+from programas.services.padron import cargar_padron, parsear_padron
+from programas.services.personas import fecha_iso, normalizar_persona
+from programas.views import relevamientos as vistas_rel
+from programas.views.revision import RenaperPendientesListView
+
+
+def _xlsx(filas):
+    from openpyxl import Workbook
+
+    libro = Workbook()
+    hoja = libro.active
+    for fila in filas:
+        hoja.append(list(fila))
+    buffer = BytesIO()
+    libro.save(buffer)
+    return SimpleUploadedFile("padron.xlsx", buffer.getvalue())
+
+
+class ReporteProduccionConPublicosTests(TestCase):
+    def test_un_publico_no_rompe_el_reporte_ni_aparece(self):
+        admin = User.objects.create_superuser("root", "r@r.com", "x")
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        terri = User.objects.create_user("terri", password="x", first_name="Tere", last_name="Campo")
+        Relevamiento.objects.create(convocatoria=conv, territorial=terri, fecha_asignada=timezone.now(), zona="Z")
+        Relevamiento.objects.create(
+            convocatoria=conv,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now(),
+            fecha_hasta=timezone.now() + timedelta(days=5),
+        )
+        reporte = reportes_becas.reporte_produccion(admin)  # antes: AttributeError → 500
+        territoriales = [fila[0] for fila in reporte.filas]
+        self.assertEqual(territoriales, ["Tere Campo"])
+
+
+class RateLimitDevuelveMensajeTests(_BaseInscripcionTest):
+    @patch("portal.views.inscripcion.consultar_persona")
+    def test_rate_limit_no_es_un_500(self, mock_consulta):
+        with patch("portal.views.inscripcion.intentos_excedidos", return_value=True):
+            try:
+                resp = self._post_paso1()
+            except AttributeError as exc:
+                _tolerar_render_local(exc)  # antes: 'cleaned_data' → 500
+                return
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "demasiados intentos")
+        mock_consulta.assert_not_called()
+
+
+class PendientesRenaperConPublicosTests(TestCase):
+    def setUp(self):
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        publico = Relevamiento.objects.create(
+            convocatoria=conv,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now(),
+            fecha_hasta=timezone.now() + timedelta(days=5),
+        )
+        Formulario.objects.create(
+            relevamiento=publico, celular="1", email_contacto="a@a.com", datos_identificacion={"dni": "1"}
+        )
+
+    def test_el_selector_no_ofrece_territorial_none(self):
+        base = Formulario.objects.filter(validado_renaper=False)
+        opciones = list(RenaperPendientesListView.territoriales_pendientes(base))
+        self.assertEqual(opciones, [])
+
+    def test_filtro_territorial_invalido_no_rompe(self):
+        vista = RenaperPendientesListView()
+        vista.request = RequestFactory().get("/?territorial=None&segmento=abc")
+        self.assertEqual(vista.get_queryset().count(), 1)  # antes: ValueError → 500
+
+
+class FechaNoIsoTests(_BasePaso2Test):
+    def test_fecha_iso_normaliza_formatos_de_proveedor(self):
+        self.assertEqual(fecha_iso("15/03/2010"), "2010-03-15")
+        self.assertEqual(fecha_iso("2010-03-15"), "2010-03-15")
+        self.assertEqual(fecha_iso("2010-03-15T00:00:00"), "2010-03-15")
+        self.assertEqual(fecha_iso("20100315"), "2010-03-15")
+        self.assertEqual(fecha_iso(date(2010, 3, 15)), "2010-03-15")
+        self.assertEqual(fecha_iso("sin fecha"), "")
+        self.assertEqual(normalizar_persona({"data": {"fechaNacimiento": "15/03/2010"}}, "1")["fecha_nacimiento"], "2010-03-15")
+
+    def test_menor_con_fecha_dd_mm_aaaa_exige_apoderado(self):
+        hoy = timezone.localdate()
+        nacimiento = hoy - timedelta(days=16 * 365)
+        ident = _identificacion()
+        ident["datos"]["fecha_nacimiento"] = nacimiento.strftime("%d/%m/%Y")
+        form = InscripcionPaso2Form(
+            self._data(), self._files(), definicion=self.definicion, identificacion=ident
+        )
+        self.assertFalse(form.is_valid())  # antes: parse_date → None → RN-22 salteada
+        self.assertIn("apoderado_dni", form.errors)
+
+
+class GateEnScopesTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("sin_publico", password="x")
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        self.publico = Relevamiento.objects.create(
+            convocatoria=conv,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now(),
+            fecha_hasta=timezone.now() + timedelta(days=5),
+        )
+        self.territorial = Relevamiento.objects.create(
+            convocatoria=conv, territorial=self.user, fecha_asignada=timezone.now(), zona="Z"
+        )
+        self.request = RequestFactory().post("/")
+        self.request.user = self.user
+
+    def test_assert_scope_bloquea_publicos_sin_capacidad(self):
+        # Con alcance sobre el segmento pero sin la capacidad de público.
+        with patch.object(vistas_rel, "puede_gestionar_segmento", return_value=True), patch.object(
+            vistas_rel, "convocatorias_visibles"
+        ) as visibles, patch.object(vistas_rel, "_puede_publico", return_value=False):
+            visibles.return_value.filter.return_value.exists.return_value = True
+            vistas_rel._assert_scope(self.request, self.territorial)  # pasa
+            with self.assertRaises(PermissionDenied):
+                vistas_rel._assert_scope(self.request, self.publico)  # antes: pasaba y mutaba
+
+
+class PadronFloatsTests(TestCase):
+    def test_dni_float_y_largo_invalido(self):
+        entradas, rechazadas = parsear_padron(_xlsx([("documento", "sexo"), (30123456.0, "M"), (301234560, "F"), ("28.111.222", "f")]))
+        self.assertEqual(entradas, [("30123456", "M"), ("28111222", "F")])
+        self.assertEqual(rechazadas, 1)  # el de 9 dígitos
+
+
+class PadronSeRechequeaAlEnviarTests(_BasePaso2Test):
+    def test_reemplazo_entre_pasos_bloquea_el_envio(self):
+        ident = _identificacion()
+        form = InscripcionPaso2Form(self._data(), self._files(), definicion=self.definicion, identificacion=ident)
+        self.assertTrue(form.is_valid(), form.errors)
+        cargar_padron(self.relevamiento, None, [("11111111", "M")])  # María ya no figura
+        with self.assertRaises(InscripcionNoHabilitada):
+            crear_formulario_publico(self.relevamiento, identificacion=ident, form=form, client_uuid=str(uuid4()))
+        self.assertEqual(self.relevamiento.formularios.count(), 0)
+
+
+class TokenAlCambiarTipoTests(TestCase):
+    def test_territorial_convertido_a_publico_recibe_token(self):
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        terri = User.objects.create_user("terri", password="x")
+        rel = Relevamiento.objects.create(convocatoria=conv, territorial=terri, fecha_asignada=timezone.now(), zona="Z")
+        self.assertIsNone(rel.token_publico)
+        rel.tipo = Relevamiento.Tipo.PUBLICO
+        rel.territorial = None
+        rel.zona = ""
+        rel.save()
+        rel.refresh_from_db()
+        self.assertIsNotNone(rel.token_publico)  # antes: link vacío
+        self.assertTrue(rel.url_publica)

--- a/portal/tests/test_correcciones_review.py
+++ b/portal/tests/test_correcciones_review.py
@@ -59,7 +59,7 @@ class ReporteProduccionConPublicosTests(TestCase):
 class RateLimitDevuelveMensajeTests(_BaseInscripcionTest):
     @patch("portal.views.inscripcion.consultar_persona")
     def test_rate_limit_no_es_un_500(self, mock_consulta):
-        with patch("portal.views.inscripcion.intentos_excedidos", return_value=True):
+        with patch("portal.views.inscripcion.paso1_excedido", return_value=True):
             try:
                 resp = self._post_paso1()
             except AttributeError as exc:
@@ -94,7 +94,9 @@ class PendientesRenaperConPublicosTests(TestCase):
     def test_filtro_territorial_invalido_no_rompe(self):
         vista = RenaperPendientesListView()
         vista.request = RequestFactory().get("/?territorial=None&segmento=abc")
-        self.assertEqual(vista.get_queryset().count(), 1)  # antes: ValueError → 500
+        vista.request.user = User.objects.create_user("admin_publicos")
+        with patch("programas.views.revision.puede", return_value=True):
+            self.assertEqual(vista.get_queryset().count(), 1)
 
 
 class FechaNoIsoTests(_BasePaso2Test):

--- a/portal/tests/test_correcciones_review_2.py
+++ b/portal/tests/test_correcciones_review_2.py
@@ -1,0 +1,240 @@
+"""Regresiones de la segunda revision del formulario publico de Becas (Fase 6)."""
+
+from datetime import date, timedelta
+from io import BytesIO
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from portal.forms.inscripcion import InscripcionPaso2Form
+from portal.services import inscripcion as servicio
+from portal.tests.test_inscripcion import DATOS_GRAN_BASE, _BaseInscripcionTest, _tolerar_render_local
+from portal.tests.test_inscripcion_envio import _BasePaso2Test, _identificacion
+from programas.admin import RelevamientoAdmin
+from programas.forms import RelevamientoForm
+from programas.models import Convocatoria, Formulario, Relevamiento, Segmento
+from programas.services.inscripcion_publica import crear_formulario_publico
+from programas.views import relevamientos as vistas_rel
+from programas.views import revision as vistas_rev
+from programas.views.relevamientos import ConvocatoriaDetailView
+from programas.views.revision import RevisionPersonasListView
+
+
+def _xlsx(filas):
+    from openpyxl import Workbook
+
+    libro = Workbook()
+    hoja = libro.active
+    for fila in filas:
+        hoja.append(list(fila))
+    buffer = BytesIO()
+    libro.save(buffer)
+    return SimpleUploadedFile("padron.xlsx", buffer.getvalue())
+
+
+class RateLimitHeaderTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.rf = RequestFactory()
+
+    def test_x_real_ip_prevalece_sobre_x_forwarded_for(self):
+        req1 = self.rf.post("/", HTTP_X_REAL_IP="10.0.0.1", HTTP_X_FORWARDED_FOR="1.1.1.1")
+        req2 = self.rf.post("/", HTTP_X_REAL_IP="10.0.0.1", HTTP_X_FORWARDED_FOR="2.2.2.2")
+        with patch.object(servicio, "MAX_INTENTOS_IP", 1):
+            self.assertFalse(servicio.paso1_excedido(req1))
+            self.assertTrue(servicio.paso1_excedido(req2))
+
+    def test_x_forwarded_for_usa_el_ultimo_valor_si_no_hay_x_real_ip(self):
+        req1 = self.rf.post("/", HTTP_X_FORWARDED_FOR="1.1.1.1, 10.0.0.9")
+        req2 = self.rf.post("/", HTTP_X_FORWARDED_FOR="2.2.2.2, 10.0.0.9")
+        with patch.object(servicio, "MAX_INTENTOS_IP", 1):
+            self.assertFalse(servicio.paso1_excedido(req1))
+            self.assertTrue(servicio.paso1_excedido(req2))
+
+
+class CaptchaConsumeTests(_BaseInscripcionTest):
+    @patch("portal.views.inscripcion.consultar_persona", return_value=DATOS_GRAN_BASE)
+    def test_captcha_correcto_se_consume_y_no_se_reutiliza(self, mock_consulta):
+        primero = self._post_paso1()
+        self.assertEqual(primero.status_code, 302)
+        try:
+            self.client.post(self._url(), {"dni": "28111222", "sexo": "F", "captcha": "7"})
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
+        mock_consulta.assert_called_once_with("30123456", "F")
+
+
+class IdempotenciaUuidTextoTests(_BasePaso2Test):
+    def _form_valido(self, ident):
+        form = self._form(identificacion=ident)
+        self.assertTrue(form.is_valid(), form.errors)
+        return form
+
+    def test_client_uuid_string_con_guiones_es_idempotente(self):
+        client_uuid = str(uuid4())
+        ident = _identificacion(client_uuid=client_uuid)
+        primero, creado1 = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=client_uuid
+        )
+        segundo, creado2 = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=self._form_valido(ident), client_uuid=client_uuid
+        )
+        self.assertTrue(creado1)
+        self.assertFalse(creado2)
+        self.assertEqual(primero.pk, segundo.pk)
+
+
+class ScopeRevalidarRenaperTests(TestCase):
+    def test_revalidar_renaper_bloquea_formulario_publico_sin_capacidad(self):
+        user = User.objects.create_user("operador")
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        rel = Relevamiento.objects.create(
+            convocatoria=conv,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now(),
+            fecha_hasta=timezone.now() + timedelta(days=5),
+        )
+        formulario = Formulario.objects.create(relevamiento=rel, celular="1", email_contacto="a@a.com")
+        request = RequestFactory().post("/")
+        request.user = user
+        with patch.object(vistas_rev, "puede", return_value=False):
+            with self.assertRaises(PermissionDenied):
+                vistas_rev.formulario_revalidar_renaper.__wrapped__.__wrapped__(request, formulario.pk)
+
+
+class FechaProveedorYApoderadoTests(_BasePaso2Test):
+    def test_personas_sin_fecha_normalizada_exige_fecha_y_apoderado_si_es_menor(self):
+        hoy = timezone.localdate()
+        ident = _identificacion()
+        ident["datos"]["fecha_nacimiento"] = "texto raro"
+        data = self._data(fecha_nacimiento=(hoy - timedelta(days=16 * 365)).isoformat())
+        form = self._form(identificacion=ident, data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("fecha_nacimiento", form.fields)
+        self.assertIn("apoderado_dni", form.errors)
+
+    def test_personas_sin_fecha_guarda_la_fecha_del_form(self):
+        ident = _identificacion()
+        ident["datos"]["fecha_nacimiento"] = "texto raro"
+        data = self._data(
+            fecha_nacimiento="1990-01-01",
+            apoderado_dni="30.123.456",
+        )
+        form = self._form(identificacion=ident, data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+        formulario, _ = crear_formulario_publico(
+            self.relevamiento, identificacion=ident, form=form, client_uuid=ident["client_uuid"]
+        )
+        self.assertEqual(formulario.ciudadano.fecha_nacimiento.isoformat(), "1990-01-01")
+
+    def test_apoderado_dni_se_normaliza_tambien_en_adultos(self):
+        form = self._form(data=self._data(apoderado_dni="30.123.456"))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["apoderado_dni"], "30123456")
+        invalido = self._form(data=self._data(apoderado_dni="abc"))
+        self.assertFalse(invalido.is_valid())
+        self.assertIn("apoderado_dni", invalido.errors)
+
+
+class PadronAtomicidadTests(TestCase):
+    def test_si_falla_carga_de_padron_no_queda_relevamiento_publico(self):
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        data = {
+            "tipo": Relevamiento.Tipo.PUBLICO,
+            "convocatoria": conv.pk,
+            "fecha_asignada": "2026-06-01T10:00",
+            "fecha_hasta": "2026-06-30T18:00",
+            "cupo_maximo": "10",
+            "confirmar_por_email": "on",
+        }
+        form = RelevamientoForm(data, {"padron": _xlsx([("documento", "sexo"), ("30123456", "F")])}, puede_publico=True)
+        self.assertTrue(form.is_valid(), form.errors)
+        inicial = Relevamiento.objects.count()
+        with patch("programas.services.padron.PadronHabilitado.objects.bulk_create", side_effect=RuntimeError):
+            with self.assertRaises(RuntimeError):
+                form.save()
+        self.assertEqual(Relevamiento.objects.count(), inicial)
+
+
+class ListadosPublicosScopeTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("operador")
+        self.seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        self.conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=self.seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        terr = User.objects.create_user("terr")
+        self.rel_territorial = Relevamiento.objects.create(
+            convocatoria=self.conv, territorial=terr, fecha_asignada=timezone.now(), zona="Z"
+        )
+        self.rel_publico = Relevamiento.objects.create(
+            convocatoria=self.conv,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now(),
+            fecha_hasta=timezone.now() + timedelta(days=5),
+        )
+        self.form_territorial = Formulario.objects.create(
+            relevamiento=self.rel_territorial, celular="1", email_contacto="t@a.com", validado_renaper=False
+        )
+        self.form_publico = Formulario.objects.create(
+            relevamiento=self.rel_publico, celular="1", email_contacto="p@a.com", validado_renaper=False
+        )
+
+    def test_revision_personas_excluye_publicos_sin_capacidad(self):
+        view = RevisionPersonasListView()
+        view.request = RequestFactory().get("/")
+        view.request.user = self.user
+        with patch.object(vistas_rev, "convocatorias_visibles", return_value=Convocatoria.objects.all()), patch.object(
+            vistas_rev, "puede", return_value=False
+        ):
+            self.assertEqual(list(view.get_queryset()), [self.form_territorial])
+
+    def test_beneficiarios_y_export_excluyen_publicos_sin_capacidad(self):
+        self.form_territorial.estado = Formulario.Estado.APROBADO
+        self.form_territorial.save(update_fields=["estado"])
+        self.form_publico.estado = Formulario.Estado.APROBADO
+        self.form_publico.save(update_fields=["estado"])
+        request = RequestFactory().get("/")
+        request.user = self.user
+
+        view = ConvocatoriaDetailView()
+        view.request = request
+        view.object = self.conv
+        with patch.object(vistas_rel, "_puede_publico", return_value=False), patch.object(
+            vistas_rel, "segmentos_visibles", return_value=Segmento.objects.all()
+        ), patch.object(vistas_rel, "convocatorias_visibles", return_value=Convocatoria.objects.all()), patch.object(
+            vistas_rel, "subsegmentos_visibles", return_value=[]
+        ), patch.object(vistas_rel, "usuarios_territoriales_becas", return_value=User.objects.none()):
+            ctx = view.get_context_data()
+            self.assertEqual(ctx["n_beneficiarios"], 1)
+            response = vistas_rel.convocatoria_export_beneficiarios.__wrapped__.__wrapped__(request, self.conv.pk)
+        filas = response.content.decode("utf-8").splitlines()
+        self.assertEqual(len(filas), 2)
+
+
+class RelevamientoAdminTests(TestCase):
+    def test_tipo_es_readonly_solo_al_editar(self):
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        conv = Convocatoria.objects.create(
+            nombre="Conv", segmento=seg, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        terr = User.objects.create_user("terr_admin")
+        rel = Relevamiento.objects.create(convocatoria=conv, territorial=terr, fecha_asignada=timezone.now(), zona="Z")
+        admin = RelevamientoAdmin(Relevamiento, AdminSite())
+        request = RequestFactory().get("/")
+        self.assertNotIn("tipo", admin.get_readonly_fields(request, obj=None))
+        self.assertIn("tipo", admin.get_readonly_fields(request, obj=rel))

--- a/portal/tests/test_inscripcion.py
+++ b/portal/tests/test_inscripcion.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from legajos.models import Ciudadano
+from core.services.throttle import rate_limit_excedido
 from portal.services import inscripcion as servicio
 
 
@@ -123,11 +124,10 @@ class ServiciosInscripcionTests(_BaseInscripcionTest):
         rf = RequestFactory()
         request = rf.post("/", REMOTE_ADDR="10.0.0.1")
         for _ in range(servicio.MAX_INTENTOS_IP):
-            self.assertFalse(servicio.intentos_excedidos(request))
-            servicio.registrar_intento(request)
-        self.assertTrue(servicio.intentos_excedidos(request))
+            self.assertFalse(rate_limit_excedido(request, "inscripcion_paso1", servicio.MAX_INTENTOS_IP, servicio.VENTANA_SEGUNDOS))
+        self.assertTrue(rate_limit_excedido(request, "inscripcion_paso1", servicio.MAX_INTENTOS_IP, servicio.VENTANA_SEGUNDOS))
         otra_ip = rf.post("/", REMOTE_ADDR="10.0.0.2")
-        self.assertFalse(servicio.intentos_excedidos(otra_ip))
+        self.assertFalse(rate_limit_excedido(otra_ip, "inscripcion_paso1", servicio.MAX_INTENTOS_IP, servicio.VENTANA_SEGUNDOS))
 
 
 class Paso1FlujoTests(_BaseInscripcionTest):
@@ -214,7 +214,7 @@ class Paso1FlujoTests(_BaseInscripcionTest):
     @patch("portal.views.inscripcion.consultar_persona", return_value=DATOS_GRAN_BASE)
     def test_rate_limit_corta_sin_consultar(self, mock_consulta):
         with patch.object(servicio, "MAX_INTENTOS_IP", 0), patch(
-            "portal.views.inscripcion.intentos_excedidos", return_value=True
+            "portal.views.inscripcion.paso1_excedido", return_value=True
         ):
             try:
                 self._post_paso1()

--- a/portal/tests/test_inscripcion.py
+++ b/portal/tests/test_inscripcion.py
@@ -12,6 +12,15 @@ from django.utils import timezone
 
 from legajos.models import Ciudadano
 from portal.services import inscripcion as servicio
+
+
+def _tolerar_render_local(exc):
+    """Solo se tolera el bug conocido de ``Context.__copy__`` del test client con
+    Python 3.14 + Django 4.2 (mensaje con ``dicts``). Cualquier otro
+    ``AttributeError`` es un bug real y se re-lanza: uno de rate limit se
+    escondió acá (revisión Cambio 40)."""
+    if "dicts" not in str(exc):
+        raise exc
 from programas.models import Convocatoria, Formulario, Relevamiento, Segmento
 from programas.services.padron import cargar_padron
 
@@ -125,8 +134,9 @@ class Paso1FlujoTests(_BaseInscripcionTest):
     def test_token_invalido_404(self):
         try:
             resp = self.client.get(reverse("portal:inscripcion_paso1", kwargs={"token": uuid4()}))
-        except AttributeError:
-            return  # render de la página 404 en el entorno local (Py3.14); se valida en CI
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
+            return
         self.assertEqual(resp.status_code, 404)
 
     @patch("portal.views.inscripcion.consultar_persona", return_value=DATOS_GRAN_BASE)
@@ -156,16 +166,16 @@ class Paso1FlujoTests(_BaseInscripcionTest):
     def test_fallecido_no_avanza(self, mock_consulta):
         try:
             self._post_paso1()
-        except AttributeError:
-            pass  # render del entorno local (Py3.14); la aserción clave es la sesión
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
         self.assertNotIn(servicio.clave_sesion(self.relevamiento), self.client.session)
 
     @patch("portal.views.inscripcion.consultar_persona")
     def test_captcha_incorrecto_no_consulta_identidad(self, mock_consulta):
         try:
             self._post_paso1(captcha="999")
-        except AttributeError:
-            pass  # render del entorno local
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
         mock_consulta.assert_not_called()
         self.assertNotIn(servicio.clave_sesion(self.relevamiento), self.client.session)
 
@@ -174,8 +184,8 @@ class Paso1FlujoTests(_BaseInscripcionTest):
         cargar_padron(self.relevamiento, None, [("28111222", "M")])
         try:
             self._post_paso1(dni="30123456", sexo="F")
-        except AttributeError:
-            pass  # render del entorno local
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
         mock_consulta.assert_not_called()
         self.assertNotIn(servicio.clave_sesion(self.relevamiento), self.client.session)
 
@@ -196,8 +206,8 @@ class Paso1FlujoTests(_BaseInscripcionTest):
         )
         try:
             self._post_paso1(dni="30123456", sexo="F")
-        except AttributeError:
-            pass  # render del entorno local
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
         mock_consulta.assert_not_called()
         self.assertNotIn(servicio.clave_sesion(self.relevamiento), self.client.session)
 
@@ -208,8 +218,8 @@ class Paso1FlujoTests(_BaseInscripcionTest):
         ):
             try:
                 self._post_paso1()
-            except AttributeError:
-                pass  # render del entorno local
+            except AttributeError as exc:
+                _tolerar_render_local(exc)
         mock_consulta.assert_not_called()
 
     def test_paso2_sin_paso1_redirige(self):
@@ -222,6 +232,7 @@ class Paso1FlujoTests(_BaseInscripcionTest):
         )
         try:
             resp = self.client.get(self._url(vencido))
-        except AttributeError:
-            return  # render del entorno local: la pantalla se valida en CI
+        except AttributeError as exc:
+            _tolerar_render_local(exc)
+            return
         self.assertTemplateUsed(resp, "portal/inscripcion/no_disponible.html")

--- a/portal/views/inscripcion.py
+++ b/portal/views/inscripcion.py
@@ -32,6 +32,7 @@ from programas.services.becas import definicion_formulario
 from programas.services.inscripcion_publica import (
     InscripcionDuplicada,
     InscripcionNoDisponible,
+    InscripcionNoHabilitada,
     crear_formulario_publico,
     enmascarar_email,
     enviar_confirmacion_inscripcion,
@@ -74,10 +75,12 @@ def inscripcion_paso1(request, token):
     if not relevamiento_disponible(relevamiento):
         return _no_disponible(request, relevamiento)
 
-    form = InscripcionPaso1Form(request.POST or None)
+    form = InscripcionPaso1Form(request.POST if request.method == "POST" else None)
     if request.method == "POST":
         if intentos_excedidos(request):
-            form = InscripcionPaso1Form()  # no procesar nada del POST
+            # Solo se valida el form para poder colgarle el error general: no
+            # se registra el intento ni se consulta identidad.
+            form.is_valid()
             form.add_error(None, MENSAJE_DEMASIADOS_INTENTOS)
         elif not captcha_valido(request, request.POST.get("captcha")):
             registrar_intento(request)
@@ -162,17 +165,21 @@ def inscripcion_paso2(request, token):
                 "portal/inscripcion/ya_inscripto.html",
                 {"relevamiento": relevamiento, "dni": identificacion["dni"]},
             )
-        # Correo de confirmación (#296): solo si el relevamiento lo tiene
-        # activo y solo en el envío que creó el formulario; su falla no
-        # rompe nada (queda logueada).
-        correo_enviado = bool(creado and enviar_confirmacion_inscripcion(formulario))
-        request.session.pop(clave_sesion(relevamiento), None)
-        request.session[f"inscripcion_ok_{relevamiento.pk}"] = {
-            "numero": formulario.numero,
-            "email": enmascarar_email(formulario.email_contacto),
-            "correo_enviado": correo_enviado,
-        }
-        return redirect("portal:inscripcion_confirmacion", token=relevamiento.token_publico)
+        except InscripcionNoHabilitada:
+            # El padrón cambió entre el paso 1 y el envío (RN-P14).
+            form.add_error(None, MENSAJE_NO_HABILITADO)
+        else:
+            # Correo de confirmación (#296): solo si el relevamiento lo tiene
+            # activo y solo en el envío que creó el formulario; su falla no
+            # rompe nada (queda logueada).
+            correo_enviado = bool(creado and enviar_confirmacion_inscripcion(formulario))
+            request.session.pop(clave_sesion(relevamiento), None)
+            request.session[f"inscripcion_ok_{relevamiento.pk}"] = {
+                "numero": formulario.numero,
+                "email": enmascarar_email(formulario.email_contacto),
+                "correo_enviado": correo_enviado,
+            }
+            return redirect("portal:inscripcion_confirmacion", token=relevamiento.token_publico)
 
     return render(
         request,

--- a/portal/views/inscripcion.py
+++ b/portal/views/inscripcion.py
@@ -20,11 +20,11 @@ from portal.forms.inscripcion import InscripcionPaso1Form, InscripcionPaso2Form
 from portal.services.inscripcion import (
     captcha_valido,
     clave_sesion,
+    consumir_captcha,
     dni_ya_inscripto,
-    intentos_excedidos,
     nuevo_captcha,
+    paso1_excedido,
     pregunta_captcha,
-    registrar_intento,
     relevamiento_disponible,
 )
 from programas.models import Relevamiento
@@ -77,16 +77,15 @@ def inscripcion_paso1(request, token):
 
     form = InscripcionPaso1Form(request.POST if request.method == "POST" else None)
     if request.method == "POST":
-        if intentos_excedidos(request):
+        if paso1_excedido(request):
             # Solo se valida el form para poder colgarle el error general: no
             # se registra el intento ni se consulta identidad.
             form.is_valid()
             form.add_error(None, MENSAJE_DEMASIADOS_INTENTOS)
         elif not captcha_valido(request, request.POST.get("captcha")):
-            registrar_intento(request)
             form.add_error("captcha", "La verificación no es correcta. Probá de nuevo.")
         elif form.is_valid():
-            registrar_intento(request)
+            consumir_captcha(request)
             dni = form.cleaned_data["dni"]
             sexo = form.cleaned_data["sexo"]
             if not esta_habilitado(relevamiento, dni, sexo):
@@ -113,8 +112,6 @@ def inscripcion_paso1(request, token):
                         "origen": "personas" if validado else "manual",
                     }
                     return redirect("portal:inscripcion_paso2", token=relevamiento.token_publico)
-        else:
-            registrar_intento(request)
 
     contexto = {
         "relevamiento": relevamiento,

--- a/programas/admin.py
+++ b/programas/admin.py
@@ -236,6 +236,12 @@ class RelevamientoAdmin(admin.ModelAdmin):
     search_fields = ("nombre", "zona", "territorial__username")
     readonly_fields = ("nombre", "token_publico")
 
+    def get_readonly_fields(self, request, obj=None):
+        fields = list(super().get_readonly_fields(request, obj))
+        if obj is not None and "tipo" not in fields:
+            fields.append("tipo")
+        return fields
+
 
 @admin.register(PreguntaGlobal)
 class PreguntaGlobalAdmin(admin.ModelAdmin):

--- a/programas/api/views.py
+++ b/programas/api/views.py
@@ -7,8 +7,7 @@ y formularios. Capacidad requerida: ``becas.campo``.
 from datetime import timedelta
 
 from django.db import transaction
-from django.db.models import CharField, Count, Q, Value
-from django.db.models.functions import Cast, Replace
+from django.db.models import Count, Q
 from django.utils import timezone
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
@@ -28,7 +27,7 @@ from programas.api.serializers import (
     RelevamientoListSerializer,
 )
 from programas.models import Formulario, Relevamiento
-from programas.services.becas import resolver_ciudadano_offline
+from programas.services.becas import formulario_por_client_uuid, resolver_ciudadano_offline
 from programas.services.personas import consultar_persona
 
 CAP = "becas.campo"
@@ -54,23 +53,7 @@ def _formulario_dni_existe(relevamiento, dni):
     return _formulario_por_dni(relevamiento, dni) is not None
 
 
-def _formulario_por_client_uuid(relevamiento, client_uuid):
-    """Busca la clave idempotente sin depender del lookup UUID del motor.
-
-    El esquema productivo guarda UUIDField como texto sin guiones. En algunas versiones de
-    MySQL/MariaDB el lookup nativo de UUID de Django genera una expresion que el
-    motor rechaza. El CAST conserva la comparacion exacta y funciona igual en
-    SQLite (tests) y MySQL.
-    """
-    if not client_uuid:
-        return None
-    return (
-        relevamiento.formularios.annotate(
-            client_uuid_text=Replace(Cast("client_uuid", CharField()), Value("-"), Value(""))
-        )
-        .filter(client_uuid_text=client_uuid.hex)
-        .first()
-    )
+_formulario_por_client_uuid = formulario_por_client_uuid
 
 
 def _captura_habilitada(relevamiento, capturado_en=None):

--- a/programas/forms.py
+++ b/programas/forms.py
@@ -8,7 +8,7 @@ from datetime import datetime, time
 from django import forms
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.dateparse import parse_date
@@ -1248,12 +1248,13 @@ class RelevamientoForm(forms.ModelForm):
         return archivo
 
     def save(self, commit=True):
-        instance = super().save(commit)
-        if commit and getattr(self, "_padron_entradas", None):
-            from programas.services.padron import cargar_padron
+        with transaction.atomic():
+            instance = super().save(commit)
+            if commit and getattr(self, "_padron_entradas", None):
+                from programas.services.padron import cargar_padron
 
-            cargar_padron(instance, self.cleaned_data["padron"], self._padron_entradas)
-        return instance
+                cargar_padron(instance, self.cleaned_data["padron"], self._padron_entradas)
+            return instance
 
     def clean_zona(self):
         """Del catálogo al texto: se guarda el nombre de la localidad.

--- a/programas/models/__init__.py
+++ b/programas/models/__init__.py
@@ -1678,12 +1678,12 @@ class Relevamiento(PausableMixin, TimeStamped):
             self.fecha_hasta = timezone.make_aware(
                 datetime.combine(dia, time(23, 59, 59)), timezone.get_current_timezone()
             )
-        if self._state.adding and self.tipo == self.Tipo.PUBLICO:
-            # No hay territorial que lo inicie: nace operativo y con su link.
-            if not self.token_publico:
-                self.token_publico = uuid.uuid4()
-            if self.estado == self.Estado.ASIGNADO:
-                self.estado = self.Estado.EN_CURSO
+        if self.tipo == self.Tipo.PUBLICO and not self.token_publico:
+            # Un público siempre tiene link, también si cambió de tipo por admin.
+            self.token_publico = uuid.uuid4()
+        if self._state.adding and self.tipo == self.Tipo.PUBLICO and self.estado == self.Estado.ASIGNADO:
+            # No hay territorial que lo inicie: nace operativo.
+            self.estado = self.Estado.EN_CURSO
         if self._state.adding and not self.numero:
             with transaction.atomic():
                 Convocatoria.objects.select_for_update().get(pk=self.convocatoria_id)

--- a/programas/services/becas.py
+++ b/programas/services/becas.py
@@ -7,6 +7,8 @@ RBAC (admin vs coordinador con alcance) vive en ``programas.services.autorizacio
 from datetime import date
 
 from django.db import models, transaction
+from django.db.models import CharField, Value
+from django.db.models.functions import Cast, Replace
 
 from legajos.models import Ciudadano
 from programas.models import (
@@ -62,6 +64,19 @@ def definicion_formulario(relevamiento):
         "globales": [_campo_dict(p, "global") for p in globales],
         "requisitos": [_campo_dict(r, _alcance_requisito(r)) for r in requisitos],
     }
+
+
+def formulario_por_client_uuid(relevamiento, client_uuid):
+    """Busca la clave idempotente sin depender del lookup UUID del motor."""
+    if not client_uuid:
+        return None
+    return (
+        relevamiento.formularios.annotate(
+            client_uuid_text=Replace(Cast("client_uuid", CharField()), Value("-"), Value(""))
+        )
+        .filter(client_uuid_text=client_uuid.hex)
+        .first()
+    )
 
 
 def _alcance_requisito(requisito):

--- a/programas/services/inscripcion_publica.py
+++ b/programas/services/inscripcion_publica.py
@@ -23,8 +23,9 @@ from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 
-from programas.models import AdjuntoFormulario, Formulario, Relevamiento
+from programas.models import AdjuntoFormulario, Convocatoria, Formulario, Relevamiento
 from programas.services.becas import resolver_ciudadano_offline
+from programas.services.padron import esta_habilitado
 
 
 class InscripcionNoDisponible(Exception):
@@ -35,7 +36,19 @@ class InscripcionDuplicada(Exception):
     """El DNI ya está inscripto en la convocatoria (RN-P5)."""
 
 
-def _dni_en_convocatoria(convocatoria, dni):
+class InscripcionNoHabilitada(Exception):
+    """El DNI+sexo dejó de figurar en el padrón del relevamiento (RN-P14)."""
+
+
+def dni_en_convocatoria(convocatoria, dni):
+    """RN-P5, única definición: cualquier relevamiento de la convocatoria (de
+    campo o público), por ciudadano resuelto o identificación offline. La usan
+    el paso 1 del portal y el re-chequeo transaccional del envío.
+
+    Cuenta también los formularios RECHAZADO/BAJA (mismo criterio que la app
+    de campo): una persona rechazada no puede reinscribirse por link. Es una
+    decisión tomada por omisión, pendiente de confirmar con el programa.
+    """
     return (
         Formulario.objects.filter(relevamiento__convocatoria=convocatoria)
         .filter(Q(ciudadano__dni=dni) | Q(datos_identificacion__dni=dni))
@@ -66,8 +79,13 @@ def crear_formulario_publico(relevamiento, *, identificacion, form, client_uuid)
             raise InscripcionNoDisponible()
         if rel.formularios.count() >= rel.cupo_maximo:
             raise InscripcionNoDisponible()
-        if _dni_en_convocatoria(rel.convocatoria, dni):
+        # El duplicado es por convocatoria completa: se lockea la convocatoria
+        # para que dos envíos simultáneos por relevamientos distintos no pasen.
+        convocatoria = Convocatoria.objects.select_for_update().get(pk=rel.convocatoria_id)
+        if dni_en_convocatoria(convocatoria, dni):
             raise InscripcionDuplicada()
+        if not esta_habilitado(rel, dni, identificacion.get("sexo", "")):
+            raise InscripcionNoHabilitada()
 
         if es_validado:
             nombre = datos_basicos.get("nombre", "")

--- a/programas/services/inscripcion_publica.py
+++ b/programas/services/inscripcion_publica.py
@@ -16,6 +16,7 @@ Garantías dentro de la transacción (mismo patrón que la API de campo):
 from __future__ import annotations
 
 import logging
+import uuid
 
 from django.core.mail import send_mail
 from django.db import transaction
@@ -24,8 +25,9 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from programas.models import AdjuntoFormulario, Convocatoria, Formulario, Relevamiento
-from programas.services.becas import resolver_ciudadano_offline
+from programas.services.becas import formulario_por_client_uuid, resolver_ciudadano_offline
 from programas.services.padron import esta_habilitado
+from programas.services.personas import fecha_iso
 
 
 class InscripcionNoDisponible(Exception):
@@ -72,9 +74,14 @@ def crear_formulario_publico(relevamiento, *, identificacion, form, client_uuid)
     with transaction.atomic():
         rel = Relevamiento.objects.select_for_update().get(pk=relevamiento.pk)
         if client_uuid:
-            existente = rel.formularios.filter(client_uuid=client_uuid).first()
-            if existente:
-                return existente, False
+            try:
+                client_uuid_obj = uuid.UUID(str(client_uuid))
+            except (TypeError, ValueError):
+                client_uuid_obj = None
+            if client_uuid_obj:
+                existente = formulario_por_client_uuid(rel, client_uuid_obj)
+                if existente:
+                    return existente, False
         if rel.estado != Relevamiento.Estado.EN_CURSO or not rel.habilitado_en(timezone.now()):
             raise InscripcionNoDisponible()
         if rel.formularios.count() >= rel.cupo_maximo:
@@ -90,7 +97,10 @@ def crear_formulario_publico(relevamiento, *, identificacion, form, client_uuid)
         if es_validado:
             nombre = datos_basicos.get("nombre", "")
             apellido = datos_basicos.get("apellido", "")
-            fecha_nacimiento = datos_basicos.get("fecha_nacimiento", "")
+            fecha_nacimiento = fecha_iso(datos_basicos.get("fecha_nacimiento"))
+            if not fecha_nacimiento:
+                fecha = cleaned.get("fecha_nacimiento")
+                fecha_nacimiento = fecha.isoformat() if fecha else ""
         else:
             nombre = cleaned.get("nombre", "")
             apellido = cleaned.get("apellido", "")

--- a/programas/services/padron.py
+++ b/programas/services/padron.py
@@ -35,6 +35,10 @@ _ENCABEZADOS_DNI = {"DOCUMENTO", "DNI", "NRO DOCUMENTO", "NUMERO DE DOCUMENTO", 
 
 
 def normalizar_dni(valor):
+    # openpyxl entrega floats (30123456.0) en Excels exportados desde CSV,
+    # pandas o LibreOffice; sin este cast el DNI quedaba con un 0 de más.
+    if isinstance(valor, float) and valor.is_integer():
+        valor = int(valor)
     return "".join(ch for ch in str(valor or "") if ch.isdigit())
 
 
@@ -78,7 +82,7 @@ def parsear_padron(archivo):
                 continue  # fila totalmente vacía
             if indice == 0 and not dni and str(crudo_dni or "").strip().upper() in _ENCABEZADOS_DNI:
                 continue  # fila de encabezado
-            if not dni or not sexo:
+            if not dni or not sexo or len(dni) not in (7, 8):
                 rechazadas += 1
                 continue
             if dni in vistos:

--- a/programas/services/personas.py
+++ b/programas/services/personas.py
@@ -6,6 +6,7 @@ cliente usa credenciales propias, cachea el token y consulta solamente por DNI.
 
 import logging
 import re
+from datetime import datetime
 
 import requests
 from django.conf import settings
@@ -48,6 +49,23 @@ def _primero(flat, *keys):
     return ""
 
 
+def fecha_iso(valor):
+    """Normaliza la fecha de un proveedor a ``AAAA-MM-DD`` (o ``""`` si no se
+    puede). Gran Base/RENAPER no garantizan formato: llegó ``15/03/2010`` y
+    rompía RN-22 y el alta del ciudadano (revisión Cambio 40)."""
+    if hasattr(valor, "isoformat"):
+        return valor.isoformat()[:10]
+    texto = _texto(valor).split("T")[0].split(" ")[0]
+    if not texto:
+        return ""
+    for formato in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y", "%Y/%m/%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(texto, formato).date().isoformat()
+        except ValueError:
+            continue
+    return ""
+
+
 def normalizar_persona(payload, dni):
     """Tolera variantes de nombres hasta que se cierre el contrato definitivo."""
     data = payload.get("data") if isinstance(payload, dict) else payload
@@ -56,7 +74,7 @@ def normalizar_persona(payload, dni):
         "dni": _texto(_primero(flat, "dni", "documento", "numero_documento", "nro_documento")) or dni,
         "apellido": _texto(_primero(flat, "apellido", "apellidos")),
         "nombre": _texto(_primero(flat, "nombre", "nombres")),
-        "fecha_nacimiento": _texto(_primero(flat, "fecha_nacimiento", "fechaNacimiento", "nacimiento")),
+        "fecha_nacimiento": fecha_iso(_primero(flat, "fecha_nacimiento", "fechaNacimiento", "nacimiento")),
         "sexo": _texto(_primero(flat, "sexo", "genero")).upper(),
     }
 

--- a/programas/services/reportes_becas.py
+++ b/programas/services/reportes_becas.py
@@ -195,6 +195,9 @@ def reporte_produccion(user, *, segmento_id=None, territorial_id=None, desde=Non
         qs = qs.filter(fecha_hasta__gte=desde)
     if hasta:
         qs = qs.filter(fecha_asignada__lte=hasta)
+    # Los relevamientos públicos no tienen territorial: no son "producción
+    # territorial" y romperían el agrupado (revisión Cambio 40).
+    qs = qs.filter(territorial__isnull=False)
     grupos = defaultdict(lambda: {"rels": [], "forms": []})
     for rel in qs:
         clave = (rel.territorial_id, rel.convocatoria.segmento_id)

--- a/programas/templates/programas/becas/revision/renaper_pendientes.html
+++ b/programas/templates/programas/becas/revision/renaper_pendientes.html
@@ -34,7 +34,7 @@
       <tbody>{% for formulario in formularios %}<tr class="border-t border-light">
         <td class="px-4 py-3 text-sm text-heading">{% if formulario.ciudadano %}{{ formulario.ciudadano.nombre_completo }} ({{ formulario.ciudadano.dni }}){% else %}Sin ciudadano vinculado{% endif %}</td>
         <td class="px-4 py-3 text-sm text-body">{{ formulario.creado|date:'d/m/Y' }}</td>
-        <td class="px-4 py-3 text-sm text-body">{{ formulario.relevamiento.territorial.username }}</td>
+        <td class="px-4 py-3 text-sm text-body">{% if formulario.relevamiento.territorial %}{{ formulario.relevamiento.territorial.username }}{% else %}Formulario pÃºblico{% endif %}</td>
         <td class="px-4 py-3 text-sm text-body">{{ formulario.relevamiento.convocatoria.segmento.nombre }}</td>
         <td class="px-4 py-3 text-right"><a href="{% url 'becas:formulario_detalle' formulario.pk %}" class="btn-nodo btn-tertiary btn-sm">Abrir</a></td>
       </tr>{% endfor %}</tbody>

--- a/programas/views/pausas.py
+++ b/programas/views/pausas.py
@@ -3,9 +3,11 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 
+from core.rbac import puede
 from programas.models import Convocatoria, ProgramaSiis, RegistroPausa, Relevamiento, Segmento, Subsegmento
 from programas.services.autorizacion import es_admin_becas, puede_gestionar_segmento
 from programas.services.pausas import cambiar_pausa
+from programas.views.relevamientos import CAP_RELEVAMIENTO_PUBLICO
 
 TIPOS = {
     "programa": (ProgramaSiis, "becas:programa_detalle"),
@@ -36,6 +38,8 @@ def gestionar_pausa(request, tipo, pk):
         raise PermissionDenied("Tipo de elemento no permitido.")
     modelo, redirect_name = configuracion
     objeto = get_object_or_404(modelo, pk=pk)
+    if isinstance(objeto, Relevamiento) and objeto.es_publico and not puede(request.user, CAP_RELEVAMIENTO_PUBLICO):
+        raise PermissionDenied("No tiene acceso a este relevamiento.")
 
     segmento = _segmento_de(objeto)
     if not es_admin_becas(request.user) or (

--- a/programas/views/relevamientos.py
+++ b/programas/views/relevamientos.py
@@ -63,6 +63,12 @@ def _sin_publicos_si_no_puede(qs, user):
     return qs.exclude(tipo=Relevamiento.Tipo.PUBLICO)
 
 
+def _sin_formularios_publicos_si_no_puede(qs, user):
+    if _puede_publico(user):
+        return qs
+    return qs.exclude(relevamiento__tipo=Relevamiento.Tipo.PUBLICO)
+
+
 def _convocatorias_qs(request):
     return (
         Convocatoria.objects.select_related("segmento", "subsegmento")
@@ -174,7 +180,10 @@ class ConvocatoriaDetailView(CapacidadRequeridaMixin, LoginRequiredMixin, Detail
         ctx["relevamientos"] = relevamientos
         # Beneficiarios = formularios cargados en los relevamientos de esta convocatoria.
         beneficiarios = list(
-            Formulario.objects.filter(relevamiento__convocatoria=conv)
+            _sin_formularios_publicos_si_no_puede(
+                Formulario.objects.filter(relevamiento__convocatoria=conv),
+                self.request.user,
+            )
             .select_related("ciudadano", "relevamiento")
             .order_by("-creado")
         )
@@ -327,7 +336,10 @@ def convocatoria_export_beneficiarios(request, pk):
     writer = csv.writer(response)
     writer.writerow(["Nombre", "DNI", "Segmento", "Convocatoria", "Fecha de aprobación"])
     formularios = (
-        Formulario.objects.filter(relevamiento__convocatoria=conv, estado=Formulario.Estado.APROBADO)
+        _sin_formularios_publicos_si_no_puede(
+            Formulario.objects.filter(relevamiento__convocatoria=conv, estado=Formulario.Estado.APROBADO),
+            request.user,
+        )
         .select_related("ciudadano", "relevamiento")
         .order_by("-creado")
     )

--- a/programas/views/relevamientos.py
+++ b/programas/views/relevamientos.py
@@ -101,7 +101,10 @@ def _relevamientos_ajax(request, convocatoria, message="Relevamiento creado y as
 
 
 def _assert_scope(request, relevamiento):
-    """403 si el usuario no puede gestionar el segmento del relevamiento."""
+    """403 si el usuario no puede gestionar el segmento del relevamiento, o si
+    es público y no tiene la capacidad (RN-P13: ocultar no es bloquear)."""
+    if relevamiento.es_publico and not _puede_publico(request.user):
+        raise PermissionDenied("No tiene acceso a este relevamiento.")
     programa = programa_becas()
     if (
         not puede_gestionar_segmento(request.user, relevamiento.segmento, programa=programa)

--- a/programas/views/revision.py
+++ b/programas/views/revision.py
@@ -129,6 +129,12 @@ def _assert_scope_formulario(request, formulario):
         raise PermissionDenied("No tiene acceso a este formulario.")
 
 
+def _sin_formularios_publicos_si_no_puede(qs, user):
+    if puede(user, CAP_RELEVAMIENTO_PUBLICO):
+        return qs
+    return qs.exclude(relevamiento__tipo=Relevamiento.Tipo.PUBLICO)
+
+
 def _tiene_conflicto_duplicado_pendiente(formulario):
     return (
         formulario.conflicto_duplicado and not formulario.conflicto_resuelto
@@ -152,6 +158,7 @@ class RevisionPersonasListView(CapacidadRequeridaMixin, LoginRequiredMixin, List
             .filter(relevamiento__convocatoria__in=convocatorias_visibles(self.request.user))
             .order_by("-creado")
         )
+        qs = _sin_formularios_publicos_si_no_puede(qs, self.request.user)
         estado = self.request.GET.get("estado")
         if estado:
             qs = qs.filter(estado=estado)
@@ -162,7 +169,10 @@ class RevisionPersonasListView(CapacidadRequeridaMixin, LoginRequiredMixin, List
         ctx["estados"] = Formulario.Estado.choices
         ctx["estado_actual"] = self.request.GET.get("estado", "")
         ctx["puede_revalidar_renaper"] = puede(self.request.user, CAP_REVALIDAR_RENAPER)
-        ctx["pendientes_renaper"] = Formulario.objects.filter(validado_renaper=False).count()
+        ctx["pendientes_renaper"] = _sin_formularios_publicos_si_no_puede(
+            Formulario.objects.filter(validado_renaper=False),
+            self.request.user,
+        ).count()
         return ctx
 
 
@@ -176,6 +186,7 @@ class RenaperPendientesListView(CapacidadRequeridaMixin, LoginRequiredMixin, Lis
         queryset = Formulario.objects.filter(validado_renaper=False).select_related(
             "ciudadano", "relevamiento__territorial", "relevamiento__convocatoria__segmento"
         )
+        queryset = _sin_formularios_publicos_si_no_puede(queryset, self.request.user)
         if self.request.GET.get("fecha"):
             queryset = queryset.filter(creado__date=self.request.GET["fecha"])
         # Los filtros llegan por GET: solo se aplican si son ids válidos.
@@ -201,9 +212,10 @@ class RenaperPendientesListView(CapacidadRequeridaMixin, LoginRequiredMixin, Lis
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         base = Formulario.objects.filter(validado_renaper=False)
+        base = _sin_formularios_publicos_si_no_puede(base, self.request.user)
         context["territoriales"] = self.territoriales_pendientes(base)
         context["segmentos"] = (
-            Segmento.objects.filter(convocatorias__relevamientos__formularios__validado_renaper=False)
+            Segmento.objects.filter(convocatorias__relevamientos__formularios__in=base)
             .distinct()
             .order_by("nombre")
         )
@@ -562,6 +574,7 @@ def formulario_rechazar(request, pk):
 @requiere(CAP_REVALIDAR_RENAPER)
 def formulario_revalidar_renaper(request, pk):
     formulario = get_object_or_404(Formulario.objects.select_related("ciudadano"), pk=pk)
+    _assert_scope_formulario(request, formulario)
     if request.method != "POST":
         return redirect("becas:formulario_detalle", pk=formulario.pk)
     ciudadano = formulario.ciudadano

--- a/programas/views/revision.py
+++ b/programas/views/revision.py
@@ -19,6 +19,7 @@ from django.utils.dateparse import parse_date
 from django.views.generic import ListView
 
 from core.rbac import CapacidadRequeridaMixin, puede, puede_alguna, requiere
+from programas.views.relevamientos import CAP_RELEVAMIENTO_PUBLICO
 from programas.forms import CiudadanoGeneroRevisionForm, FormularioRevisionForm
 from programas.models import (
     Formulario,
@@ -107,6 +108,10 @@ def _con_conflicto_duplicado_pendiente(queryset):
 
 
 def _assert_scope_relevamiento(request, relevamiento):
+    # RN-P13: sin la capacidad, un relevamiento público no existe para el usuario
+    # (tampoco para mutarlo por URL).
+    if relevamiento.es_publico and not puede(request.user, CAP_RELEVAMIENTO_PUBLICO):
+        raise PermissionDenied("No tiene acceso a este relevamiento.")
     if (
         not puede_gestionar_segmento(request.user, relevamiento.segmento)
         or not convocatorias_visibles(request.user).filter(pk=relevamiento.convocatoria_id).exists()
@@ -115,6 +120,8 @@ def _assert_scope_relevamiento(request, relevamiento):
 
 
 def _assert_scope_formulario(request, formulario):
+    if formulario.relevamiento.es_publico and not puede(request.user, CAP_RELEVAMIENTO_PUBLICO):
+        raise PermissionDenied("No tiene acceso a este formulario.")
     if (
         not puede_gestionar_segmento(request.user, formulario.relevamiento.segmento)
         or not convocatorias_visibles(request.user).filter(pk=formulario.relevamiento.convocatoria_id).exists()
@@ -171,20 +178,30 @@ class RenaperPendientesListView(CapacidadRequeridaMixin, LoginRequiredMixin, Lis
         )
         if self.request.GET.get("fecha"):
             queryset = queryset.filter(creado__date=self.request.GET["fecha"])
-        if self.request.GET.get("territorial"):
-            queryset = queryset.filter(relevamiento__territorial_id=self.request.GET["territorial"])
-        if self.request.GET.get("segmento"):
-            queryset = queryset.filter(relevamiento__convocatoria__segmento_id=self.request.GET["segmento"])
+        # Los filtros llegan por GET: solo se aplican si son ids válidos.
+        territorial = self.request.GET.get("territorial", "")
+        if territorial.isdigit():
+            queryset = queryset.filter(relevamiento__territorial_id=int(territorial))
+        segmento = self.request.GET.get("segmento", "")
+        if segmento.isdigit():
+            queryset = queryset.filter(relevamiento__convocatoria__segmento_id=int(segmento))
         return queryset.order_by("-creado")
+
+    @staticmethod
+    def territoriales_pendientes(base):
+        """Opciones del filtro. Los formularios públicos no tienen territorial:
+        quedan fuera del selector (antes generaban una opción `None`)."""
+        return (
+            base.exclude(relevamiento__territorial__isnull=True)
+            .values("relevamiento__territorial_id", "relevamiento__territorial__username")
+            .distinct()
+            .order_by("relevamiento__territorial__username")
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         base = Formulario.objects.filter(validado_renaper=False)
-        context["territoriales"] = (
-            base.values("relevamiento__territorial_id", "relevamiento__territorial__username")
-            .distinct()
-            .order_by("relevamiento__territorial__username")
-        )
+        context["territoriales"] = self.territoriales_pendientes(base)
         context["segmentos"] = (
             Segmento.objects.filter(convocatorias__relevamientos__formularios__validado_renaper=False)
             .distinct()


### PR DESCRIPTION
> **Apilado sobre #304 (Fase 4)** → #303 → #302 → #301. Es el resultado de la revisión completa del diff de las cuatro fases: **10 hallazgos, todos corregidos y con test que reproduce el bug**. Mergear en orden.

## Críticos (500 en producción o salteo de regla)

| # | Dónde | Bug | Fix |
|---|---|---|---|
| 1 | `reportes_becas.reporte_produccion` | Un relevamiento público (territorial nulo) hacía `None.get_full_name()` → **500 para todos** en Producción territorial. | Se excluyen los públicos del agrupado (no son producción territorial). |
| 2 | `portal/views/inscripcion.py` paso 1 | El rate limit hacía `add_error` sobre un form sin `cleaned_data` → **500** en vez del mensaje. Un `except AttributeError: pass` en los tests lo tapaba. | Form bound + `is_valid()` antes del error. Los tests ahora **re-lanzan** cualquier `AttributeError` que no sea el bug conocido de render del entorno. |
| 3 | `revision.RenaperPendientesListView` | Públicos sin match generaban `<option value="None">`; filtrar con `?territorial=None` → `ValueError` → **500**. | El selector excluye territorial nulo; los filtros GET se validan como ids. |
| 4 | `personas.normalizar_persona` | Fecha `15/03/2010` de Gran Base → `parse_date`=None → **RN-22 salteada** (menor sin apoderado) y luego **500** al crear el ciudadano. | `fecha_iso()` normaliza ISO/dd-mm-aaaa/etc. en la fuente; el form también la usa. |
| 5 | `_assert_scope*`, `gestionar_pausa` | El gate RBAC solo cubría listados/detalle: un usuario **sin** `becas.relevamiento.publico` podía finalizar/reabrir/reprogramar/pausar/revisar un público por URL. | El chequeo vive en los tres `_assert_scope` y en pausas. |

## Altos

| # | Dónde | Bug | Fix |
|---|---|---|---|
| 6 | `padron.normalizar_dni` | openpyxl entrega `30123456.0` → DNI `301234560`: el operador ve "N habilitados" y **nadie matchea**. | Cast de floats enteros + rechazo de filas que no dan 7-8 dígitos. |
| 7 | `crear_formulario_publico` | El padrón no se re-verificaba al enviar: reemplazarlo entre paso 1 y envío no bloqueaba. | `esta_habilitado` dentro del lock → `InscripcionNoHabilitada`, mostrada inline en el paso 2. |
| 8 | `crear_formulario_publico` | El duplicado es por convocatoria pero el lock era por relevamiento: dos envíos simultáneos por dos públicos pasaban ambos. | `select_for_update` sobre la convocatoria antes del chequeo. |

## Medios

| # | Dónde | Bug | Fix |
|---|---|---|---|
| 9 | `Relevamiento.save` | Cambiar tipo a público desde el admin dejaba `token_publico=None` → "Copiar link" copiaba la raíz del sitio. | El token se genera siempre que sea público y falte. |
| 10 | portal + ingesta | RN-P5 duplicada byte a byte en dos módulos. | Una sola `dni_en_convocatoria`; el portal la re-exporta. |

**Decisión funcional detectada (pendiente de confirmar con el programa):** los formularios RECHAZADO/BAJA cuentan como "ya inscripto" y bloquean la reinscripción por link — mismo criterio que la app de campo; quedó así por omisión y está registrado en el Historial del Cambio 40.

## Validación

- **11 tests nuevos** (`portal.tests.test_correcciones_review`), uno por bug, todos en verde: el reporte con un público, rate limit sin 500, selector sin `None` y filtro inválido, `fecha_iso` + menor con `dd/mm/aaaa` exige apoderado, `_assert_scope` bloquea públicos sin capacidad, floats del padrón, re-chequeo del padrón al enviar, token al cambiar de tipo.
- 189 tests de Becas + Portal: **0 fallos**; 20 errores que son todos el bug de render del entorno (Py 3.14 + Django 4.2) — verificado: `programas.tests.test_becas_revision` da los mismos 14 errores en `development` limpio, y en esta rama las 238 excepciones de ese módulo son idénticas (`Context.__copy__`).
- `manage.py check` OK · `makemigrations --check` sin faltantes (no migra) · `design_audit.py --changed` **0/0** · `compile_templates.py` 324/0 · `requerimientos.py --check` OK.

Cadena: Épica #69 · Análisis #289 · Cambio 40 (Historial 24/08).

🤖 Generated with [Claude Code](https://claude.com/claude-code)