### PR TITLE
feat(portal): el apoderado es obligatorio para todas las personas que se inscriben (Cambio 67)

### DIFF
--- a/docs/internal/requerimientos.md
+++ b/docs/internal/requerimientos.md
@@ -211,6 +211,7 @@ Los campos que no apliquen se escriben como «No requiere» o «No aplica»; no 
 | 64 | Solapa «Dashboard» en el programa Becas: métricas, filtros y exportación | Becas / configuración del programa | `#ui` `#convocatorias` `#relevamientos` `#datos` | PM — en sesión: «vamos a armar un dashboard en el programa Becas… al lado de Requisitos del programa quiero agregar una solapa de dashboard, tiene que ser a nivel visual y poder exportar» | 05/09/2026 | 🟢 **Hecho — en producción de ECOM desde el 05/09/2026 y con la corrección de performance desde el 06/09/2026 (releases 43ffddf, 55d842e, fc740b8, ea33681 y ac9192b); falta QA formal #374 y la validación de las 86 h por el Ministerio** | No requiere |
 | 65 | Exportar las respuestas de los formularios por persona, eligiendo la convocatoria | Becas / dashboard del programa | `#ui` `#datos` `#convocatorias` | PM — en sesión: «quiero que cuando lo toco me aparezca un pop up donde tenga que seleccionar una convocatoria y me exporte un excel con… una columna por cada pregunta y un registro por caso enviado» | 06/09/2026 | 🟢 **Hecho — en producción de ECOM desde el 06/09/2026 (release 2b3f271, PR #381)** | No requiere |
 | 66 | Performance del sistema: la revisión de casos, los listados y el costo fijo de cada pantalla | Transversal (Becas, Legajos, home, RBAC) | `#performance` `#datos` `#ui` | PM — en sesión: «quiero mejorar la performance de respuesta y de carga del sistema… quiero mejorar el código para que funcione y después vemos el tema de la infra» | 05/09/2026 | 🟢 **Hecho — en producción de ECOM desde el 06/09/2026 (release afdb661, PR #382)** | `programas.0058`, `programas.0059`, `legajos.0008` (solo índices) |
+| 67 | El apoderado es obligatorio para todas las personas que se inscriben por el link | Becas / link público de inscripción y revisión | `#relevamientos` `#ui` `#mobile` | PM — en sesión: «tengo la sección Apoderado y no es obligatorio, quiero que lo sea… para todas las personas, incluidas las mayores de edad, todas las convocatorias, los cinco campos» | 08/09/2026 | 🟡 **En revisión — PR contra `development`; sin desplegar en ECOM. La app de campo conserva la regla de menores hasta que Mobile la cambie** | No requiere |
 
 **Notas del índice**
 
@@ -7050,5 +7051,104 @@ Cada frente es un commit independiente. Las tres migraciones se revierten con `m
 
 Entrada nueva. Nace del pedido del PM tras el incidente de producción del Cambio 64, y del relevamiento que ese
 incidente motivó: el mismo banco de medición que se armó para el dashboard se usó para el resto del sistema.
+
+---
+
+# Cambio 67 — El apoderado es obligatorio para todas las personas que se inscriben por el link
+
+🟡 **EN REVISIÓN — 08/09/2026** · PR contra `development` abierto · Sin desplegar en ECOM · La app de campo conserva
+la regla de menores hasta que Mobile la cambie
+
+| | |
+|---|---|
+| **Programa / módulo** | Becas · link público de inscripción (paso 2) y detalle del caso en revisión |
+| **Etiquetas** | `#relevamientos` `#ui` `#mobile` |
+| **Solicitante** | PM — en sesión del 08/09/2026, sobre la convocatoria abierta en `datanach.chaco.gob.ar` |
+| **Fecha del pedido** | 08/09/2026 |
+| **Issue / épica** | Sin issue propio: corrección de regla sobre el Cambio 41 |
+| **Partes afectadas** | `InscripcionPaso2Form`, `paso2.html`, `formulario_detalle` (revisión) y sus tests |
+| **Migración** | No requiere: las columnas `apoderado_*` del caso ya admiten vacío |
+
+## Pedido original
+
+> «Tengo la sección Apoderado y no es obligatorio, quiero que lo sea.» Consultado el alcance: **para todas las
+> personas, incluidas las mayores de edad; todas las convocatorias; los cinco campos** (nombre, apellido, DNI, sexo y
+> fecha de nacimiento).
+
+## Cómo se relevó
+
+Se verificó primero qué versión corre en `datanach.chaco.gob.ar`: es `main`, sin el Cambio 58 (el constructor no está
+en `main` ni en `development`). Ahí el Apoderado es el bloque fijo del Cambio 41: se mostraba siempre con el texto
+«Completalo solo si la persona que se inscribe es menor de 18 años», sus campos eran opcionales y el servidor los
+exigía únicamente si la persona era menor (RN-22). La misma regla vive en el serializer de la API que valida lo que
+manda la app de campo, en la vista de revisión (que mostraba la sección solo a menores o si había datos) y en la app
+móvil (repo aparte).
+
+## Decisiones tomadas
+
+- **Se reemplaza la RN-22 en el link público**: los cinco datos del apoderado son obligatorios para toda persona que
+  se inscribe, sin mirar la edad. La RN-22 del Cambio 41 queda registrada como histórica; esta decisión la manda el PM.
+- **La app de campo mantiene, por ahora, la regla de menores.** Exigir el apoderado a los adultos en la API sin que la
+  app lo pida los dejaría con casos que el servidor rechaza al sincronizar. El cambio en Mobile y en el serializer
+  (`programas/api/serializers.py`, validación bajo `es_menor`) va junto, cuando el equipo móvil lo tenga; queda en
+  Pendientes.
+- **La revisión muestra siempre la sección del apoderado**, también en casos anteriores, para poder completarla.
+- **Global, no por convocatoria.** No se agregó un interruptor por convocatoria en `main`: eso ya existe en el Cambio 58
+  (condición del grupo Apoderado en el constructor y obligatoriedad en el catálogo) y duplicarlo con una migración
+  quedaría obsoleto al llegar esa rama.
+
+## Implementación
+
+- `portal/forms/inscripcion.py`: los cinco campos `apoderado_*` pasan a requeridos; `clean()` conserva solo la
+  normalización y validación del DNI; se quitan `fecha_nacimiento_efectiva` y la dependencia de `es_menor`.
+- `portal/templates/portal/inscripcion/paso2.html`: el subtítulo pasa a «Completá los datos del apoderado: se piden a
+  todas las personas que se inscriben» y las etiquetas llevan el asterisco de obligatorio.
+- `programas/views/revision.py`: `mostrar_apoderado` es siempre verdadero.
+
+## Archivos
+
+`portal/forms/inscripcion.py` · `portal/templates/portal/inscripcion/paso2.html` · `programas/views/revision.py` ·
+`portal/tests/test_inscripcion_envio.py` · `portal/tests/test_correcciones_review.py` ·
+`portal/tests/test_correcciones_review_2.py`.
+
+## Base de datos
+
+Sin cambios. `Formulario.apoderado_*` ya admiten vacío; los casos anteriores sin apoderado quedan como están y se
+pueden completar desde la revisión.
+
+## Validación
+
+`test_apoderado_obligatorio_para_menores_y_mayores` (mayor sin apoderado: los cinco campos en error; menor igual;
+mayor con apoderado completo pasa), `test_el_paso_2_marca_el_apoderado_como_obligatorio`, y los tests de fecha no ISO
+y de fecha de proveedor rota se ajustaron para seguir probando lo suyo con el apoderado ausente. Suite de `portal`,
+`test_becas_revision` y `test_becas_api` con Python 3.12 / Django 5.2. `manage.py check`, ruff, `design_audit`,
+`compile_templates` y `check_design_agent` en 0.
+
+## Puesta en marcha en el servidor
+
+Merge del PR a `development` → release automático a `main` (`publish-main.yml`) → espejo al GitLab de ECOM con
+`/pushGitLabecom` (`test` primero, después `main`, que despliega producción en 5 a 7 minutos). Sin migraciones ni
+coordinación con ECOM. La convocatoria abierta empieza a exigir el apoderado desde el deploy; quien tenga el paso 2
+abierto en ese momento ve el error de campos obligatorios al enviar y completa.
+
+## Pendientes / a definir
+
+- **App de campo**: cuando Mobile pida el apoderado a todos, cambiar en el mismo PR la validación del serializer
+  (`programas/api/serializers.py`, bloque bajo `es_menor`) y su test `test_menor_sin_apoderado_falla`. Hasta entonces
+  los dos canales exigen distinto.
+- **Cambio 58**: cuando el constructor llegue a `main`, esta regla pasa a ser configuración. El equivalente es: sin
+  condición en el grupo Apoderado (en el catálogo, como condición por defecto, y en el constructor de cada
+  convocatoria) y `obligatorio` tildado en «Sexo del apoderado» y «Fecha de nacimiento del apoderado» (nombre,
+  apellido y DNI ya lo son). El seed y la migración `programas.0060` de esa rama siembran hoy la condición `edad < 18`
+  y sexo/fecha opcionales: hay que alinearlos antes del merge para no volver atrás.
+
+## Reversión
+
+Revertir el commit del PR. No hay datos que deshacer.
+
+## Historial
+
+Entrada nueva. Modifica la RN-22 registrada en el Cambio 41 («los menores pueden inscribirse; el paso 2 exige apoderado,
+misma regla que la app») por decisión del PM del 08/09/2026, solo para el link público hasta que Mobile acompañe.
 
 ---

--- a/docs/internal/requerimientos.md
+++ b/docs/internal/requerimientos.md
@@ -211,7 +211,7 @@ Los campos que no apliquen se escriben como «No requiere» o «No aplica»; no 
 | 64 | Solapa «Dashboard» en el programa Becas: métricas, filtros y exportación | Becas / configuración del programa | `#ui` `#convocatorias` `#relevamientos` `#datos` | PM — en sesión: «vamos a armar un dashboard en el programa Becas… al lado de Requisitos del programa quiero agregar una solapa de dashboard, tiene que ser a nivel visual y poder exportar» | 05/09/2026 | 🟢 **Hecho — en producción de ECOM desde el 05/09/2026 y con la corrección de performance desde el 06/09/2026 (releases 43ffddf, 55d842e, fc740b8, ea33681 y ac9192b); falta QA formal #374 y la validación de las 86 h por el Ministerio** | No requiere |
 | 65 | Exportar las respuestas de los formularios por persona, eligiendo la convocatoria | Becas / dashboard del programa | `#ui` `#datos` `#convocatorias` | PM — en sesión: «quiero que cuando lo toco me aparezca un pop up donde tenga que seleccionar una convocatoria y me exporte un excel con… una columna por cada pregunta y un registro por caso enviado» | 06/09/2026 | 🟢 **Hecho — en producción de ECOM desde el 06/09/2026 (release 2b3f271, PR #381)** | No requiere |
 | 66 | Performance del sistema: la revisión de casos, los listados y el costo fijo de cada pantalla | Transversal (Becas, Legajos, home, RBAC) | `#performance` `#datos` `#ui` | PM — en sesión: «quiero mejorar la performance de respuesta y de carga del sistema… quiero mejorar el código para que funcione y después vemos el tema de la infra» | 05/09/2026 | 🟢 **Hecho — en producción de ECOM desde el 06/09/2026 (release afdb661, PR #382)** | `programas.0058`, `programas.0059`, `legajos.0008` (solo índices) |
-| 67 | El apoderado es obligatorio para todas las personas que se inscriben por el link | Becas / link público de inscripción y revisión | `#relevamientos` `#ui` `#mobile` | PM — en sesión: «tengo la sección Apoderado y no es obligatorio, quiero que lo sea… para todas las personas, incluidas las mayores de edad, todas las convocatorias, los cinco campos» | 08/09/2026 | 🟡 **En revisión — PR contra `development`; sin desplegar en ECOM. La app de campo conserva la regla de menores hasta que Mobile la cambie** | No requiere |
+| 67 | El apoderado es obligatorio para todas las personas que se inscriben por el link | Becas / link público de inscripción y revisión | `#relevamientos` `#ui` `#mobile` | PM — en sesión: «tengo la sección Apoderado y no es obligatorio, quiero que lo sea… para todas las personas, incluidas las mayores de edad, todas las convocatorias, los cinco campos» | 08/09/2026 | 🟡 **En revisión — PR #383 contra `development`; sin desplegar en ECOM. La app de campo conserva la regla de menores hasta que Mobile la cambie** | No requiere |
 
 **Notas del índice**
 
@@ -7056,7 +7056,7 @@ incidente motivó: el mismo banco de medición que se armó para el dashboard se
 
 # Cambio 67 — El apoderado es obligatorio para todas las personas que se inscriben por el link
 
-🟡 **EN REVISIÓN — 08/09/2026** · PR contra `development` abierto · Sin desplegar en ECOM · La app de campo conserva
+🟡 **EN REVISIÓN — 08/09/2026** · PR #383 contra `development` · Sin desplegar en ECOM · La app de campo conserva
 la regla de menores hasta que Mobile la cambie
 
 | | |

--- a/portal/forms/inscripcion.py
+++ b/portal/forms/inscripcion.py
@@ -1,9 +1,7 @@
 """Formularios de la inscripción pública de Becas (#293 paso 1, #294 paso 2)."""
 
 from django import forms
-from django.utils.dateparse import parse_date
 
-from programas.services.becas import es_menor
 from programas.services.padron import normalizar_dni
 from programas.services.personas import fecha_iso
 
@@ -146,34 +144,31 @@ class InscripcionPaso2Form(forms.Form):
         widget=forms.EmailInput(attrs={"class": INPUT_CLASS, "placeholder": "nombre@correo.com"}),
     )
 
-    # Bloque D — apoderado (obligatorio solo para menores, RN-22/RN-P9).
+    # Bloque D — apoderado. Cambio 67: los cinco datos son obligatorios para
+    # toda persona que se inscribe, sin importar su edad (reemplaza la RN-22
+    # del Cambio 41, que solo lo exigía a menores).
     apoderado_nombre = forms.CharField(
         label="Nombre del apoderado",
         max_length=120,
-        required=False,
         widget=forms.TextInput(attrs={"class": INPUT_CLASS}),
     )
     apoderado_apellido = forms.CharField(
         label="Apellido del apoderado",
         max_length=120,
-        required=False,
         widget=forms.TextInput(attrs={"class": INPUT_CLASS}),
     )
     apoderado_dni = forms.CharField(
         label="DNI del apoderado",
         max_length=12,
-        required=False,
         widget=forms.TextInput(attrs={"class": INPUT_CLASS, "inputmode": "numeric"}),
     )
     apoderado_genero = forms.ChoiceField(
         label="Sexo del apoderado",
-        required=False,
         choices=(("", "Elegí una opción"), ("F", "Femenino"), ("M", "Masculino")),
         widget=forms.Select(attrs={"class": INPUT_CLASS}),
     )
     apoderado_fecha_nacimiento = forms.DateField(
         label="Fecha de nacimiento del apoderado",
-        required=False,
         widget=forms.DateInput(attrs={"class": INPUT_CLASS, "type": "date"}),
     )
 
@@ -210,35 +205,16 @@ class InscripcionPaso2Form(forms.Form):
     def campos_requisitos(self):
         return [self[clave] for clave, campo in self._campos_dinamicos if clave.startswith("r_")]
 
-    # --- RN-22: apoderado obligatorio para menores ------------------------
-    def fecha_nacimiento_efectiva(self):
-        if self.es_manual:
-            return self.cleaned_data.get("fecha_nacimiento")
-        if "fecha_nacimiento" in self.fields:
-            return self.cleaned_data.get("fecha_nacimiento")
-        datos = self.identificacion.get("datos") or {}
-        return parse_date(fecha_iso(datos.get("fecha_nacimiento")) or "") or None
-
+    # --- Apoderado (Cambio 67) --------------------------------------------
     def clean(self):
         cleaned = super().clean()
+        # La obligatoriedad de los cinco datos del apoderado la lleva cada
+        # field (toda persona, sin mirar la edad). Acá solo se normaliza el DNI.
         dni_apoderado_original = cleaned.get("apoderado_dni")
         dni_apoderado = normalizar_dni(dni_apoderado_original)
         if dni_apoderado_original and len(dni_apoderado) not in (7, 8):
             self.add_error("apoderado_dni", "Ingresa un DNI valido de 7 u 8 digitos.")
         cleaned["apoderado_dni"] = dni_apoderado
-        if es_menor(self.fecha_nacimiento_efectiva()):
-            campos = (
-                "apoderado_nombre",
-                "apoderado_apellido",
-                "apoderado_dni",
-                "apoderado_genero",
-                "apoderado_fecha_nacimiento",
-            )
-            for campo in campos:
-                if not cleaned.get(campo):
-                    self.add_error(
-                        campo, "Este dato es obligatorio cuando la persona que se inscribe es menor de edad."
-                    )
         return cleaned
 
     # --- Salidas hacia la ingesta (#295) ----------------------------------

--- a/portal/templates/portal/inscripcion/paso2.html
+++ b/portal/templates/portal/inscripcion/paso2.html
@@ -93,11 +93,11 @@ desplegable del navegador y el formulario se envía igual.{% endcomment %}
         {% endif %}
 
         <h2 class="text-sm font-bold uppercase tracking-wide mb-1" style="color: var(--text-body-subtle);">Apoderado</h2>
-        <p class="text-xs mb-3" style="color: var(--text-body-subtle);">Completalo solo si la persona que se inscribe es menor de 18 años.</p>
+        <p class="text-xs mb-3" style="color: var(--text-body-subtle);">Completá los datos del apoderado: se piden a todas las personas que se inscriben.</p>
         <div class="space-y-4 mb-6">
             {% for campo in form %}{% if campo.name == "apoderado_nombre" or campo.name == "apoderado_apellido" or campo.name == "apoderado_dni" or campo.name == "apoderado_genero" or campo.name == "apoderado_fecha_nacimiento" %}
             <div>
-                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }}</label>
+                <label for="{{ campo.id_for_label }}" class="block text-sm font-semibold mb-1" style="color: var(--text-heading);">{{ campo.label }} <span style="color: var(--text-fg-danger);">*</span></label>
                 {{ campo }}
                 {% for error in campo.errors %}<p class="text-xs mt-1" style="color: var(--text-fg-danger);">{{ error }}</p>{% endfor %}
             </div>

--- a/portal/tests/test_correcciones_review.py
+++ b/portal/tests/test_correcciones_review.py
@@ -116,8 +116,10 @@ class FechaNoIsoTests(_BasePaso2Test):
         nacimiento = hoy - timedelta(days=16 * 365)
         ident = _identificacion()
         ident["datos"]["fecha_nacimiento"] = nacimiento.strftime("%d/%m/%Y")
-        form = InscripcionPaso2Form(self._data(), self._files(), definicion=self.definicion, identificacion=ident)
-        self.assertFalse(form.is_valid())  # antes: parse_date → None → RN-22 salteada
+        form = InscripcionPaso2Form(
+            self._data_sin_apoderado(), self._files(), definicion=self.definicion, identificacion=ident
+        )
+        self.assertFalse(form.is_valid())  # Cambio 67: el apoderado se exige a toda persona
         self.assertIn("apoderado_dni", form.errors)
 
 

--- a/portal/tests/test_correcciones_review_2.py
+++ b/portal/tests/test_correcciones_review_2.py
@@ -20,7 +20,6 @@ from portal.tests.test_inscripcion import DATOS_GRAN_BASE, _BaseInscripcionTest,
 from portal.tests.test_inscripcion_envio import _BasePaso2Test, _identificacion
 from portal.views.inscripcion import MENSAJE_RECHAZO
 from programas.admin import RelevamientoAdmin
-from programas.forms import RelevamientoForm
 from programas.models import Convocatoria, Formulario, Relevamiento, Segmento
 from programas.services.inscripcion_publica import crear_formulario_publico
 from programas.views import relevamientos as vistas_rel
@@ -169,11 +168,11 @@ class FechaProveedorYApoderadoTests(_BasePaso2Test):
         hoy = timezone.localdate()
         ident = _identificacion()
         ident["datos"]["fecha_nacimiento"] = "texto raro"
-        data = self._data(fecha_nacimiento=(hoy - timedelta(days=16 * 365)).isoformat())
+        data = self._data_sin_apoderado(fecha_nacimiento=(hoy - timedelta(days=16 * 365)).isoformat())
         form = self._form(identificacion=ident, data=data)
         self.assertFalse(form.is_valid())
         self.assertIn("fecha_nacimiento", form.fields)
-        self.assertIn("apoderado_dni", form.errors)
+        self.assertIn("apoderado_dni", form.errors)  # Cambio 67: obligatorio para toda persona
 
     def test_personas_sin_fecha_guarda_la_fecha_del_form(self):
         ident = _identificacion()

--- a/portal/tests/test_inscripcion_envio.py
+++ b/portal/tests/test_inscripcion_envio.py
@@ -1,15 +1,14 @@
 """Tests del paso 2 y la ingesta del formulario público (#294/#295, análisis #289)."""
 
 from datetime import date, timedelta
-from uuid import uuid4
-
 from pathlib import Path
+from uuid import uuid4
 
 from django import forms
 from django.contrib.staticfiles import finders
 from django.core.cache import cache
-from django.template.loader import get_template
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.template.loader import get_template
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -80,13 +79,29 @@ class _BasePaso2Test(TestCase):
         )
         self.definicion = definicion_formulario(self.relevamiento)
 
+    APODERADO = {
+        "apoderado_nombre": "Ana",
+        "apoderado_apellido": "Gómez",
+        "apoderado_dni": "20111222",
+        "apoderado_genero": "F",
+        "apoderado_fecha_nacimiento": "1980-05-05",
+    }
+
     def _data(self, **extra):
         data = {
             "celular": "3624123456",
             "email_contacto": "maria@correo.com",
             f"g_{self.pregunta.pk}": "Sí",
+            # Cambio 67: el apoderado es obligatorio para toda persona.
+            **self.APODERADO,
         }
         data.update(extra)
+        return data
+
+    def _data_sin_apoderado(self, **extra):
+        data = self._data(**extra)
+        for clave in self.APODERADO:
+            data.pop(clave, None)
         return data
 
     def _files(self, **extra):
@@ -148,18 +163,28 @@ class Paso2FormTests(_BasePaso2Test):
         form = self._form(files={f"r_{self.requisito.pk}": gigante})
         self.assertFalse(form.is_valid())
 
-    def test_menor_exige_apoderado_y_mayor_no(self):
+    def test_apoderado_obligatorio_para_menores_y_mayores(self):
+        """Cambio 67: los cinco datos del apoderado se exigen a toda persona
+        que se inscribe, sin mirar la edad (antes solo a menores, RN-22)."""
         hoy = timezone.localdate()
+        # Mayor (1991) sin apoderado: los cinco campos faltan.
+        form = self._form(data=self._data_sin_apoderado())
+        self.assertFalse(form.is_valid())
+        for campo in self.APODERADO:
+            self.assertIn(campo, form.errors)
+        # Menor sin apoderado: igual.
         menor = _identificacion()
         menor["datos"]["fecha_nacimiento"] = (hoy - timedelta(days=17 * 365)).isoformat()
-        form = self._form(identificacion=menor)
+        form = self._form(identificacion=menor, data=self._data_sin_apoderado())
         self.assertFalse(form.is_valid())
         self.assertIn("apoderado_dni", form.errors)
-        # Cumple 18 exactamente hoy: se trata como mayor (RN-22).
-        cumple_hoy = _identificacion()
-        cumple_hoy["datos"]["fecha_nacimiento"] = hoy.replace(year=hoy.year - 18).isoformat()
-        form = self._form(identificacion=cumple_hoy)
-        self.assertTrue(form.is_valid(), form.errors)
+        # Mayor con el apoderado completo: pasa.
+        self.assertTrue(self._form().is_valid())
+
+    def test_el_paso_2_marca_el_apoderado_como_obligatorio(self):
+        html = Path(get_template("portal/inscripcion/paso2.html").origin.name).read_text(encoding="utf-8")
+        self.assertNotIn("solo si la persona que se inscribe es menor", html)
+        self.assertIn("se piden a todas las personas", html)
 
     def test_menor_con_apoderado_completo_pasa(self):
         hoy = timezone.localdate()
@@ -370,7 +395,7 @@ class Paso2PresentacionSelectorTests(_BasePaso2Test):
 
     def test_el_buscador_no_cambia_que_valores_son_validos(self):
         definicion = self._definicion_con("SELECTOR", "BUSCADOR")
-        base = {"celular": "3624123456", "email_contacto": "maria@correo.com"}
+        base = {"celular": "3624123456", "email_contacto": "maria@correo.com", **self.APODERADO}
 
         valido = InscripcionPaso2Form(
             {**base, "g_1": "Secundario"}, definicion=definicion, identificacion=_identificacion()

--- a/programas/tests/test_becas_revision.py
+++ b/programas/tests/test_becas_revision.py
@@ -288,7 +288,9 @@ class EdicionTrazaTests(_BaseRevisionTest):
             },
         )
 
-    def test_detalle_adulto_sin_apoderado_oculta_sus_campos(self):
+    def test_detalle_adulto_sin_apoderado_muestra_la_seccion_para_completarla(self):
+        """Cambio 67: el apoderado se pide a toda persona, así que la sección
+        editable está siempre, también en un caso anterior sin datos."""
         self.form_a.ciudadano = Ciudadano.objects.create(
             dni="60600601",
             nombre="Persona",
@@ -300,8 +302,8 @@ class EdicionTrazaTests(_BaseRevisionTest):
         resp = self.client.get(reverse("becas:formulario_detalle", args=[self.form_a.pk]))
 
         self.assertContains(resp, "Datos de contacto")
-        self.assertNotContains(resp, "Datos del apoderado")
-        self.assertNotContains(resp, 'name="apoderado_fecha_nacimiento"')
+        self.assertContains(resp, "Datos del apoderado")
+        self.assertContains(resp, 'name="apoderado_fecha_nacimiento"')
 
     def test_detalle_menor_muestra_fecha_apoderado_en_formato_html(self):
         self.form_a.ciudadano = Ciudadano.objects.create(

--- a/programas/views/revision.py
+++ b/programas/views/revision.py
@@ -36,7 +36,7 @@ from programas.models import (
 )
 from programas.services.autorizacion import convocatorias_visibles, puede_gestionar_segmento
 from programas.services.avisos_resolucion import enviar_aviso_resolucion
-from programas.services.becas import es_menor, registrar_traza, resolver_ciudadano_offline
+from programas.services.becas import registrar_traza, resolver_ciudadano_offline
 from programas.services.cupo import aprobar_o_poner_en_espera, motivo_bloqueo_aprobacion
 from programas.services.identidad import gran_base_activa
 from programas.services.padron import fila_padron
@@ -432,21 +432,10 @@ def formulario_detalle(request, pk):
         form = FormularioRevisionForm(instance=formulario)
 
     globales_list, requisitos_segmento, requisitos_subsegmento = _respuestas_resueltas(formulario)
-    fecha_nacimiento = None
-    if formulario.ciudadano_id:
-        fecha_nacimiento = formulario.ciudadano.fecha_nacimiento
-    elif isinstance(formulario.datos_identificacion, dict):
-        fecha_nacimiento = formulario.datos_identificacion.get("fecha_nacimiento")
-        if isinstance(fecha_nacimiento, str):
-            fecha_nacimiento = parse_date(fecha_nacimiento)
-    tiene_datos_apoderado = bool(
-        formulario.apoderado_nombre
-        or formulario.apoderado_apellido
-        or formulario.apoderado_dni
-        or formulario.apoderado_genero
-        or formulario.apoderado_fecha_nacimiento
-    )
-    mostrar_apoderado = bool(es_menor(fecha_nacimiento) or tiene_datos_apoderado)
+    # Cambio 67: el apoderado se pide a toda persona que se inscribe, así que
+    # la sección editable se muestra siempre (también en los casos anteriores,
+    # que pueden completarse desde acá).
+    mostrar_apoderado = True
     mapa = None
     if formulario.gps_lat is not None and formulario.gps_lng is not None:
         lat = float(formulario.gps_lat)


### PR DESCRIPTION
## Qué cambia

Decisión del PM (08/09/2026) sobre la convocatoria abierta en `datanach.chaco.gob.ar`: los **cinco datos del apoderado** (nombre, apellido, DNI, sexo y fecha de nacimiento) son **obligatorios para toda persona que se inscribe por el link**, sin mirar la edad. Reemplaza la RN-22 del Cambio 41 en el link público.

- `portal/forms/inscripcion.py`: los campos `apoderado_*` pasan a requeridos; `clean()` conserva solo la normalización y validación del DNI (se quitan `fecha_nacimiento_efectiva` y `es_menor`).
- `portal/templates/portal/inscripcion/paso2.html`: subtítulo «Completá los datos del apoderado: se piden a todas las personas que se inscriben» y asterisco en las etiquetas.
- `programas/views/revision.py`: la sección editable del apoderado se muestra siempre (también en casos anteriores, para completarla).
- Registro en `docs/internal/requerimientos.md` como **Cambio 67**.

## Lo que NO cambia (a propósito)

La **API de la app de campo** conserva la regla de menores (`programas/api/serializers.py`): exigir el apoderado a los adultos sin que la app lo pida dejaría casos rechazados al sincronizar. Va junto con el cambio en Mobile; queda en Pendientes del Cambio 67.

## Migraciones

Ninguna. `Formulario.apoderado_*` ya admiten vacío.

## Validación

- `test_apoderado_obligatorio_para_menores_y_mayores`, `test_el_paso_2_marca_el_apoderado_como_obligatorio`, y ajuste de los tests de fecha no ISO / fecha de proveedor rota y del detalle de revisión.
- `portal`, `test_becas_revision` y `test_becas_api` con Python 3.12 / Django 5.2 (modo CI). Los únicos fallos locales (correo y CSRF) fallan igual sobre `development` sin tocar: son del entorno local.
- `manage.py check`, ruff, `design_audit --changed`, `compile_templates`, `check_design_agent` y `requerimientos.py --check` en 0/OK.

## Puesta en marcha

Merge → release automático a `main` → espejo a ECOM con `/pushGitLabecom` (`test` y después `main`). Sin coordinación con ECOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
