### PR TITLE
feat(becas): constructor de formularios por convocatoria (Cambio 58) — rama única

### DIFF
--- a/docs/internal/requerimientos.md
+++ b/docs/internal/requerimientos.md
@@ -201,7 +201,7 @@ Los campos que no apliquen se escriben como «No requiere» o «No aplica»; no 
 | 55 | Validar la identidad a mano cuando Base de Personas no puede validar | Becas / revisión | `#siis` `#rbac` `#ui` `#datos` | PM — «hoy en día no puedo validar; podemos agregar una funcionalidad para, aunque no valide, poder forzar la validación» | 27/08/2026 | 🟢 **Hecho** | `programas.0054` |
 | 56 | Los selectores se pueden mostrar como buscador con píldoras | Becas · configuración → Portal | `#ui` `#relevamientos` `#datos` | PM — «cuando el campo es alguno de los dos tipo de selector, quiero poder configurar cuándo se ve como buscador con selector y el valor seleccionado se ve en píldora» | 28/08/2026 | 🟢 **Hecho** | `programas.0055` |
 | 57 | Padrón de la convocatoria como fuente de identidad (Base de Personas apagada por configuración) | Becas · identificación | `#relevamientos` `#siis` `#datos` `#infra` | PM — «la Gran Base no está funcionando; vamos a agregar esos datos al Excel y autocompletar de ahí» | 28/08/2026 | 🟢 **Hecho — desarrollo de #327–#333 (28/08/2026); quedan las pruebas #334/#335** | `programas.0056` |
-| 58 | Constructor de formularios por convocatoria: grupos, textos, condiciones y campos del legajo | Becas · configuración → Portal · App | `#relevamientos` `#ui` `#datos` `#rbac` | PM — «al configurar la convocatoria, Configurar formulario: el diseño y al lado cómo quedaría publicado; los requisitos son campos que se arrastran» | 28/08/2026 | 🟡 **Analizado — análisis #326 Definido, mockups entregados; tasks #336–#356 en Backlog (150 h)** | Pendiente (catálogo, diseño, caso) |
+| 58 | Constructor de formularios por convocatoria: grupos, textos, condiciones y campos del legajo | Becas · configuración → Portal · App | `#relevamientos` `#ui` `#datos` `#rbac` | PM — «al configurar la convocatoria, Configurar formulario: el diseño y al lado cómo quedaría publicado; los requisitos son campos que se arrastran» | 28/08/2026 | 🟡 **En desarrollo — Fase 1 hecha (#336 catálogo agrupado con orígenes, #338 canal; `programas.0057`); siguen #337 y el motor** | `programas.0057` + pendientes |
 
 **Notas del índice**
 
@@ -6014,7 +6014,21 @@ Por fase; la última (caso) es la única con migración destructiva.
 
 ## Historial
 
-No aplica: entrada nueva. Es la fase 2 explícita de lo que el Cambio 41 dejó fuera («configurador de formularios
-propio»). El Cambio 56 (presentación de selectores) queda absorbido como atributo del catálogo.
+- **28/08/2026 — Fase 1 (catálogo) hecha, tasks #336 y #338.** `GrupoRequisito` (clave, nombre, subtítulo,
+  orden, protegido, condición por defecto, canal); `PreguntaGlobal` con `grupo`, `origen` (pregunta / legajo /
+  persona_vinculada), `vinculo`, `protegido` y `canal`; `RequisitoNativo.canal`; `Formulario.celular` y
+  `email_contacto` ahora `blank=True` (D9). `VINCULOS_LEGAJO` dicta tipo y opciones de los campos vinculados.
+  `seed_becas` siembra los grupos protegidos —Datos personales, Contacto, Apoderado (condición por defecto
+  `edad_menor 18`)— con sus doce campos, y manda al «Cuestionario social» toda pregunta sin grupo
+  (`PreguntaGlobal.save` también lo hace). El form bloquea tipo/opciones de los protegidos y obligatorio/estado de
+  la identidad; las vistas rechazan borrar protegidos y desactivar identidad. Los modales de los cuatro
+  configuradores ofrecen «Se pide en» y la lista de generales muestra grupo, origen y protegido.
+  `definicion_formulario` filtra por el canal del relevamiento (`CanalFormulario.del_relevamiento`) y expone
+  `canal`, `origen`, `vinculo` y `grupo` por campo; **excluye los campos vinculados** hasta que el diseño por
+  convocatoria los consuma (si entraran hoy se pedirían dos veces). Migración `programas.0057`. Tests:
+  `programas/tests/test_catalogo_grupos.py` (19). Pendiente de esta fase: la pantalla agrupada con drag & drop (#337).
+
+Entrada nueva el 28/08/2026. Es la fase 2 explícita de lo que el Cambio 41 dejó fuera («configurador de
+formularios propio»). El Cambio 56 (presentación de selectores) queda absorbido como atributo del catálogo.
 
 ---

--- a/programas/forms.py
+++ b/programas/forms.py
@@ -23,6 +23,7 @@ from programas.models import (
     Dispositivo,
     EntregaMercaderia,
     Formulario,
+    GrupoRequisito,
     PreguntaGlobal,
     PresentacionCampo,
     PrestacionDiaria,
@@ -827,21 +828,60 @@ class PrestacionMensualForm(forms.Form):
 
 
 class PreguntaGlobalForm(_OrdenUnicoMixin, _PresentacionMixin, _OpcionesMixin):
-    """Requisitos generales: el orden es único entre todas las preguntas."""
+    """Requisitos generales: el orden es único entre todas las preguntas.
+
+    Cambio 58: cada pregunta pertenece a un grupo y declara su canal. Los
+    campos **protegidos** (vinculados al legajo o al apoderado) no cambian de
+    tipo ni de opciones —los dicta el legajo— y los de identidad tampoco de
+    obligatoriedad ni de estado (D12); lo demás (texto, grupo, orden, canal) sí.
+    """
 
     mensaje_orden_duplicado = "Ya hay otra pregunta con el orden {orden}. Elegí un número libre."
+    # Lo que un protegido no puede cambiar desde el backoffice.
+    _BLOQUEADOS_PROTEGIDO = ("tipo", "presentacion", "opciones_texto")
+    _BLOQUEADOS_IDENTIDAD = ("obligatorio", "activo")
 
     class Meta:
         model = PreguntaGlobal
-        fields = ["texto", "tipo", "presentacion", "obligatorio", "orden", "activo"]
+        fields = ["texto", "tipo", "presentacion", "grupo", "canal", "obligatorio", "orden", "activo"]
         widgets = {
             "texto": forms.TextInput(attrs={"class": INPUT_CLASS}),
             "tipo": forms.Select(attrs={"class": INPUT_CLASS}),
             "presentacion": forms.Select(attrs={"class": INPUT_CLASS}),
+            "grupo": forms.Select(attrs={"class": INPUT_CLASS}),
+            "canal": forms.Select(attrs={"class": INPUT_CLASS}),
             "obligatorio": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASS}),
             "orden": forms.NumberInput(attrs={"class": INPUT_CLASS, "min": 0}),
             "activo": forms.CheckboxInput(attrs={"class": CHECKBOX_CLASS}),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        grupo = self.fields["grupo"]
+        grupo.queryset = GrupoRequisito.objects.order_by("orden", "id")
+        grupo.required = False
+        grupo.empty_label = "Sin grupo (Cuestionario social)"
+        if self.instance and self.instance.pk and self.instance.protegido:
+            bloqueados = list(self._BLOQUEADOS_PROTEGIDO)
+            if self.instance.es_identidad:
+                bloqueados += list(self._BLOQUEADOS_IDENTIDAD)
+            for nombre in bloqueados:
+                self.fields[nombre].disabled = True
+
+    def clean(self):
+        cleaned = super().clean()
+        if cleaned.get("grupo") is None:
+            cleaned["grupo"] = GrupoRequisito.objects.filter(clave="cuestionario").first()
+        if self.instance and self.instance.pk and self.instance.protegido:
+            # Un campo disabled toma el valor de la instancia, pero un POST
+            # armado a mano no puede colar un cambio de tipo ni de opciones.
+            cleaned["tipo"] = self.instance.tipo
+            cleaned["presentacion"] = self.instance.presentacion
+            cleaned["_opciones"] = self.instance.opciones
+            if self.instance.es_identidad:
+                cleaned["obligatorio"] = True
+                cleaned["activo"] = True
+        return cleaned
 
     def hermanos_orden(self):
         return PreguntaGlobal.objects.all()
@@ -860,11 +900,12 @@ class RequisitoNativoForm(_OrdenUnicoMixin, _PresentacionMixin, _OpcionesMixin):
 
     class Meta:
         model = RequisitoNativo
-        fields = ["texto", "tipo", "presentacion", "obligatorio", "orden"]
+        fields = ["texto", "tipo", "presentacion", "canal", "obligatorio", "orden"]
         widgets = {
             "texto": forms.TextInput(attrs={"class": INPUT_CLASS}),
             "tipo": forms.Select(attrs={"class": INPUT_CLASS}),
             "presentacion": forms.Select(attrs={"class": INPUT_CLASS}),
+            "canal": forms.Select(attrs={"class": INPUT_CLASS}),
             "orden": forms.NumberInput(attrs={"class": INPUT_CLASS, "min": 0}),
         }
 

--- a/programas/management/commands/seed_becas.py
+++ b/programas/management/commands/seed_becas.py
@@ -20,7 +20,15 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from core import rbac
-from programas.models import PreguntaGlobal, Programa, TipoCampo
+from programas.models import (
+    VINCULOS_LEGAJO,
+    CanalFormulario,
+    GrupoRequisito,
+    OrigenRequisito,
+    PreguntaGlobal,
+    Programa,
+    TipoCampo,
+)
 from users.models import Capacidad, RolMeta
 
 PROGRAMA_BECAS_CODIGO = "BECAS"
@@ -174,6 +182,114 @@ def asegurar_adjuntos_obligatorios():
     return creados
 
 
+# Catálogo protegido (Cambio 58, D5): los bloques que antes eran fijos en el
+# código pasan a ser requisitos generales agrupados y vinculados al legajo.
+# Cada grupo: (clave, nombre, subtítulo, orden, condición por defecto, campos);
+# cada campo: (origen, vínculo, etiqueta, obligatorio). El tipo y las opciones
+# salen de VINCULOS_LEGAJO, nunca de acá.
+CONDICION_APODERADO = {
+    "modo": "todas",
+    "reglas": [{"fuente": "legajo:fecha_nacimiento", "op": "edad_menor", "valor": 18}],
+}
+CATALOGO_PROTEGIDO = [
+    (
+        "datos_personales",
+        "Datos personales",
+        "Tomamos estos datos de tu identificación.",
+        0,
+        None,
+        [
+            (OrigenRequisito.LEGAJO, "nombre", "Nombre", True),
+            (OrigenRequisito.LEGAJO, "apellido", "Apellido", True),
+            (OrigenRequisito.LEGAJO, "dni", "DNI", True),
+            (OrigenRequisito.LEGAJO, "fecha_nacimiento", "Fecha de nacimiento", True),
+            (OrigenRequisito.LEGAJO, "genero", "Sexo", True),
+        ],
+    ),
+    (
+        "contacto",
+        "Contacto",
+        "",
+        1,
+        None,
+        [
+            (OrigenRequisito.LEGAJO, "telefono", "Celular", True),
+            (OrigenRequisito.LEGAJO, "email", "Correo electrónico", False),
+        ],
+    ),
+    (
+        "apoderado",
+        "Apoderado",
+        "Como sos menor de 18, necesitamos los datos de un adulto responsable.",
+        2,
+        CONDICION_APODERADO,
+        [
+            (OrigenRequisito.PERSONA_VINCULADA, "nombre", "Nombre del apoderado", True),
+            (OrigenRequisito.PERSONA_VINCULADA, "apellido", "Apellido del apoderado", True),
+            (OrigenRequisito.PERSONA_VINCULADA, "dni", "DNI del apoderado", True),
+            (OrigenRequisito.PERSONA_VINCULADA, "genero", "Sexo del apoderado", False),
+            (OrigenRequisito.PERSONA_VINCULADA, "fecha_nacimiento", "Fecha de nacimiento del apoderado", False),
+        ],
+    ),
+]
+GRUPO_CUESTIONARIO = ("cuestionario", "Cuestionario social", "", 10)
+
+
+def asegurar_catalogo_protegido():
+    """Siembra los grupos protegidos con sus campos vinculados y manda al
+    «Cuestionario social» toda pregunta que no tenga grupo. Idempotente: la
+    identidad de un campo protegido es (origen, vínculo); el texto, el grupo y
+    el orden se pueden haber cambiado desde el backoffice y no se pisan."""
+    creados = 0
+    ordenes_usados = set(PreguntaGlobal.objects.values_list("orden", flat=True))
+
+    def orden_libre(desde):
+        while desde in ordenes_usados:
+            desde += 1
+        ordenes_usados.add(desde)
+        return desde
+
+    for clave, nombre, subtitulo, orden, condicion, campos in CATALOGO_PROTEGIDO:
+        grupo, _ = GrupoRequisito.objects.get_or_create(
+            clave=clave,
+            defaults={
+                "nombre": nombre,
+                "subtitulo": subtitulo,
+                "orden": orden,
+                "protegido": True,
+                "condicion_defecto": condicion,
+            },
+        )
+        if not grupo.protegido:
+            grupo.protegido = True
+            grupo.save(update_fields=["protegido", "modificado"])
+        for indice, (origen, vinculo, etiqueta, obligatorio) in enumerate(campos):
+            info = VINCULOS_LEGAJO[vinculo]
+            _, created = PreguntaGlobal.objects.get_or_create(
+                origen=origen,
+                vinculo=vinculo,
+                defaults={
+                    "texto": etiqueta,
+                    "tipo": info["tipo"],
+                    "opciones": info["opciones"],
+                    "grupo": grupo,
+                    "protegido": True,
+                    "obligatorio": obligatorio,
+                    "activo": True,
+                    "canal": CanalFormulario.AMBOS,
+                    "orden": orden_libre(orden * 10 + indice + 1),
+                },
+            )
+            creados += int(created)
+
+    clave, nombre, subtitulo, orden = GRUPO_CUESTIONARIO
+    cuestionario, _ = GrupoRequisito.objects.get_or_create(
+        clave=clave, defaults={"nombre": nombre, "subtitulo": subtitulo, "orden": orden}
+    )
+    PreguntaGlobal.objects.filter(grupo__isnull=True).update(grupo=cuestionario)
+    return creados
+
+
 def asegurar_roles_becas(programa):
     """Crea/asegura los 3 roles del programa con sus capacidades (idempotente).
 
@@ -220,6 +336,14 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 f"  ✓ Adjuntos obligatorios asegurados ({creados} nuevos, {len(ADJUNTOS_OBLIGATORIOS)} totales)"
+            )
+        )
+
+        protegidos = asegurar_catalogo_protegido()
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"  ✓ Catálogo protegido asegurado ({protegidos} campos nuevos; "
+                f"grupos {', '.join(c[1] for c in CATALOGO_PROTEGIDO)} + {GRUPO_CUESTIONARIO[1]})"
             )
         )
 

--- a/programas/migrations/0057_catalogo_grupos_origen_canal.py
+++ b/programas/migrations/0057_catalogo_grupos_origen_canal.py
@@ -1,0 +1,123 @@
+# Cambio 58, Fase 1 — el catálogo de requisitos generales se agrupa y admite
+# tres orígenes (pregunta / campo del legajo / campo del apoderado); todo
+# requisito declara en qué canal se pide. Los grupos y campos protegidos los
+# siembra `seed_becas` (idempotente, corre en cada arranque del pod); acá solo
+# se crea el grupo por defecto y se le asignan las preguntas existentes.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def preguntas_al_cuestionario(apps, schema_editor):
+    Grupo = apps.get_model("programas", "GrupoRequisito")
+    Pregunta = apps.get_model("programas", "PreguntaGlobal")
+    cuestionario, _ = Grupo.objects.get_or_create(
+        clave="cuestionario",
+        defaults={"nombre": "Cuestionario social", "orden": 10, "protegido": False},
+    )
+    Pregunta.objects.filter(grupo__isnull=True).update(grupo=cuestionario)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programas", "0056_padron_convocatoria_identidad"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GrupoRequisito",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("creado", models.DateTimeField(auto_now_add=True)),
+                ("modificado", models.DateTimeField(auto_now=True)),
+                ("clave", models.SlugField(max_length=60, unique=True, verbose_name="Clave")),
+                ("nombre", models.CharField(max_length=120, verbose_name="Nombre")),
+                ("subtitulo", models.CharField(blank=True, max_length=240, verbose_name="Subtítulo")),
+                ("orden", models.PositiveIntegerField(default=0, verbose_name="Orden")),
+                ("protegido", models.BooleanField(default=False, verbose_name="Protegido")),
+                ("condicion_defecto", models.JSONField(blank=True, null=True, verbose_name="Condición por defecto")),
+                (
+                    "canal",
+                    models.CharField(
+                        choices=[("ambos", "Ambos canales"), ("app", "Solo app de campo"), ("link", "Solo link público")],
+                        default="ambos",
+                        max_length=10,
+                        verbose_name="Se pide en",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Grupo de requisitos",
+                "verbose_name_plural": "Grupos de requisitos",
+                "ordering": ["orden", "id"],
+            },
+        ),
+        migrations.AddField(
+            model_name="preguntaglobal",
+            name="grupo",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="preguntas",
+                to="programas.gruporequisito",
+                verbose_name="Grupo",
+            ),
+        ),
+        migrations.AddField(
+            model_name="preguntaglobal",
+            name="origen",
+            field=models.CharField(
+                choices=[
+                    ("pregunta", "Pregunta"),
+                    ("legajo", "Campo del legajo de la persona"),
+                    ("persona_vinculada", "Campo del apoderado (persona vinculada)"),
+                ],
+                default="pregunta",
+                max_length=20,
+                verbose_name="Origen",
+            ),
+        ),
+        migrations.AddField(
+            model_name="preguntaglobal",
+            name="vinculo",
+            field=models.CharField(blank=True, max_length=60, verbose_name="Campo vinculado"),
+        ),
+        migrations.AddField(
+            model_name="preguntaglobal",
+            name="protegido",
+            field=models.BooleanField(default=False, verbose_name="Protegido"),
+        ),
+        migrations.AddField(
+            model_name="preguntaglobal",
+            name="canal",
+            field=models.CharField(
+                choices=[("ambos", "Ambos canales"), ("app", "Solo app de campo"), ("link", "Solo link público")],
+                default="ambos",
+                max_length=10,
+                verbose_name="Se pide en",
+            ),
+        ),
+        migrations.AddField(
+            model_name="requisitonativo",
+            name="canal",
+            field=models.CharField(
+                choices=[("ambos", "Ambos canales"), ("app", "Solo app de campo"), ("link", "Solo link público")],
+                default="ambos",
+                max_length=10,
+                verbose_name="Se pide en",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="formulario",
+            name="celular",
+            field=models.CharField(blank=True, max_length=20, verbose_name="Celular"),
+        ),
+        migrations.AlterField(
+            model_name="formulario",
+            name="email_contacto",
+            field=models.EmailField(blank=True, max_length=254, verbose_name="Correo electrónico"),
+        ),
+        migrations.RunPython(preguntas_al_cuestionario, migrations.RunPython.noop),
+    ]

--- a/programas/models/__init__.py
+++ b/programas/models/__init__.py
@@ -1157,6 +1157,54 @@ class PresentacionCampo(models.TextChoices):
     BUSCADOR = "BUSCADOR", "Buscador con píldoras"
 
 
+class CanalFormulario(models.TextChoices):
+    """En qué canal se pide un requisito o un grupo (Cambio 58, D14).
+
+    Hay preguntas que solo tienen sentido con el territorial adelante (foto del
+    DNI físico) o solo en el link. Vive donde vive el obligatorio: en el
+    catálogo para los requisitos, en el diseño para los campos propios.
+    """
+
+    AMBOS = "ambos", "Ambos canales"
+    APP = "app", "Solo app de campo"
+    LINK = "link", "Solo link público"
+
+    @classmethod
+    def del_relevamiento(cls, relevamiento):
+        return cls.LINK if relevamiento.es_publico else cls.APP
+
+
+class OrigenRequisito(models.TextChoices):
+    """De dónde sale y a dónde va la respuesta de un requisito general (Cambio 58, RN-4).
+
+    - ``PREGUNTA``: lo de siempre, la respuesta va al caso.
+    - ``LEGAJO``: vinculado a un campo del ciudadano que se inscribe; el tipo y
+      las opciones los dicta el legajo, la respuesta se vuelca a la ficha.
+    - ``PERSONA_VINCULADA``: campo de otra persona (el apoderado), resuelta por
+      DNI a su propio legajo.
+    """
+
+    PREGUNTA = "pregunta", "Pregunta"
+    LEGAJO = "legajo", "Campo del legajo de la persona"
+    PERSONA_VINCULADA = "persona_vinculada", "Campo del apoderado (persona vinculada)"
+
+
+# Campos del legajo que un requisito general puede vincular. El tipo y las
+# opciones salen de acá, no del operador (RN-4). ``identidad`` marca los que
+# vienen precargados y en solo lectura cuando la identidad está validada, no
+# se desactivan y no se pueden hacer opcionales; ``solo_lectura`` los que la
+# persona nunca edita (el DNI es la identificación del paso 1).
+VINCULOS_LEGAJO = {
+    "nombre": {"etiqueta": "Nombre", "tipo": TipoCampo.STRING, "opciones": None, "identidad": True},
+    "apellido": {"etiqueta": "Apellido", "tipo": TipoCampo.STRING, "opciones": None, "identidad": True},
+    "dni": {"etiqueta": "DNI", "tipo": TipoCampo.STRING, "opciones": None, "identidad": True, "solo_lectura": True},
+    "fecha_nacimiento": {"etiqueta": "Fecha de nacimiento", "tipo": TipoCampo.DATE, "opciones": None, "identidad": True},
+    "genero": {"etiqueta": "Sexo", "tipo": TipoCampo.SELECTOR, "opciones": ["F", "M"], "identidad": True},
+    "telefono": {"etiqueta": "Celular", "tipo": TipoCampo.STRING, "opciones": None},
+    "email": {"etiqueta": "Correo electrónico", "tipo": TipoCampo.STRING, "opciones": None},
+}
+
+
 class CampoTipoDispositivo(TimeStamped):
     """Campo configurable del formulario propio de un tipo de dispositivo."""
 
@@ -1855,12 +1903,75 @@ class PadronHabilitado(TimeStamped):
         return bool(self.nombre.strip() and self.apellido.strip())
 
 
+class GrupoRequisito(TimeStamped):
+    """Grupo de requisitos generales (Cambio 58, RN-3). Es lo que la persona ve
+    como sección con título; en el constructor es el contenedor de los campos.
+
+    Los protegidos (Datos personales, Contacto, Apoderado) vienen sembrados por
+    ``seed_becas``: se renombran, ordenan y condicionan, pero no se borran.
+    ``condicion_defecto`` es la condición con la que el grupo entra a cada
+    diseño nuevo (el Apoderado nace con «edad < 18», la regla de hoy).
+    """
+
+    clave = models.SlugField(max_length=60, unique=True, verbose_name="Clave")
+    nombre = models.CharField(max_length=120, verbose_name="Nombre")
+    subtitulo = models.CharField(max_length=240, blank=True, verbose_name="Subtítulo")
+    orden = models.PositiveIntegerField(default=0, verbose_name="Orden")
+    protegido = models.BooleanField(default=False, verbose_name="Protegido")
+    condicion_defecto = models.JSONField(null=True, blank=True, verbose_name="Condición por defecto")
+    canal = models.CharField(
+        max_length=10,
+        choices=CanalFormulario.choices,
+        default=CanalFormulario.AMBOS,
+        verbose_name="Se pide en",
+    )
+
+    class Meta:
+        verbose_name = "Grupo de requisitos"
+        verbose_name_plural = "Grupos de requisitos"
+        ordering = ["orden", "id"]
+
+    def __str__(self):
+        return self.nombre
+
+    def save(self, *args, **kwargs):
+        if not self.clave:
+            self.clave = f"grupo-{uuid.uuid4().hex[:8]}"
+        super().save(*args, **kwargs)
+
+
 class PreguntaGlobal(TimeStamped):
-    """Pregunta del cuestionario social (requisito general); aplica a todos los
-    formularios. Los adjuntos obligatorios fijos se modelan como tipo ARCHIVO."""
+    """Requisito general: aplica a todos los formularios. Desde el Cambio 58 se
+    agrupa y puede ser una pregunta (respuesta al caso), un campo del legajo de
+    la persona o un campo del apoderado. Los adjuntos obligatorios fijos se
+    modelan como tipo ARCHIVO."""
 
     texto = models.CharField(max_length=500, verbose_name="Texto")
     tipo = models.CharField(max_length=20, choices=TipoCampo.choices, verbose_name="Tipo de campo")
+    grupo = models.ForeignKey(
+        GrupoRequisito,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="preguntas",
+        verbose_name="Grupo",
+    )
+    origen = models.CharField(
+        max_length=20,
+        choices=OrigenRequisito.choices,
+        default=OrigenRequisito.PREGUNTA,
+        verbose_name="Origen",
+    )
+    # Nombre del campo del legajo (o del apoderado) al que está vinculado; vacío
+    # para las preguntas. Con ``origen`` identifica a los protegidos.
+    vinculo = models.CharField(max_length=60, blank=True, verbose_name="Campo vinculado")
+    protegido = models.BooleanField(default=False, verbose_name="Protegido")
+    canal = models.CharField(
+        max_length=10,
+        choices=CanalFormulario.choices,
+        default=CanalFormulario.AMBOS,
+        verbose_name="Se pide en",
+    )
     opciones = models.JSONField(
         null=True,
         blank=True,
@@ -1892,6 +2003,31 @@ class PreguntaGlobal(TimeStamped):
     def __str__(self):
         return self.texto
 
+    def save(self, *args, **kwargs):
+        # RN-3 del Cambio 58: todo campo vive en un grupo. Sin uno explícito va
+        # al Cuestionario social (si el seed ya lo creó).
+        if self.grupo_id is None:
+            self.grupo = GrupoRequisito.objects.filter(clave="cuestionario").first()
+        super().save(*args, **kwargs)
+
+    @property
+    def es_pregunta(self):
+        return self.origen == OrigenRequisito.PREGUNTA
+
+    @property
+    def vinculo_info(self):
+        return {} if self.es_pregunta else VINCULOS_LEGAJO.get(self.vinculo, {})
+
+    @property
+    def es_identidad(self):
+        """Los campos de identidad de la persona (no del apoderado): no se
+        desactivan ni se hacen opcionales (D12)."""
+        return self.origen == OrigenRequisito.LEGAJO and bool(self.vinculo_info.get("identidad"))
+
+    @property
+    def solo_lectura(self):
+        return bool(self.vinculo_info.get("solo_lectura"))
+
 
 class RequisitoNativo(TimeStamped):
     """Requisito configurable de un programa, segmento o subsegmento. Genera un
@@ -1916,6 +2052,12 @@ class RequisitoNativo(TimeStamped):
         blank=True,
         verbose_name="Presentación",
         help_text="Solo para Selector / Selector múltiple: cómo elige la persona entre las opciones.",
+    )
+    canal = models.CharField(
+        max_length=10,
+        choices=CanalFormulario.choices,
+        default=CanalFormulario.AMBOS,
+        verbose_name="Se pide en",
     )
     programa = models.ForeignKey(
         ProgramaSiis,
@@ -2149,9 +2291,10 @@ class Formulario(TimeStamped):
         verbose_name="Motivo de la validación manual",
     )
 
-    # Bloque C — Contacto (manual, obligatorio)
-    celular = models.CharField(max_length=20, verbose_name="Celular")
-    email_contacto = models.EmailField(verbose_name="Correo electrónico")
+    # Bloque C — Contacto. Desde el Cambio 58 (D9) la obligatoriedad la decide
+    # el catálogo (grupo Contacto), no el modelo: pueden quedar vacíos.
+    celular = models.CharField(max_length=20, blank=True, verbose_name="Celular")
+    email_contacto = models.EmailField(blank=True, verbose_name="Correo electrónico")
 
     # Bloque D — Apoderado (solo si el ciudadano es menor; RN-22)
     apoderado_nombre = models.CharField(max_length=120, blank=True, verbose_name="Nombre del apoderado")

--- a/programas/services/becas.py
+++ b/programas/services/becas.py
@@ -13,32 +13,52 @@ from django.db.models.functions import Cast, Replace
 from legajos.models import Ciudadano
 from programas.models import (
     AsignacionCoordinador,
+    CanalFormulario,
+    OrigenRequisito,
     PreguntaGlobal,
     RequisitoNativo,
     Segmento,
 )
 
 
-def get_campos_formulario(convocatoria):
+def _filtro_canal(canal):
+    """Un requisito se pide en su canal o en ambos (Cambio 58, D14)."""
+    if not canal:
+        return models.Q()
+    return models.Q(canal=CanalFormulario.AMBOS) | models.Q(canal=canal)
+
+
+def get_campos_formulario(convocatoria, canal=None):
     """Devuelve ``(globales, requisitos)`` para renderizar el formulario.
 
-    - ``globales``: ``PreguntaGlobal`` activas, ordenadas (RN-31).
+    - ``globales``: ``PreguntaGlobal`` activas, ordenadas (RN-31). Solo las de
+      origen *pregunta*: los campos vinculados al legajo (Datos personales,
+      Contacto, Apoderado; Cambio 58) siguen rindiéndose como bloques fijos
+      hasta que el diseño por convocatoria los consuma.
     - ``requisitos``: ``RequisitoNativo`` del programa del segmento (los heredan
       todos sus segmentos), del segmento (subsegmento=None) y, si la convocatoria
       tiene subsegmento, también los del subsegmento (herencia; RN-32).
+    - ``canal``: ``CanalFormulario.APP`` o ``LINK`` filtra lo que no se pide en
+      ese canal; ``None`` devuelve todo.
     """
-    globales = PreguntaGlobal.objects.filter(activo=True).order_by("orden", "id")
+    globales = (
+        PreguntaGlobal.objects.filter(activo=True, origen=OrigenRequisito.PREGUNTA)
+        .filter(_filtro_canal(canal))
+        .select_related("grupo")
+        .order_by("orden", "id")
+    )
     filtros = models.Q(segmento_id=convocatoria.segmento_id, subsegmento__isnull=True)
     if convocatoria.subsegmento_id:
         filtros |= models.Q(subsegmento_id=convocatoria.subsegmento_id)
     programa_id = convocatoria.segmento.programa_id
     if programa_id:
         filtros |= models.Q(programa_id=programa_id)
-    requisitos = RequisitoNativo.objects.filter(filtros).order_by("orden", "id")
+    requisitos = RequisitoNativo.objects.filter(filtros).filter(_filtro_canal(canal)).order_by("orden", "id")
     return globales, requisitos
 
 
 def _campo_dict(obj, alcance):
+    grupo = getattr(obj, "grupo", None)
     return {
         "id": obj.pk,
         "texto": obj.texto,
@@ -51,19 +71,27 @@ def _campo_dict(obj, alcance):
         "orden": obj.orden,
         "alcance": alcance,
         "subsegmento_id": getattr(obj, "subsegmento_id", None),
+        # Cambio 58: canal, origen y grupo del catálogo. La app vieja los ignora.
+        "canal": obj.canal,
+        "origen": getattr(obj, "origen", OrigenRequisito.PREGUNTA),
+        "vinculo": getattr(obj, "vinculo", ""),
+        "grupo": {"clave": grupo.clave, "nombre": grupo.nombre} if grupo is not None else None,
     }
 
 
 def definicion_formulario(relevamiento):
-    """Definición del formulario para la app de campo (#82).
+    """Definición del formulario para la app de campo (#82) y el link público.
 
     Devuelve preguntas globales y requisitos (con herencia de subsegmento) según
-    la convocatoria del relevamiento, más el flag ``requiere_gps`` del segmento.
+    la convocatoria del relevamiento, filtrados por el canal del relevamiento
+    (Cambio 58), más el flag ``requiere_gps`` del segmento.
     """
     convocatoria = relevamiento.convocatoria
-    globales, requisitos = get_campos_formulario(convocatoria)
+    canal = CanalFormulario.del_relevamiento(relevamiento)
+    globales, requisitos = get_campos_formulario(convocatoria, canal=canal)
     return {
         "requiere_gps": convocatoria.segmento.requiere_gps,
+        "canal": canal,
         "globales": [_campo_dict(p, "global") for p in globales],
         "requisitos": [_campo_dict(r, _alcance_requisito(r)) for r in requisitos],
     }

--- a/programas/templates/programas/becas/config/_preguntas_table.html
+++ b/programas/templates/programas/becas/config/_preguntas_table.html
@@ -6,6 +6,7 @@
       <tr class="bg-secondary border-b border-base">
         <th class="px-4 py-[11px] text-right font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Orden</th>
         <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Texto</th>
+        <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Grupo</th>
         <th class="px-4 py-[11px] text-left font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Tipo</th>
         <th class="px-4 py-[11px] text-center font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Obligatorio</th>
         <th class="px-4 py-[11px] text-center font-bold uppercase tracking-[.05em] text-body-subtle" style="font-size:11px;">Estado</th>
@@ -16,9 +17,17 @@
       {% for p in preguntas %}
       <tr class="hover:bg-secondary">
         <td class="px-4 py-[13px] text-sm border-t border-light text-body-subtle text-right font-semibold">{{ p.orden }}</td>
-        <td class="px-4 py-[13px] text-sm border-t border-light text-heading font-medium">{{ p.texto }}</td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-heading font-medium">
+          {{ p.texto }}
+          {% if p.protegido %}<span class="badge badge-info ml-1" title="Viene con el sistema: se renombra y se mueve, no se borra"><i class="fas fa-lock" style="font-size:10px;"></i> Protegido</span>{% endif %}
+        </td>
+        <td class="px-4 py-[13px] text-sm border-t border-light text-body">{{ p.grupo.nombre|default:"—" }}</td>
         <td class="px-4 py-[13px] text-sm border-t border-light">
-          <span class="badge badge-white">{{ p.get_tipo_display }}</span>
+          <div class="flex flex-wrap gap-1">
+            <span class="badge badge-white">{{ p.get_tipo_display }}</span>
+            {% if not p.es_pregunta %}<span class="badge badge-info">{% if p.origen == "legajo" %}Legajo → {{ p.vinculo }}{% else %}Apoderado → {{ p.vinculo }}{% endif %}</span>{% endif %}
+            {% if p.canal != "ambos" %}<span class="badge badge-white">{{ p.get_canal_display }}</span>{% endif %}
+          </div>
         </td>
         <td class="px-4 py-[13px] text-sm border-t border-light text-center">
           {% if p.obligatorio %}
@@ -46,21 +55,29 @@
                 '{{ p.activo|yesno:'True,False' }}',
                 {{ p.orden }},
                 [{% for o in p.opciones %}'{{ o|escapejs }}'{% if not forloop.last %},{% endif %}{% endfor %}],
-                '{{ p.presentacion }}'
+                '{{ p.presentacion }}',
+                '{{ p.grupo_id|default_if_none:'' }}',
+                '{{ p.canal }}',
+                {{ p.protegido|yesno:'true,false' }},
+                {{ p.es_identidad|yesno:'true,false' }}
               )">
               <i class="fas fa-edit"></i>
             </button>
+            {% if not p.es_identidad %}
             <button type="button" class="text-body-subtle hover:text-fg-warning p-1" title="Activar/Desactivar"
                     data-confirm-url="{% url 'becas:pregunta_toggle' p.pk %}"
                     data-confirm-title="{% if p.activo %}¿Desactivar pregunta?{% else %}¿Activar pregunta?{% endif %}"
                     data-confirm-text="{{ p.texto }}" data-confirm-icon="question" data-confirm-ok="Sí">
               <i class="fas fa-power-off"></i>
             </button>
+            {% endif %}
+            {% if not p.protegido %}
             <button type="button" class="text-body-subtle hover:text-fg-danger p-1" title="Eliminar"
                     data-confirm-url="{% url 'becas:pregunta_eliminar' p.pk %}"
                     data-confirm-title="¿Eliminar pregunta?" data-confirm-text="{{ p.texto }}" data-confirm-ok="Sí, eliminar">
               <i class="fas fa-trash"></i>
             </button>
+            {% endif %}
             {% endif %}
           </div>
         </td>

--- a/programas/templates/programas/becas/config/_requisitos_panel.html
+++ b/programas/templates/programas/becas/config/_requisitos_panel.html
@@ -37,7 +37,8 @@
                 '{{ req.obligatorio|yesno:'True,False' }}',
                 {{ req.orden }},
                 [{% for o in req.opciones %}'{{ o|escapejs }}'{% if not forloop.last %},{% endif %}{% endfor %}],
-                '{{ req.presentacion }}'
+                '{{ req.presentacion }}',
+                '{{ req.canal }}'
               )">
               <i class="fas fa-edit"></i>
             </button>

--- a/programas/templates/programas/becas/config/_requisitos_programa_panel.html
+++ b/programas/templates/programas/becas/config/_requisitos_programa_panel.html
@@ -37,7 +37,8 @@
                 '{{ req.obligatorio|yesno:'True,False' }}',
                 {{ req.orden }},
                 [{% for o in req.opciones %}'{{ o|escapejs }}'{% if not forloop.last %},{% endif %}{% endfor %}],
-                '{{ req.presentacion }}'
+                '{{ req.presentacion }}',
+                '{{ req.canal }}'
               )">
               <i class="fas fa-edit"></i>
             </button>

--- a/programas/templates/programas/becas/config/_requisitos_propios_panel.html
+++ b/programas/templates/programas/becas/config/_requisitos_propios_panel.html
@@ -37,7 +37,8 @@
                 '{{ req.obligatorio|yesno:'True,False' }}',
                 {{ req.orden }},
                 [{% for o in req.opciones %}'{{ o|escapejs }}'{% if not forloop.last %},{% endif %}{% endfor %}],
-                '{{ req.presentacion }}'
+                '{{ req.presentacion }}',
+                '{{ req.canal }}'
               )">
               <i class="fas fa-edit"></i>
             </button>

--- a/programas/templates/programas/becas/config/pregunta_list.html
+++ b/programas/templates/programas/becas/config/pregunta_list.html
@@ -10,12 +10,15 @@
        modalEdit: false,
        createTipo: 'STRING',
        createPresentacion: 'LISTA',
+       createGrupo: '', createCanal: 'ambos',
        editUrl: '', editTexto: '', editTipo: '', editObl: 'True', editActivo: 'True', editOrden: 0, editOpciones: '',
-       editPresentacion: 'LISTA',
-       openEdit(url, texto, tipo, obl, activo, orden, opc, presentacion) {
+       editPresentacion: 'LISTA', editGrupo: '', editCanal: 'ambos', editProtegido: false, editIdentidad: false,
+       openEdit(url, texto, tipo, obl, activo, orden, opc, presentacion, grupo, canal, protegido, identidad) {
          this.editUrl = url; this.editTexto = texto; this.editTipo = tipo;
          this.editObl = obl; this.editActivo = activo; this.editOrden = orden; this.editOpciones = (opc || []).join('\n');
          this.editPresentacion = presentacion || 'LISTA';
+         this.editGrupo = grupo || ''; this.editCanal = canal || 'ambos';
+         this.editProtegido = !!protegido; this.editIdentidad = !!identidad;
          this.modalEdit = true;
        }
      }"
@@ -130,6 +133,20 @@
             </select>
             <p class="text-xs text-body-subtle mt-1">Cómo elige la persona entre las opciones.</p>
           </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Grupo</label>
+            <select name="grupo" x-model="createGrupo" class="nodo-field">
+              <option value="">Sin grupo (Cuestionario social)</option>
+              {% for g in grupos %}<option value="{{ g.pk }}">{{ g.nombre }}</option>{% endfor %}
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Se pide en</label>
+            <select name="canal" x-model="createCanal" class="nodo-field">
+              {% for val, label in canal_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+            </select>
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
+          </div>
         </div>
 
         {% comment %}FOOTER{% endcomment %}
@@ -177,20 +194,20 @@
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
               <label class="block text-sm font-medium text-heading mb-1">Tipo de campo <span class="text-fg-danger">*</span></label>
-              <select name="tipo" x-model="editTipo" class="nodo-field">
+              <select name="tipo" x-model="editTipo" :disabled="editProtegido" class="nodo-field">
                 {% for val, label in tipo_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
               </select>
             </div>
             <div>
               <label class="block text-sm font-medium text-heading mb-1">Obligatorio</label>
-              <select name="obligatorio" x-model="editObl" class="nodo-field">
+              <select name="obligatorio" x-model="editObl" :disabled="editIdentidad" class="nodo-field">
                 <option value="True">Obligatorio</option>
                 <option value="False">Opcional</option>
               </select>
             </div>
             <div>
               <label class="block text-sm font-medium text-heading mb-1">Estado</label>
-              <select name="activo" x-model="editActivo" class="nodo-field">
+              <select name="activo" x-model="editActivo" :disabled="editIdentidad" class="nodo-field">
                 <option value="True">Activa</option>
                 <option value="False">Inactiva</option>
               </select>
@@ -203,7 +220,8 @@
           </div>
           <div x-show="editTipo === 'SELECTOR' || editTipo === 'SELECTOR_MULTIPLE'">
             <label class="block text-sm font-medium text-heading mb-1">Opciones (una por línea)</label>
-            <textarea name="opciones_texto" x-model="editOpciones" rows="4" class="nodo-field"></textarea>
+            <textarea name="opciones_texto" x-model="editOpciones" :disabled="editProtegido" rows="4" class="nodo-field"></textarea>
+            <p x-show="editProtegido" class="text-xs text-body-subtle mt-1">El tipo y las opciones de un campo del legajo los dicta el legajo.</p>
           </div>
           <div x-show="editTipo === 'SELECTOR' || editTipo === 'SELECTOR_MULTIPLE'">
             <label class="block text-sm font-medium text-heading mb-1">Presentación</label>
@@ -211,6 +229,20 @@
               {% for val, label in presentacion_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
             </select>
             <p class="text-xs text-body-subtle mt-1">Cómo elige la persona entre las opciones.</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Grupo</label>
+            <select name="grupo" x-model="editGrupo" class="nodo-field">
+              <option value="">Sin grupo (Cuestionario social)</option>
+              {% for g in grupos %}<option value="{{ g.pk }}">{{ g.nombre }}</option>{% endfor %}
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Se pide en</label>
+            <select name="canal" x-model="editCanal" class="nodo-field">
+              {% for val, label in canal_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+            </select>
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
           </div>
         </div>
 

--- a/programas/templates/programas/becas/config/programa_detail.html
+++ b/programas/templates/programas/becas/config/programa_detail.html
@@ -19,8 +19,8 @@
        editReqObligatorio: 'True',
        editReqOrden: 0,
        editReqOpciones: '',
-       editReqPresentacion: 'LISTA',
-       openReqEdit(url, texto, tipo, obligatorio, orden, opciones, presentacion) {
+       editReqPresentacion: 'LISTA', editReqCanal: 'ambos',
+       openReqEdit(url, texto, tipo, obligatorio, orden, opciones, presentacion, canal) {
          this.editReqUrl = url;
          this.editReqTexto = texto;
          this.editReqTipo = tipo;
@@ -28,6 +28,7 @@
          this.editReqOrden = orden;
          this.editReqOpciones = (opciones || []).join('\n');
          this.editReqPresentacion = presentacion || 'LISTA';
+         this.editReqCanal = canal || 'ambos';
          this.modalReqEdit = true;
        },
        openInfo(datos) {
@@ -319,6 +320,12 @@
             <p class="text-xs text-body-subtle mt-1">{{ form_requisito.presentacion.help_text }}</p>
             <p class="mt-1 text-xs text-fg-danger hidden" data-error="presentacion"></p>
           </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">{{ form_requisito.canal.label }}</label>
+            {{ form_requisito.canal }}
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="canal"></p>
+          </div>
         </div>
         <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">
           <button type="button" @click="modalReq=false" class="btn-nodo btn-tertiary btn-base">Cancelar</button>
@@ -389,6 +396,13 @@
               {% for val, label in presentacion_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
             </select>
             <p class="text-xs text-body-subtle mt-1">Cómo elige la persona entre las opciones.</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Se pide en</label>
+            <select name="canal" x-model="editReqCanal" class="nodo-field">
+              {% for val, label in canal_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+            </select>
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
           </div>
         </div>
         <div class="flex justify-end gap-3 px-6 py-4 border-t bg-secondary" style="border-color:var(--border-light)">

--- a/programas/templates/programas/becas/config/segmento_detail.html
+++ b/programas/templates/programas/becas/config/segmento_detail.html
@@ -26,8 +26,8 @@
        editReqObligatorio: 'True',
        editReqOrden: 0,
        editReqOpciones: '',
-       editReqPresentacion: 'LISTA',
-       openReqEdit(url, texto, tipo, obligatorio, orden, opciones, presentacion) {
+       editReqPresentacion: 'LISTA', editReqCanal: 'ambos',
+       openReqEdit(url, texto, tipo, obligatorio, orden, opciones, presentacion, canal) {
          this.editReqUrl = url;
          this.editReqTexto = texto;
          this.editReqTipo = tipo;
@@ -35,6 +35,7 @@
          this.editReqOrden = orden;
          this.editReqOpciones = (opciones || []).join('\n');
          this.editReqPresentacion = presentacion || 'LISTA';
+         this.editReqCanal = canal || 'ambos';
          this.modalReqEdit = true;
        },
        openSubEdit(url, nombre, desc, cupo, referente) {
@@ -636,6 +637,12 @@
             <p class="text-xs text-body-subtle mt-1">{{ form_requisito.presentacion.help_text }}</p>
             <p class="mt-1 text-xs text-fg-danger hidden" data-error="presentacion"></p>
           </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">{{ form_requisito.canal.label }}</label>
+            {{ form_requisito.canal }}
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="canal"></p>
+          </div>
         </div>
 
         {% comment %}FOOTER{% endcomment %}
@@ -714,6 +721,13 @@
               {% for val, label in presentacion_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
             </select>
             <p class="text-xs text-body-subtle mt-1">Cómo elige la persona entre las opciones.</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-heading mb-1">Se pide en</label>
+            <select name="canal" x-model="editReqCanal" class="nodo-field">
+              {% for val, label in canal_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+            </select>
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
           </div>
         </div>
 

--- a/programas/templates/programas/becas/config/subsegmento_detail.html
+++ b/programas/templates/programas/becas/config/subsegmento_detail.html
@@ -15,8 +15,8 @@
        editReqObligatorio: 'True',
        editReqOrden: 0,
        editReqOpciones: '',
-       editReqPresentacion: 'LISTA',
-       openReqEdit(url, texto, tipo, obligatorio, orden, opciones, presentacion) {
+       editReqPresentacion: 'LISTA', editReqCanal: 'ambos',
+       openReqEdit(url, texto, tipo, obligatorio, orden, opciones, presentacion, canal) {
          this.editReqUrl = url;
          this.editReqTexto = texto;
          this.editReqTipo = tipo;
@@ -24,6 +24,7 @@
          this.editReqOrden = orden;
          this.editReqOpciones = (opciones || []).join('\n');
          this.editReqPresentacion = presentacion || 'LISTA';
+         this.editReqCanal = canal || 'ambos';
          this.modalReqEdit = true;
        }
      }"
@@ -195,6 +196,12 @@
             <p class="text-xs text-body-subtle mt-1">{{ form_requisito.presentacion.help_text }}</p>
             <p class="mt-1 text-xs text-fg-danger hidden" data-error="presentacion"></p>
           </div>
+          <div>
+            <label class="block text-[13px] font-semibold text-heading mb-1.5">{{ form_requisito.canal.label }}</label>
+            {{ form_requisito.canal }}
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
+            <p class="mt-1 text-xs text-fg-danger hidden" data-error="canal"></p>
+          </div>
 
           <p class="text-xs text-fg-danger hidden" data-error="__all__"></p>
         </div>
@@ -287,6 +294,13 @@
               {% for val, label in presentacion_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
             </select>
             <p class="text-xs text-body-subtle mt-1">Cómo elige la persona entre las opciones.</p>
+          </div>
+          <div>
+            <label class="block text-[13px] font-semibold text-heading mb-1.5">Se pide en</label>
+            <select name="canal" x-model="editReqCanal" class="nodo-field w-full">
+              {% for val, label in canal_choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}
+            </select>
+            <p class="text-xs text-body-subtle mt-1">Ambos canales, solo la app de campo o solo el link público.</p>
           </div>
 
           <p class="text-xs text-fg-danger hidden" data-error="__all__"></p>

--- a/programas/tests/test_catalogo_grupos.py
+++ b/programas/tests/test_catalogo_grupos.py
@@ -1,0 +1,253 @@
+"""Catálogo de requisitos generales agrupado, con orígenes y canal (Cambio 58,
+Fase 1: tasks #336 y #338, análisis #326)."""
+
+from datetime import date, timedelta
+from io import StringIO
+
+from django.contrib.auth.models import Group, User
+from django.core.management import call_command
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from programas.forms import PreguntaGlobalForm, RequisitoNativoForm
+from programas.management.commands.seed_becas import ROL_ADMIN
+from programas.models import (
+    VINCULOS_LEGAJO,
+    CanalFormulario,
+    Convocatoria,
+    GrupoRequisito,
+    OrigenRequisito,
+    PreguntaGlobal,
+    Relevamiento,
+    RequisitoNativo,
+    Segmento,
+    TipoCampo,
+)
+from programas.services.becas import definicion_formulario, get_campos_formulario
+
+
+def _seed():
+    call_command("seed_becas", stdout=StringIO())
+
+
+class SeedCatalogoProtegidoTests(TestCase):
+    def test_siembra_los_grupos_y_los_campos_vinculados(self):
+        _seed()
+        claves = list(GrupoRequisito.objects.order_by("orden").values_list("clave", flat=True))
+        self.assertEqual(claves, ["datos_personales", "contacto", "apoderado", "cuestionario"])
+        self.assertEqual(GrupoRequisito.objects.filter(protegido=True).count(), 3)
+        apoderado = GrupoRequisito.objects.get(clave="apoderado")
+        self.assertEqual(apoderado.condicion_defecto["reglas"][0]["op"], "edad_menor")
+        self.assertEqual(apoderado.condicion_defecto["reglas"][0]["valor"], 18)
+
+        legajo = PreguntaGlobal.objects.filter(origen=OrigenRequisito.LEGAJO)
+        self.assertEqual(
+            set(legajo.values_list("vinculo", flat=True)),
+            {"nombre", "apellido", "dni", "fecha_nacimiento", "genero", "telefono", "email"},
+        )
+        self.assertEqual(PreguntaGlobal.objects.filter(origen=OrigenRequisito.PERSONA_VINCULADA).count(), 5)
+        genero = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="genero")
+        # El tipo y las opciones los dicta el legajo, no el operador (RN-4).
+        self.assertEqual(genero.tipo, TipoCampo.SELECTOR)
+        self.assertEqual(genero.opciones, ["F", "M"])
+        self.assertTrue(genero.protegido)
+        self.assertTrue(genero.es_identidad)
+        email = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="email")
+        self.assertFalse(email.obligatorio)  # D9: el contacto puede ser opcional
+        self.assertFalse(email.es_identidad)
+
+    def test_es_idempotente_y_respeta_lo_editado(self):
+        _seed()
+        antes = PreguntaGlobal.objects.count()
+        celular = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="telefono")
+        celular.texto = "Tu celular"
+        celular.save(update_fields=["texto"])
+        _seed()
+        self.assertEqual(PreguntaGlobal.objects.count(), antes)
+        celular.refresh_from_db()
+        self.assertEqual(celular.texto, "Tu celular")
+
+    def test_las_preguntas_sin_grupo_caen_en_el_cuestionario(self):
+        suelta = PreguntaGlobal.objects.create(texto="¿Trabajás?", tipo=TipoCampo.STRING)
+        _seed()
+        suelta.refresh_from_db()
+        self.assertEqual(suelta.grupo.clave, "cuestionario")
+        self.assertTrue(suelta.es_pregunta)
+        self.assertFalse(suelta.protegido)
+
+    def test_los_ordenes_de_los_protegidos_no_chocan_con_los_existentes(self):
+        PreguntaGlobal.objects.create(texto="Ocupa el 1", tipo=TipoCampo.STRING, orden=1)
+        _seed()
+        ordenes = list(PreguntaGlobal.objects.values_list("orden", flat=True))
+        self.assertEqual(len(ordenes), len(set(ordenes)))
+
+    def test_el_registro_de_vinculos_cubre_lo_sembrado(self):
+        for vinculo in ("nombre", "apellido", "dni", "fecha_nacimiento", "genero", "telefono", "email"):
+            self.assertIn(vinculo, VINCULOS_LEGAJO)
+        self.assertTrue(VINCULOS_LEGAJO["dni"]["solo_lectura"])
+
+
+class FormProtegidoTests(TestCase):
+    def setUp(self):
+        _seed()
+        self.dni = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="dni")
+        self.email = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="email")
+        self.contacto = GrupoRequisito.objects.get(clave="contacto")
+
+    def _data(self, pregunta, **extra):
+        data = {
+            "texto": pregunta.texto,
+            "tipo": pregunta.tipo,
+            "presentacion": pregunta.presentacion,
+            "grupo": pregunta.grupo_id,
+            "canal": pregunta.canal,
+            "orden": pregunta.orden,
+            "obligatorio": "on" if pregunta.obligatorio else "",
+            "activo": "on" if pregunta.activo else "",
+        }
+        data.update(extra)
+        return data
+
+    def test_un_protegido_no_cambia_de_tipo_ni_de_opciones_por_post(self):
+        form = PreguntaGlobalForm(
+            self._data(self.dni, tipo=TipoCampo.SELECTOR, opciones_texto="A\nB", texto="Documento"),
+            instance=self.dni,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        guardado = form.save()
+        self.assertEqual(guardado.tipo, TipoCampo.STRING)
+        self.assertIsNone(guardado.opciones)
+        self.assertEqual(guardado.texto, "Documento")  # la etiqueta sí se edita
+        self.assertTrue(form.fields["tipo"].disabled)
+
+    def test_la_identidad_no_se_hace_opcional_ni_se_desactiva(self):
+        form = PreguntaGlobalForm(self._data(self.dni, obligatorio="", activo=""), instance=self.dni)
+        self.assertTrue(form.is_valid(), form.errors)
+        guardado = form.save()
+        self.assertTrue(guardado.obligatorio)
+        self.assertTrue(guardado.activo)
+
+    def test_el_contacto_si_puede_ser_opcional_y_cambiar_de_grupo(self):
+        datos = GrupoRequisito.objects.get(clave="datos_personales")
+        form = PreguntaGlobalForm(self._data(self.email, obligatorio="", grupo=datos.pk, canal="link"), instance=self.email)
+        self.assertTrue(form.is_valid(), form.errors)
+        guardado = form.save()
+        self.assertFalse(guardado.obligatorio)
+        self.assertEqual(guardado.grupo, datos)
+        self.assertEqual(guardado.canal, CanalFormulario.LINK)
+
+    def test_una_pregunta_nueva_sin_grupo_va_al_cuestionario(self):
+        form = PreguntaGlobalForm(
+            {"texto": "¿Tenés obra social?", "tipo": TipoCampo.STRING, "canal": "ambos", "obligatorio": "on", "activo": "on"}
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.save().grupo.clave, "cuestionario")
+
+    def test_el_requisito_nativo_declara_canal(self):
+        seg = Segmento.objects.create(nombre="Seg", cupo_maximo=10)
+        form = RequisitoNativoForm(
+            {"texto": "Foto del DNI físico", "tipo": TipoCampo.ARCHIVO, "canal": "app", "obligatorio": "True"},
+            segmento=seg,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.save(commit=False).canal, CanalFormulario.APP)
+
+
+class VistasProtegidasTests(TestCase):
+    def setUp(self):
+        _seed()
+        self.admin = User.objects.create_user("admin_cat", password="x")
+        self.admin.groups.add(Group.objects.get(name=ROL_ADMIN))
+        self.client.force_login(self.admin)
+        self.dni = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="dni")
+        self.email = PreguntaGlobal.objects.get(origen=OrigenRequisito.LEGAJO, vinculo="email")
+
+    def test_no_se_elimina_un_protegido(self):
+        self.client.post(reverse("becas:pregunta_eliminar", args=[self.dni.pk]))
+        self.assertTrue(PreguntaGlobal.objects.filter(pk=self.dni.pk).exists())
+
+    def test_no_se_desactiva_la_identidad(self):
+        self.client.post(reverse("becas:pregunta_toggle", args=[self.dni.pk]))
+        self.dni.refresh_from_db()
+        self.assertTrue(self.dni.activo)
+
+    def test_el_contacto_si_se_desactiva(self):
+        self.client.post(reverse("becas:pregunta_toggle", args=[self.email.pk]))
+        self.email.refresh_from_db()
+        self.assertFalse(self.email.activo)
+
+    def test_una_pregunta_comun_se_elimina(self):
+        comun = PreguntaGlobal.objects.create(texto="X", tipo=TipoCampo.STRING)
+        self.client.post(reverse("becas:pregunta_eliminar", args=[comun.pk]))
+        self.assertFalse(PreguntaGlobal.objects.filter(pk=comun.pk).exists())
+
+
+class DefinicionPorCanalTests(TestCase):
+    """La definición filtra por el canal del relevamiento y, hasta que el
+    diseño por convocatoria los consuma, deja afuera los campos vinculados
+    (siguen siendo bloques fijos en el link y en la app)."""
+
+    def setUp(self):
+        _seed()
+        self.segmento = Segmento.objects.create(nombre="Seg", cupo_maximo=100)
+        self.convocatoria = Convocatoria.objects.create(
+            nombre="Conv", segmento=self.segmento, fecha_inicio=date(2026, 1, 1), fecha_fin=date(2026, 12, 31)
+        )
+        self.territorial = User.objects.create_user("terri_canal")
+        self.rel_app = Relevamiento.objects.create(
+            convocatoria=self.convocatoria,
+            territorial=self.territorial,
+            fecha_asignada=timezone.now(),
+            zona="Zona",
+        )
+        self.rel_link = Relevamiento.objects.create(
+            convocatoria=self.convocatoria,
+            tipo=Relevamiento.Tipo.PUBLICO,
+            fecha_asignada=timezone.now() - timedelta(days=1),
+            fecha_hasta=timezone.now() + timedelta(days=10),
+        )
+        PreguntaGlobal.objects.create(texto="Solo app", tipo=TipoCampo.ARCHIVO, canal="app", orden=501)
+        PreguntaGlobal.objects.create(texto="Solo link", tipo=TipoCampo.STRING, canal="link", orden=502)
+        PreguntaGlobal.objects.create(texto="Ambos", tipo=TipoCampo.STRING, canal="ambos", orden=503)
+        RequisitoNativo.objects.create(texto="Req app", tipo=TipoCampo.STRING, segmento=self.segmento, canal="app", orden=1)
+        RequisitoNativo.objects.create(texto="Req ambos", tipo=TipoCampo.STRING, segmento=self.segmento, canal="ambos", orden=2)
+
+    def _textos(self, definicion, clave):
+        return [c["texto"] for c in definicion[clave]]
+
+    def test_la_app_recibe_lo_de_app_y_lo_de_ambos(self):
+        definicion = definicion_formulario(self.rel_app)
+        self.assertEqual(definicion["canal"], "app")
+        globales = self._textos(definicion, "globales")
+        self.assertIn("Solo app", globales)
+        self.assertIn("Ambos", globales)
+        self.assertNotIn("Solo link", globales)
+        self.assertEqual(self._textos(definicion, "requisitos"), ["Req app", "Req ambos"])
+
+    def test_el_link_recibe_lo_de_link_y_lo_de_ambos(self):
+        definicion = definicion_formulario(self.rel_link)
+        self.assertEqual(definicion["canal"], "link")
+        globales = self._textos(definicion, "globales")
+        self.assertIn("Solo link", globales)
+        self.assertNotIn("Solo app", globales)
+        self.assertEqual(self._textos(definicion, "requisitos"), ["Req ambos"])
+
+    def test_los_campos_vinculados_no_entran_como_preguntas(self):
+        """Hasta el diseño por convocatoria, nombre/apellido/etc. siguen siendo
+        bloques fijos: si entraran acá se pedirían dos veces."""
+        definicion = definicion_formulario(self.rel_link)
+        for campo in definicion["globales"]:
+            self.assertEqual(campo["origen"], "pregunta")
+        self.assertNotIn("DNI", self._textos(definicion, "globales"))
+
+    def test_cada_campo_lleva_canal_origen_y_grupo(self):
+        campo = next(c for c in definicion_formulario(self.rel_app)["globales"] if c["texto"] == "Ambos")
+        self.assertEqual(campo["canal"], "ambos")
+        self.assertEqual(campo["origen"], "pregunta")
+        self.assertEqual(campo["grupo"]["clave"], "cuestionario")
+
+    def test_sin_canal_devuelve_todo(self):
+        globales, requisitos = get_campos_formulario(self.convocatoria)
+        self.assertEqual({p.canal for p in globales} >= {"app", "link", "ambos"}, True)
+        self.assertEqual(requisitos.count(), 2)

--- a/programas/views/configuracion.py
+++ b/programas/views/configuracion.py
@@ -33,6 +33,8 @@ from programas.forms import (
 )
 from programas.models import (
     AsignacionCoordinador,
+    CanalFormulario,
+    GrupoRequisito,
     PreguntaGlobal,
     PresentacionCampo,
     ProgramaSiis,
@@ -252,6 +254,7 @@ class ProgramaSiisDetailView(CapacidadRequeridaMixin, LoginRequiredMixin, Detail
         ctx["form_segmento"] = SegmentoCreateForm(initial={"programa": programa.pk})
         ctx["form_requisito"] = RequisitoNativoForm(programa=programa)
         ctx["presentacion_choices"] = PresentacionCampo.choices
+        ctx["canal_choices"] = CanalFormulario.choices
         return ctx
 
 
@@ -371,6 +374,7 @@ class SegmentoDetailView(SegmentoScopedMixin, CapacidadRequeridaMixin, LoginRequ
         ctx["form_coordinador"] = AsignacionCoordinadorForm(segmento=seg)
         ctx["form_requisito"] = RequisitoNativoForm(segmento=seg)
         ctx["presentacion_choices"] = PresentacionCampo.choices
+        ctx["canal_choices"] = CanalFormulario.choices
         return ctx
 
 
@@ -682,6 +686,7 @@ class RequisitosSegmentoView(CapacidadRequeridaMixin, LoginRequiredMixin, ListVi
         ctx["sub_actual"] = self.request.GET.get("subsegmento", "")
         ctx["tipo_choices"] = TipoCampo.choices
         ctx["presentacion_choices"] = PresentacionCampo.choices
+        ctx["canal_choices"] = CanalFormulario.choices
         ctx["form_requisito"] = RequisitoNativoForm()
         return ctx
 
@@ -713,6 +718,7 @@ class SubsegmentoDetailView(SegmentoScopedMixin, CapacidadRequeridaMixin, LoginR
         ctx["requisitos_propios"] = sub.requisitos.order_by("orden", "id")
         ctx["form_requisito"] = RequisitoNativoForm(segmento=seg, subsegmento=sub)
         ctx["presentacion_choices"] = PresentacionCampo.choices
+        ctx["canal_choices"] = CanalFormulario.choices
         return ctx
 
 
@@ -736,7 +742,8 @@ class PreguntaGlobalListView(CapacidadRequeridaMixin, LoginRequiredMixin, ListVi
     context_object_name = "preguntas"
 
     def get_queryset(self):
-        queryset = PreguntaGlobal.objects.order_by("orden", "id")
+        # Cambio 58: agrupadas; dentro del grupo, por orden.
+        queryset = PreguntaGlobal.objects.select_related("grupo").order_by("grupo__orden", "grupo__id", "orden", "id")
         texto = self.request.GET.get("q", "").strip()
         tipo = self.request.GET.get("tipo", "").strip()
         obligatorio = self.request.GET.get("obligatorio", "").strip()
@@ -755,9 +762,11 @@ class PreguntaGlobalListView(CapacidadRequeridaMixin, LoginRequiredMixin, ListVi
         ctx = super().get_context_data(**kwargs)
         ctx["tipo_choices"] = TipoCampo.choices
         ctx["presentacion_choices"] = PresentacionCampo.choices
+        ctx["canal_choices"] = CanalFormulario.choices
         ctx["hay_filtros_activos"] = any(
             self.request.GET.get(nombre, "").strip() for nombre in ("q", "tipo", "obligatorio", "activo")
         )
+        ctx["grupos"] = GrupoRequisito.objects.order_by("orden", "id")
         return ctx
 
 
@@ -807,6 +816,10 @@ def pregunta_toggle_activo(request, pk):
     if request.method != "POST":
         return redirect("becas:preguntas")
     pregunta = get_object_or_404(PreguntaGlobal, pk=pk)
+    if pregunta.es_identidad:
+        # Cambio 58, D12: sin identidad no hay caso.
+        messages.error(request, "Los campos de identidad de la persona no se pueden desactivar.")
+        return redirect("becas:preguntas")
     pregunta.activo = not pregunta.activo
     pregunta.save(update_fields=["activo", "modificado"])
     messages.success(request, f"Pregunta {'activada' if pregunta.activo else 'desactivada'}.")
@@ -818,6 +831,10 @@ def pregunta_toggle_activo(request, pk):
 def pregunta_eliminar(request, pk):
     pregunta = get_object_or_404(PreguntaGlobal, pk=pk)
     if request.method == "POST":
+        if pregunta.protegido:
+            # Cambio 58, RN-5: los protegidos se renombran, agrupan y ordenan; no se borran.
+            messages.error(request, "Este campo viene con el sistema y no se puede eliminar; podés renombrarlo o moverlo de grupo.")
+            return redirect("becas:preguntas")
         pregunta.delete()
         messages.success(request, "Pregunta eliminada.")
     return redirect("becas:preguntas")


### PR DESCRIPTION
## Qué es

**Rama única** del **constructor de formularios** (análisis #326, épica #69, Cambio 58). Por pedido del PM todo el desarrollo va acá, por fases, y **no se mergea hasta que el PM lo indique**. Mockups: https://claude.ai/code/artifact/84861117-5a64-433d-a2e1-aeaedea723c8

## Fases incluidas

### Fase 1 — Catálogo (#336, #338) · `programas.0057`
- `GrupoRequisito`; `PreguntaGlobal` con `grupo`, `origen` (pregunta / legajo / apoderado), `vinculo`, `protegido`, `canal`; `RequisitoNativo.canal`; contacto opcional en el caso (D9).
- Protegidos sembrados por `seed_becas` (Datos personales, Contacto, Apoderado con `edad_menor 18`); todo lo existente en «Cuestionario social».
- «Se pide en» en los cuatro configuradores; la definición filtra por canal y **excluye los vinculados** hasta que el diseño los consuma.

### Fase 2 — Motor (#339, #340, #341) · `programas.0058`
- `DisenoFormulario` + `ItemDiseno` (claves estables, condiciones, campos propios); `services/diseno.py` (plan por defecto sin escribir, reconciliación con aviso, versión, serialización por canal).
- `services/condiciones.py` (operadores por tipo, todas/alguna, aplicar en orden, coherencia).
- `definicion_formulario` v2: `version` + `items` anidados; listas planas intactas para la app vieja.

### Fase 3 — Constructor (#337, #342, #343, #344) · en curso
### Fase 4 — Portal y caso (#345, #346, #347) · pendiente

## Validación (acumulada)
`test_catalogo_grupos` (19) · `test_condiciones` (24) · `test_diseno` (21) · regresión completa de `portal` y `programas` sin fallos propios · presupuesto de consultas sin cambios · `check` / `makemigrations --check` / `compile_templates` / `design_audit` / `requerimientos --check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
